### PR TITLE
Land iteration_2: 35 commits of loop-engine, multi-PR, service mode, and ops hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env and fill in your values.
+# .env is gitignored — never commit real secrets.
+
+# Personal access token with `repo` scope.
+# Required for GitHub MCP server, issue tracking, and PR management.
+# Generate one at: https://github.com/settings/tokens
+GITHUB_TOKEN=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  ci:
+    name: fmt / clippy / test / release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo registry and build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Check formatting
+        run: cargo fmt -- --check
+
+      - name: Clippy (warnings as errors)
+        run: cargo clippy --all-targets --all-features
+
+      - name: Run tests
+        run: cargo test
+
+      - name: Build release binary
+        run: cargo build --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,7 @@ dependencies = [
  "ctrlc",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "thiserror",
  "toml",
@@ -435,6 +436,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +497,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -679,6 +699,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "clap",
  "ctrlc",
  "serde",
+ "serde_json",
  "tempfile",
  "thiserror",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ clap = { version = "4", features = ["derive"] }
 ctrlc = "3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 thiserror = "1"
 toml = "0.8"
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 ctrlc = "3"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 thiserror = "1"
 toml = "0.8"
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -66,10 +66,12 @@ A fully configured dev container is provided (`.devcontainer/`). It is based on 
 | Document | Description |
 |----------|-------------|
 | [docs/getting-started.md](docs/getting-started.md) | Install, configure, and run your first loop |
+| [docs/configuration.md](docs/configuration.md) | Every config field, CLI flag, default, and precedence rule |
+| [docs/providers.md](docs/providers.md) | Provider adapter invocation, environment requirements, and limitations |
 | [docs/orchestration.md](docs/orchestration.md) | Workflow branch selection, shippable signal protocol, PR lifecycle |
+| [docs/workspace-prerequisites.md](docs/workspace-prerequisites.md) | What the prerequisite checker validates and how to fix each diagnostic |
+| [docs/troubleshooting.md](docs/troubleshooting.md) | Common failure modes and remediation steps |
 | [docs/PRD.md](docs/PRD.md) | Full product requirements and roadmap |
-
-Additional reference docs (configuration, providers, workspace prerequisites, troubleshooting) are tracked in [#9](https://github.com/jamesbrayton/code-looper/issues/9).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,85 @@
-# code-looper
+# Code Looper
 
-A rust terminal application for ralph-looping various code generation CLI solutions with additional features and controls.
+Code Looper is a Rust CLI loop engine that drives multiple coding-agent CLIs (Claude Code, GitHub Copilot CLI, Codex CLI) through configurable iterations with policy-driven orchestration. Instead of writing one-off shell scripts per project, you configure a loop once and let Code Looper manage iteration count, retry behavior, provider selection, PR lifecycle, and issue tracking.
+
+## Status
+
+**Early / experimental.** Milestones M1–M14 are complete (core engine, all three provider adapters, orchestration policy, issue tracking, branch and PR lifecycle, multi-PR triage). The project follows the roadmap in [docs/PRD.md](docs/PRD.md). Breaking changes are possible until v1.0.
+
+## Quick start
+
+Prerequisites: Rust toolchain (`rustup`), and at least one provider CLI on your `$PATH` (`claude`, `gh copilot`, or `codex`).
+
+```bash
+# Clone and build
+git clone https://github.com/jamesbrayton/code-looper.git
+cd code-looper
+cargo build --release
+
+# Run a single iteration with an inline prompt
+./target/release/code-looper \
+  --provider claude \
+  --iterations 1 \
+  --prompt-inline "Describe the repository structure"
+```
+
+For a GitHub-integrated workflow with issue tracking and PR management, see [docs/getting-started.md](docs/getting-started.md).
+
+## Build & test
+
+```bash
+cargo build              # debug build
+cargo build --release    # release build
+cargo test               # run all tests
+cargo test <test_name>   # run a single test
+cargo clippy             # lint
+cargo fmt                # format code
+cargo fmt -- --check     # check formatting without modifying
+```
+
+The test suite is pure unit tests and runs without any provider CLI installed.
+
+## Development environment
+
+A fully configured dev container is provided (`.devcontainer/`). It is based on `mcr.microsoft.com/devcontainers/rust:2-1-trixie` and pre-installs:
+
+- Rust toolchain (stable)
+- Node.js LTS
+- GitHub CLI (`gh`)
+- Claude Code CLI
+- GitHub Copilot CLI
+- `uv` (Python package manager)
+
+**Environment variables:** Copy `.env.example` to `.env` and set `GITHUB_TOKEN` to a personal access token with `repo` scope. The GitHub MCP server reads this token at startup.
+
+**MCP servers:** Configured in `.mcp.json`:
+
+| Server | Purpose |
+|--------|---------|
+| `github` | GitHub API for issue/PR read and write |
+| `context7` | Library documentation lookup |
+| `markitdown` | Document format conversion |
+| `microsoftdocs` | Microsoft Learn / Azure documentation |
+
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [docs/getting-started.md](docs/getting-started.md) | Install, configure, and run your first loop |
+| [docs/orchestration.md](docs/orchestration.md) | Workflow branch selection, shippable signal protocol, PR lifecycle |
+| [docs/PRD.md](docs/PRD.md) | Full product requirements and roadmap |
+
+Additional reference docs (configuration, providers, workspace prerequisites, troubleshooting) are tracked in [#9](https://github.com/jamesbrayton/code-looper/issues/9).
+
+## Contributing
+
+Every change must be tracked by a GitHub issue before any code is written. See [CLAUDE.md](CLAUDE.md) for the full contributor workflow — issue creation, commit message format, comment cadence, and handoff expectations.
+
+```bash
+# Reference the issue in every commit
+git commit -m "Add retry backoff configuration (#42)"
+```
+
+## License
+
+[MIT](LICENSE)

--- a/docs/ADRs/ADR-001-mcp-only-github-mutations.md
+++ b/docs/ADRs/ADR-001-mcp-only-github-mutations.md
@@ -1,0 +1,39 @@
+# ADR-001: MCP-Only GitHub Mutation Path
+
+**Status:** Accepted  
+**Date:** 2024-01-01  
+**Deciders:** Code Looper project team
+
+## Context
+
+Code Looper orchestrates agent CLIs that can make GitHub mutations (create/update issues, open/comment on PRs, merge branches). There are two ways mutations could be performed:
+
+1. **Direct REST API calls** via the `gh` CLI `api` subcommand or raw HTTP
+2. **MCP server tool calls** via the configured GitHub MCP server
+
+Using raw CLI or REST calls bypasses structured tool tracking, makes mutations harder to audit, and creates a dual-path problem where some mutations are observable by MCP and others are not.
+
+## Decision
+
+All GitHub read and write operations in orchestration flows **must** go through MCP server tool interfaces. Direct `gh api` calls and raw REST mutations are disabled by default. The `PolicyGuard` layer enforces this at runtime.
+
+A `--allow-direct-github` unsafe override flag exists for debugging and testing but is documented as unsupported for production use.
+
+## Consequences
+
+**Positive:**
+- All GitHub mutations are observable and auditable through a single channel (MCP).
+- Reduces risk of accidental over-automation (e.g., mass issue creation).
+- Easier to mock/stub for testing — tests can inject fake MCP tool responses.
+- Aligns with the PRD success criterion that 100% of GitHub mutations use MCP.
+
+**Negative:**
+- Requires the GitHub MCP server to be configured and reachable at startup.
+- Loop startup performs a capability check (`workspace::check`) that fails fast when MCP is not available.
+- Adds latency relative to direct REST calls (MCP round-trip overhead).
+
+## References
+
+- `src/policy_guard.rs` — `PolicyGuard` enforcement
+- `src/workspace.rs` — startup capability validation
+- PRD §2 Acceptance Criteria: "GitHub operations and prerequisites"

--- a/docs/ADRs/ADR-001-mcp-only-github-mutations.md
+++ b/docs/ADRs/ADR-001-mcp-only-github-mutations.md
@@ -1,39 +1,95 @@
-# ADR-001: MCP-Only GitHub Mutation Path
+# ADR-001: MCP-Only GitHub Mutations for Agent Prompts
 
-**Status:** Accepted  
-**Date:** 2024-01-01  
+**Status:** Accepted (revised 2026-04-08)
+**Date:** 2024-01-01, revised 2026-04-08
 **Deciders:** Code Looper project team
 
 ## Context
 
-Code Looper orchestrates agent CLIs that can make GitHub mutations (create/update issues, open/comment on PRs, merge branches). There are two ways mutations could be performed:
+Code Looper orchestrates agent CLIs that can make GitHub mutations
+(create/update issues, open/comment on PRs, merge branches). There are
+two ways mutations could be performed:
 
 1. **Direct REST API calls** via the `gh` CLI `api` subcommand or raw HTTP
 2. **MCP server tool calls** via the configured GitHub MCP server
 
-Using raw CLI or REST calls bypasses structured tool tracking, makes mutations harder to audit, and creates a dual-path problem where some mutations are observable by MCP and others are not.
+Using raw CLI or REST calls from inside an **agent** bypasses structured
+tool tracking, makes agent-driven mutations harder to audit, and creates
+a dual-path problem where some agent-driven mutations are observable by
+MCP and others are not.
+
+In contrast, the **engine itself** — the Rust process that spawns
+provider CLIs, manages branches, merges PRs, and posts lifecycle
+comments — is the audit trail. Its actions are already observable via
+structured logs, run artifacts, and the session summary. Routing the
+engine's own bookkeeping through MCP would add latency, introduce a new
+transport dependency on an agent tool interface, and does not improve
+auditability over the existing telemetry.
 
 ## Decision
 
-All GitHub read and write operations in orchestration flows **must** go through MCP server tool interfaces. Direct `gh api` calls and raw REST mutations are disabled by default. The `PolicyGuard` layer enforces this at runtime.
+**Scope:** MCP-only applies to GitHub mutations performed by **agent
+prompts**, not to subprocess calls issued by the engine itself.
 
-A `--allow-direct-github` unsafe override flag exists for debugging and testing but is documented as unsupported for production use.
+- Every prompt sent to a provider is augmented with a preamble
+  (`MCP_ONLY_PREAMBLE` in `src/policy_guard.rs`) instructing the agent
+  to use only MCP server tools for GitHub writes. This is the
+  enforcement point for agent behaviour.
+- The **engine** is permitted to invoke `gh` (or, in future, direct REST
+  calls) for its own bookkeeping: opening/merging PRs
+  (`src/pr_manager.rs`), posting lifecycle comments
+  (`src/issue_tracker.rs`), and merge-cleanup branch operations. These
+  actions are recorded in the run manifest and structured logs, and are
+  the canonical audit channel for engine behaviour.
+- `--allow-direct-github` disables the agent-prompt preamble. It does
+  **not** affect engine subprocess calls, which are always permitted.
+- At startup, `workspace::check` looks for a `"github"` entry in the
+  workspace `.mcp.json`. This is a best-effort configuration sanity
+  check, not a runtime health probe — the engine does not attempt to
+  ping the MCP server before running.
 
 ## Consequences
 
 **Positive:**
-- All GitHub mutations are observable and auditable through a single channel (MCP).
-- Reduces risk of accidental over-automation (e.g., mass issue creation).
-- Easier to mock/stub for testing — tests can inject fake MCP tool responses.
-- Aligns with the PRD success criterion that 100% of GitHub mutations use MCP.
+- Agent-driven GitHub mutations flow through a single, observable
+  channel (MCP).
+- Engine bookkeeping stays on the lowest-latency, lowest-dependency
+  path (`gh` CLI) and is audited via structured logs.
+- Easier to mock/stub for testing — tests substitute engine `gh` calls
+  at the adapter layer and inject fake MCP responses for agent
+  behaviour.
+- Removes the contradiction between the PolicyGuard preamble (which
+  told agents `gh` is forbidden) and the `pr_manager` module docstring
+  (which called `gh` the approved mutation path).
 
 **Negative:**
-- Requires the GitHub MCP server to be configured and reachable at startup.
-- Loop startup performs a capability check (`workspace::check`) that fails fast when MCP is not available.
-- Adds latency relative to direct REST calls (MCP round-trip overhead).
+- The single-preamble design means a misbehaving agent could still run
+  `gh` directly; enforcement is prompt-level, not sandbox-level. Agents
+  are trusted to honour the preamble. A stronger sandbox would require
+  running provider processes without `gh` on `PATH`, which is out of
+  scope for this ADR.
+- Engine-side `gh` calls remain a failure surface that is not exercised
+  through MCP tests. These are covered by targeted integration tests in
+  `src/pr_manager.rs` and `src/issue_tracker.rs` instead.
+
+## Non-goals
+
+- Routing engine bookkeeping through MCP. This was considered and
+  rejected for the reasons in the Context section. If a future version
+  of the project wants full MCP audit of engine actions, that is a new
+  ADR with its own cost/benefit analysis.
+- Runtime health-probing of the MCP server at startup. The current
+  `workspace::check` only verifies that `.mcp.json` mentions a
+  `"github"` entry.
 
 ## References
 
-- `src/policy_guard.rs` — `PolicyGuard` enforcement
-- `src/workspace.rs` — startup capability validation
-- PRD §2 Acceptance Criteria: "GitHub operations and prerequisites"
+- `src/policy_guard.rs` — `augment_prompt` enforcement (the sole
+  MCP-only enforcement point)
+- `src/pr_manager.rs` — permitted engine `gh` usage for PR lifecycle
+- `src/issue_tracker.rs` — permitted engine `gh` usage for issue
+  bookkeeping
+- `src/workspace.rs` — startup `.mcp.json` configuration check
+- PRD §2 Acceptance Criteria (to be updated alongside this ADR to scope
+  "100% of GitHub mutations use MCP" to agent-initiated mutations)
+- #59 — review discussion that prompted the revision

--- a/docs/ADRs/ADR-002-provider-adapter-trait.md
+++ b/docs/ADRs/ADR-002-provider-adapter-trait.md
@@ -1,0 +1,43 @@
+# ADR-002: Provider Adapter Trait Design
+
+**Status:** Accepted  
+**Date:** 2024-01-01  
+**Deciders:** Code Looper project team
+
+## Context
+
+Code Looper supports multiple agent CLIs (Claude Code, GitHub Copilot, Codex) and must allow new providers to be added without changing core loop logic. There are several integration patterns:
+
+1. **Enum dispatch** — a single `Provider` enum with match arms per CLI; easy to add, but `loop_engine.rs` must be changed for every new provider.
+2. **Trait objects** — a `ProviderAdapter` trait with `dyn` dispatch; new providers only require a new `impl` block and a match arm in the factory function.
+3. **Plugin/shared library** — external `.so`/`.dll` loaded at runtime; maximum extensibility, but significant complexity and safety risk.
+
+## Decision
+
+Use **trait objects** (`Box<dyn ProviderAdapter>`). The `ProviderAdapter` trait exposes:
+- `fn name(&self) -> &str` — display name for logging
+- `fn execute(&self, prompt: &str) -> Result<ExecutionResult, LooperError>` — run one iteration
+
+The `build_adapter()` factory in `src/provider.rs` maps the `Provider` config enum to the concrete type. Adding a new provider requires:
+1. Implement `ProviderAdapter` for the new struct.
+2. Add an arm to the `build_adapter` match.
+3. Add a variant to the `Provider` config enum.
+
+The PRD success criterion ("new provider scaffold implementable in ≤ 1 developer day") is satisfied by this design.
+
+## Consequences
+
+**Positive:**
+- Loop engine is fully decoupled from provider implementation details.
+- Easy to inject `FakeAdapter` in tests without touching production code.
+- Output redaction (`security::redact_secrets`) and streaming apply uniformly through the shared `run_provider_process` helper.
+
+**Negative:**
+- Slight runtime overhead from vtable dispatch (negligible vs. provider subprocess latency).
+- Provider-specific flags/options that don't fit the `execute(prompt)` interface require encoding in the struct fields rather than being exposed as typed parameters.
+
+## References
+
+- `src/provider.rs` — trait definition and all three adapter impls
+- `src/error.rs` — `LooperError` variants used for provider failures
+- PRD §2 Success Criteria: "New provider adapter scaffold can be implemented and validated in ≤ 1 developer day"

--- a/docs/ADRs/ADR-003-pluggable-policy-engine.md
+++ b/docs/ADRs/ADR-003-pluggable-policy-engine.md
@@ -17,7 +17,7 @@ The loop engine needs to route work to the right workflow (PR review, issue exec
 Introduce a **pluggable policy rules model** (`src/config.rs` `PolicyRule` / `PolicyCondition` / `PolicyWorkflow`) where:
 
 1. Default rules are embedded in code (`default_policy_rules()`) and match the MVP behavior.
-2. Users can override or extend rules via the `[orchestration.policies]` section of `loop.toml`.
+2. Users can override or extend rules via the `[orchestration.policies]` section of `looper.toml`.
 3. The `PolicyEngine` evaluates rules in order, returning the first matching `WorkflowBranch`.
 4. Context resolution is abstracted behind `ContextResolver` trait so tests can inject `StubContextResolver` without calling `gh`.
 

--- a/docs/ADRs/ADR-003-pluggable-policy-engine.md
+++ b/docs/ADRs/ADR-003-pluggable-policy-engine.md
@@ -1,0 +1,56 @@
+# ADR-003: Pluggable Orchestration Policy Engine
+
+**Status:** Accepted  
+**Date:** 2024-01-01  
+**Deciders:** Code Looper project team
+
+## Context
+
+The loop engine needs to route work to the right workflow (PR review, issue execution, backlog discovery) based on live repository state. Early versions used a hardcoded `if open_prs → pr-review, else if open_issues → issue-execution, else backlog-discovery` chain. This worked for the MVP but:
+
+- Rules could not be customized per project without recompiling.
+- Testing required mocking the entire policy evaluation.
+- The ordering and conditions were opaque to users.
+
+## Decision
+
+Introduce a **pluggable policy rules model** (`src/config.rs` `PolicyRule` / `PolicyCondition` / `PolicyWorkflow`) where:
+
+1. Default rules are embedded in code (`default_policy_rules()`) and match the MVP behavior.
+2. Users can override or extend rules via the `[orchestration.policies]` section of `loop.toml`.
+3. The `PolicyEngine` evaluates rules in order, returning the first matching `WorkflowBranch`.
+4. Context resolution is abstracted behind `ContextResolver` trait so tests can inject `StubContextResolver` without calling `gh`.
+
+Rules are defined as:
+
+```toml
+[[orchestration.policies]]
+condition = "has_open_prs"
+workflow  = "pr-review"
+
+[[orchestration.policies]]
+condition = "has_open_issues"
+workflow  = "issue-execution"
+
+[[orchestration.policies]]
+condition = "always"
+workflow  = "backlog-discovery"
+```
+
+## Consequences
+
+**Positive:**
+- Projects can invert priority (issues before PRs) or add no-op policies via config alone.
+- Default behavior is fully specified as data, making it easy to audit and test.
+- `ContextResolver` abstraction enables deterministic unit tests for every policy branch.
+
+**Negative:**
+- More config surface area for users to learn.
+- Rule evaluation is linear (first match wins); complex OR/AND conditions require multiple rules.
+- Custom condition types beyond `has_open_prs`, `has_open_issues`, and `always` require code changes.
+
+## References
+
+- `src/orchestration.rs` — `PolicyEngine`, `ContextResolver`, `WorkflowBranch`
+- `src/config.rs` — `PolicyRule`, `PolicyCondition`, `PolicyWorkflow`, `default_policy_rules`
+- PRD §2 Acceptance Criteria: "Orchestration engine — conditional policy chain"

--- a/docs/ADRs/ADR-004-branch-lifecycle-manager.md
+++ b/docs/ADRs/ADR-004-branch-lifecycle-manager.md
@@ -1,0 +1,47 @@
+# ADR-004: Centralised Branch Lifecycle Manager
+
+**Status:** Accepted  
+**Date:** 2026-04-07  
+**Deciders:** Code Looper project team
+
+## Context
+
+When the loop operates in `single-pr` mode, it needs to:
+1. Ensure a feature branch exists before the agent runs (so commits land on the right branch).
+2. Derive a deterministic, URL-safe branch name from the configured prefix and issue number.
+3. Push the branch to `origin` after a shippable signal is detected (so `gh pr create` can find the commits).
+4. Optionally clean up the local and remote branch after a PR is merged.
+
+Early iterations handled branch names inline in `loop_engine.rs` with `branch_prefix.trim_end_matches('/')`, which produced the bare prefix (`loop`) instead of a valid feature branch name. All three PR strategies (`no-pr`, `single-pr`, `multi-pr`) also duplicated branch-string logic.
+
+## Decision
+
+Centralise all branch operations in `src/branch.rs` behind two surfaces:
+
+1. **`derive_branch_name(prefix, issue_number, title, max_slug)`** — pure function; produces `{prefix}{issue_number}-{slug}`. URL-safe, collapses dashes, strips leading/trailing punctuation.
+2. **`BranchManager`** — stateful struct wrapping `PrManagementConfig`; exposes `ensure_branch`, `push_branch`, and `cleanup_branch` with safety guards (refuse to operate on `base_branch`, refuse force-push unless `allow_force_push=true`, refuse to delete branches with unmerged commits).
+
+`LoopEngine` constructs a `BranchManager` when `mode == SinglePr` and:
+- Calls `ensure_branch(issue_number, "")` before the iteration loop to checkout the feature branch.
+- Calls `push_branch(branch)` before `PrManager::handle_milestone()` so commits are visible on GitHub.
+- Uses the derived branch name (not the trimmed prefix) when calling `gh pr create`.
+
+The public `current_branch()` helper allows the engine to detect the actual checked-out branch as a fallback when `BranchManager` cannot create the branch.
+
+## Consequences
+
+**Positive:**
+- Single, tested surface for all branch operations — no duplication across strategies.
+- Safety invariants (base-branch protection, force-push gate) enforced in one place.
+- Correct branch names passed to `gh pr create` (fixes the `loop` → `loop/42-` bug).
+- `cleanup_branch` is available for future automation of post-merge cleanup.
+
+**Negative:**
+- `BranchManager::ensure_branch` runs `git checkout` before the agent starts; if the agent needs to be on a different branch it must switch itself.
+- `cleanup_branch` is not yet called automatically (would require detecting PR merge events, which needs a polling loop or webhook).
+
+## References
+
+- `src/branch.rs` — `BranchManager`, `derive_branch_name`, `current_branch`
+- `src/loop_engine.rs` — `branch_manager` field, `single_pr_branch` computation in `run()`
+- GitHub issue [#28](https://github.com/jamesbrayton/code-looper/issues/28)

--- a/docs/ADRs/ADR-004-branch-lifecycle-manager.md
+++ b/docs/ADRs/ADR-004-branch-lifecycle-manager.md
@@ -19,7 +19,7 @@ Early iterations handled branch names inline in `loop_engine.rs` with `branch_pr
 Centralise all branch operations in `src/branch.rs` behind two surfaces:
 
 1. **`derive_branch_name(prefix, issue_number, title, max_slug)`** — pure function; produces `{prefix}{issue_number}-{slug}`. URL-safe, collapses dashes, strips leading/trailing punctuation.
-2. **`BranchManager`** — stateful struct wrapping `PrManagementConfig`; exposes `ensure_branch`, `push_branch`, and `cleanup_branch` with safety guards (refuse to operate on `base_branch`, refuse force-push unless `allow_force_push=true`, refuse to delete branches with unmerged commits).
+2. **`BranchManager`** — stateful struct wrapping `PrManagementConfig`; exposes `ensure_branch`, `push_branch`, and `cleanup_branch` with safety guards. Specifically: it refuses to operate on `base_branch`, it never adds `--force-with-lease` to `git push` unless `allow_force_push=true` (relying on git's default non-fast-forward rejection to prevent accidental overwrites — there is no separate refusal error path), and it refuses to delete branches with unmerged commits.
 
 `LoopEngine` constructs a `BranchManager` when `mode == SinglePr` and:
 - Calls `ensure_branch(issue_number, "")` before the iteration loop to checkout the feature branch.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -10,7 +10,7 @@
   - At least 3 providers (Claude Code CLI, GitHub Copilot CLI, Codex CLI) are supported by stable adapters in v1.0.
   - New provider adapter scaffold can be implemented and validated in <= 1 developer day using documented extension interfaces.
   - Teams report >= 20% reduction in manual repetitive orchestration steps (self-reported survey and run-log evidence) within 60 days of adoption.
-  - 100% of GitHub mutations (issue create/update/comment, PR review/comment/merge, branch actions) are executed through MCP server interfaces, with direct git-host CLI mutation disabled by default.
+  - 100% of **agent-initiated** GitHub mutations (issue create/update/comment, PR review/comment/merge, branch actions) are executed through MCP server interfaces, enforced via a policy-guard preamble on every provider prompt. Engine-initiated bookkeeping calls (opening/merging PRs, posting lifecycle comments, merge-cleanup branch ops) are explicitly permitted to use the `gh` CLI directly and are audited through structured logs and the per-run manifest. See ADR-001 for the scoping rationale.
 
 ## 2. User Experience & Functionality
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# Code Looper Documentation
+
+User-facing documentation for Code Looper — a pluggable loop engine for coding-agent CLIs.
+
+## Pages
+
+| Page | What it covers |
+|------|---------------|
+| [Getting Started](getting-started.md) | Install prerequisites, build from source, run your first loop |
+| [Configuration](configuration.md) | Every TOML config field and CLI flag, defaults, and precedence rules |
+| [Providers](providers.md) | How each provider adapter is invoked, environment requirements, and known limitations |
+| [Orchestration](orchestration.md) | Policy engine, workflow branches, when each branch is selected |
+| [Workspace Prerequisites](workspace-prerequisites.md) | What the prerequisite checker validates and how to fix each diagnostic |
+| [Troubleshooting](troubleshooting.md) | Common failure modes and specific remediation steps |
+
+## Architecture and Design
+
+- [PRD.md](PRD.md) — Full product requirements document
+- [ADRs/](ADRs/) — Architecture Decision Records

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,6 +54,7 @@ log_level: info
 | `retry_backoff_ms` | `--retry-backoff-ms` | integer | `500` | Base delay in milliseconds between retry attempts |
 | `retry_backoff_multiplier` | `--retry-backoff-multiplier` | float | `1.0` | Exponential backoff multiplier. `1.0` = flat; `2.0` = doubles delay each retry. Delay for attempt N = `retry_backoff_ms × multiplier^(N-1)` |
 | `on_complete` | `--on-complete` | string | — | Shell command to run once after the loop finishes (runs via `sh -c`) |
+| `provider_extra_args` | `--provider-extra-arg` (repeatable) | list of strings | `[]` | Extra arguments appended to the provider CLI invocation, after the adapter's hardcoded flags and before the prompt. Each element is a separate arg (no shell expansion). |
 
 ### Prompt validation
 
@@ -261,6 +262,7 @@ max_retries = 2
 retry_backoff_ms = 500
 retry_backoff_multiplier = 2.0
 on_complete = "echo 'Loop finished' | tee -a loop.log"
+provider_extra_args = ["--model", "claude-opus-4-5"]
 
 [orchestration]
 enabled = true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,7 +28,8 @@ Pass `--config path/to/config.toml` to load a base configuration. Any CLI flag e
 | `allow_direct_github` | `--allow-direct-github` | bool | `false` | **Unsafe.** Allow GitHub access via `gh` CLI instead of requiring MCP |
 | `stop_on_failure` | `--stop-on-failure` | bool | `false` | Stop the loop after the first iteration that fails after all retries |
 | `max_retries` | `--max-retries` | integer | `0` | Additional retry attempts per iteration on non-zero exit |
-| `retry_backoff_ms` | `--retry-backoff-ms` | integer | `500` | Milliseconds to wait between retry attempts |
+| `retry_backoff_ms` | `--retry-backoff-ms` | integer | `500` | Base delay in milliseconds between retry attempts |
+| `retry_backoff_multiplier` | — | float | `1.0` | Exponential backoff multiplier. `1.0` = flat; `2.0` = doubles delay each retry. Delay for attempt N = `retry_backoff_ms × multiplier^(N-1)` |
 | `on_complete` | `--on-complete` | string | — | Shell command to run once after the loop finishes (runs via `sh -c`) |
 
 ### Prompt validation
@@ -47,6 +48,48 @@ Controls the policy engine that selects a workflow branch per iteration from rep
 | `orchestration.enabled` | `--orchestration` | bool | `false` | Enable the policy engine |
 | `orchestration.repo_owner` | `--repo-owner` | string | — | GitHub owner (user or org); required when `enabled = true` |
 | `orchestration.repo_name` | `--repo-name` | string | — | GitHub repository name; required when `enabled = true` |
+| `orchestration.policies` | — | array of `PolicyRule` | see below | Ordered policy rule chain evaluated each iteration |
+
+### `[[orchestration.policies]]` — pluggable policy rules
+
+Each rule in the array specifies a condition and the workflow to execute when that condition is met. Rules are evaluated **in order**; the first matching rule wins.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `condition` | string | yes | `has_open_prs` · `has_open_issues` · `always` |
+| `workflow` | string | yes | `pr-review` · `issue-execution` · `backlog-discovery` |
+| `prompt_override` | string | no | Custom prompt for this rule; overrides the built-in default for the selected workflow |
+
+**Default policy chain** (used when `policies` is omitted):
+
+```toml
+[[orchestration.policies]]
+condition = "has_open_prs"
+workflow = "pr-review"
+
+[[orchestration.policies]]
+condition = "has_open_issues"
+workflow = "issue-execution"
+
+[[orchestration.policies]]
+condition = "always"
+workflow = "backlog-discovery"
+```
+
+**Custom example** — skip PR review entirely and only work on issues with a custom prompt:
+
+```toml
+[[orchestration.policies]]
+condition = "has_open_issues"
+workflow = "issue-execution"
+prompt_override = "Focus only on bugs labelled `critical` this iteration."
+
+[[orchestration.policies]]
+condition = "always"
+workflow = "backlog-discovery"
+```
+
+> **Note:** If no rule matches (e.g. you define only `has_open_prs` but there are no open PRs), the engine returns an error. Always include an `always` fallback rule.
 
 ---
 
@@ -121,13 +164,26 @@ iterations = -1
 log_level = "info"
 stop_on_failure = false
 max_retries = 2
-retry_backoff_ms = 1000
+retry_backoff_ms = 500
+retry_backoff_multiplier = 2.0
 on_complete = "echo 'Loop finished' | tee -a loop.log"
 
 [orchestration]
 enabled = true
 repo_owner = "acme"
 repo_name = "my-project"
+
+[[orchestration.policies]]
+condition = "has_open_prs"
+workflow = "pr-review"
+
+[[orchestration.policies]]
+condition = "has_open_issues"
+workflow = "issue-execution"
+
+[[orchestration.policies]]
+condition = "always"
+workflow = "backlog-discovery"
 
 [issue_tracking]
 mode = "github"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -229,24 +229,31 @@ listener starts. Per-request overrides are accepted in the request body.
 
 ### Protocol
 
-Each connection sends one JSON request followed by a newline; the service
-replies with one JSON response followed by a newline, then closes the
-connection.
+The service speaks newline-delimited JSON (JSON Lines).  A client may send
+multiple JSON requests over the same connection, one per line, and the
+service replies with one JSON response per request, also one per line.  The
+connection stays open until the client closes it or the service shuts down.
+
+All responses use a consistent envelope:
+
+- Success: `{"ok":true,"data":{...}}`
+- Error:   `{"ok":false,"error":"..."}`
 
 **Supported commands:**
 
 | Request | Response |
 |---------|---------|
-| `{"cmd":"run","prompt":"…","provider":"…"}` | `{"ok":true,"exit_code":0,"stdout":"…","stderr":"…","duration_ms":123}` |
-| `{"cmd":"status"}` | `{"ok":true,"uptime_secs":42,"run_count":7}` |
-| `{"cmd":"shutdown"}` | `{"ok":true}` — service exits after sending this |
-| _(unknown)_ | `{"ok":false,"error":"unknown command"}` |
+| `{"cmd":"run","prompt":"…","provider":"…"}` | `{"ok":true,"data":{"ok":true,"exit_code":0,"stdout":"…","stderr":"…","duration_ms":123}}` |
+| `{"cmd":"status"}` | `{"ok":true,"data":{"uptime_secs":42,"run_count":7,"success_count":6,"failure_count":1,"provider":"claude"}}` |
+| `{"cmd":"shutdown"}` | `{"ok":true,"data":{"message":"shutting down"}}` — service exits after sending this |
+| _(unknown / parse error)_ | `{"ok":false,"error":"…"}` |
 
 **Example session (netcat):**
 
 ```bash
-echo '{"cmd":"status"}' | nc 127.0.0.1 7979
-# → {"ok":true,"uptime_secs":5,"run_count":0}
+printf '%s\n%s\n' '{"cmd":"status"}' '{"cmd":"status"}' | nc 127.0.0.1 7979
+# → {"ok":true,"data":{"uptime_secs":5,"run_count":0,"success_count":0,"failure_count":0,"provider":"claude"}}
+# → {"ok":true,"data":{"uptime_secs":6,"run_count":0,"success_count":0,"failure_count":0,"provider":"claude"}}
 ```
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,6 +156,77 @@ Controls artifact collection and run summaries.
 
 ---
 
+## `[[multi_repo]]`
+
+When one or more `[[multi_repo]]` entries are present, Code Looper runs the
+configured loop for each target repository in sequence instead of the default
+single-repo mode. Each entry is a separate TOML array item.
+
+| TOML key | Type | Required | Description |
+|----------|------|----------|-------------|
+| `path` | path | yes | Filesystem path to the repository root. Relative paths are resolved from the working directory at startup. |
+| `name` | string | no | Human-readable label used in run logs and the aggregate summary. Defaults to the last path component of `path`. |
+| `prompt_override` | string | no | Per-repo prompt that replaces the top-level `prompt_inline` / `prompt_file` value for this specific target. |
+
+**Example:**
+
+```toml
+[[multi_repo]]
+path = "/home/dev/repos/service-a"
+name = "service-a"
+
+[[multi_repo]]
+path = "/home/dev/repos/service-b"
+prompt_override = "Run security audit only — do not change any code."
+```
+
+When `multi_repo` is non-empty the standard single-repo loop engine is skipped.
+A per-repo summary and an aggregate total are printed after all targets finish.
+
+---
+
+## `serve` subcommand
+
+`code-looper serve` starts a long-running TCP listener that accepts loop-run
+requests over a newline-delimited JSON (JSON-lines) protocol. This is the v2.0
+service / embedding mode.
+
+```
+code-looper serve [--port N] [--bind-addr ADDR]
+```
+
+| CLI flag | Default | Description |
+|----------|---------|-------------|
+| `--port` | `7979` | TCP port to listen on |
+| `--bind-addr` | `127.0.0.1` | Address to bind to (loopback-only by default) |
+
+The base `LoopConfig` is loaded from `--config` (or defaults) before the
+listener starts. Per-request overrides are accepted in the request body.
+
+### Protocol
+
+Each connection sends one JSON request followed by a newline; the service
+replies with one JSON response followed by a newline, then closes the
+connection.
+
+**Supported commands:**
+
+| Request | Response |
+|---------|---------|
+| `{"cmd":"run","prompt":"…","provider":"…"}` | `{"ok":true,"exit_code":0,"stdout":"…","stderr":"…","duration_ms":123}` |
+| `{"cmd":"status"}` | `{"ok":true,"uptime_secs":42,"run_count":7}` |
+| `{"cmd":"shutdown"}` | `{"ok":true}` — service exits after sending this |
+| _(unknown)_ | `{"ok":false,"error":"unknown command"}` |
+
+**Example session (netcat):**
+
+```bash
+echo '{"cmd":"status"}' | nc 127.0.0.1 7979
+# → {"ok":true,"uptime_secs":5,"run_count":0}
+```
+
+---
+
 ## Example TOML config
 
 ```toml
@@ -202,4 +273,14 @@ require_human_review = true
 [telemetry]
 stream_output = true
 keep_runs = 20
+
+# Optional: run against multiple repositories in sequence.
+# When present, the single-repo path is skipped entirely.
+[[multi_repo]]
+path = "/home/dev/repos/service-a"
+name = "service-a"
+
+[[multi_repo]]
+path = "/home/dev/repos/service-b"
+prompt_override = "Apply the same lint fixes as service-a."
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,7 +154,7 @@ Controls feature branch and pull-request lifecycle.
 | `pr_management.require_human_review` | `--require-human-review` / `--no-require-human-review` | bool | `true` | When true, the loop never merges a PR itself |
 | `pr_management.allow_force_push` | — | bool | `false` | Allow force-push with `--force-with-lease` on feature branches |
 | `pr_management.ready_marker` | — | string | — | Sentinel string in agent output that triggers PR creation |
-| `pr_management.triage_priority` | — | `oldest`\|`newest`\|`least-conflicts` | `oldest` | PR ordering for `multi-pr` triage |
+| `pr_management.triage_priority` | — | `oldest`\|`newest`\|`least-conflicts` | `oldest` | PR ordering for `multi-pr` triage; `least-conflicts` prioritises MERGEABLE PRs |
 | `pr_management.skip_labels` | — | string array | `["do-not-loop","wip"]` | Labels that cause a PR to be skipped during `multi-pr` triage |
 
 ### PR mode values

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -216,16 +216,35 @@ requests over a newline-delimited JSON (JSON-lines) protocol. This is the v2.0
 service / embedding mode.
 
 ```
-code-looper serve [--port N] [--bind-addr ADDR]
+code-looper serve [--port N] [--bind-addr ADDR] [--unsafe-bind]
 ```
 
 | CLI flag | Default | Description |
 |----------|---------|-------------|
 | `--port` | `7979` | TCP port to listen on |
 | `--bind-addr` | `127.0.0.1` | Address to bind to (loopback-only by default) |
+| `--unsafe-bind` | _off_ | Allow binding to a non-loopback address (see below) |
 
 The base `LoopConfig` is loaded from `--config` (or defaults) before the
 listener starts. Per-request overrides are accepted in the request body.
+
+### Security model
+
+**Service mode has no built-in authentication.** The `run` command
+executes arbitrary prompts through the configured provider with
+`--dangerously-skip-permissions`, so any caller that can reach the TCP
+socket can trigger provider runs against the host filesystem.
+
+As a result, the service will **refuse to start** if `--bind-addr` resolves
+to anything outside the loopback range (`127.0.0.0/8`, `::1`, `localhost`)
+unless you also pass `--unsafe-bind`. When `--unsafe-bind` is set the
+service logs a prominent warning and starts anyway — you are expected to
+have put the deployment behind your own auth/firewall layer (reverse
+proxy with mTLS, SSH tunnel, VPN, container network policy, etc.).
+
+If you just want to expose the service to another process on the same
+host, prefer the default `127.0.0.1` bind and do **not** pass
+`--unsafe-bind`.
 
 ### Protocol
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,7 +53,7 @@ log_level: info
 | `max_retries` | `--max-retries` | integer | `0` | Additional retry attempts per iteration on non-zero exit |
 | `retry_backoff_ms` | `--retry-backoff-ms` | integer | `500` | Base delay in milliseconds between retry attempts |
 | `retry_backoff_multiplier` | `--retry-backoff-multiplier` | float | `1.0` | Exponential backoff multiplier. `1.0` = flat; `2.0` = doubles delay each retry. Delay for attempt N = `retry_backoff_ms × multiplier^(N-1)` |
-| `on_complete` | `--on-complete` | string | — | Shell command to run once after the loop finishes (runs via `sh -c`) |
+| `on_complete` | `--on-complete` | string | — | Shell command to run once after the loop finishes (runs via `sh -c`). **Security note:** the value is passed verbatim to `sh -c`, so any config-file or CLI source that can set this field can execute arbitrary shell on the host. Treat TOML/YAML config files the same way you would treat a shell script committed to the repo. |
 | `provider_extra_args` | `--provider-extra-arg` (repeatable) | list of strings | `[]` | Extra arguments appended to the provider CLI invocation, after the adapter's hardcoded flags and before the prompt. Each element is a separate arg (no shell expansion). |
 
 ### Prompt validation

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,7 @@ Pass `--config path/to/config.toml` to load a base configuration. Any CLI flag e
 | `stop_on_failure` | `--stop-on-failure` | bool | `false` | Stop the loop after the first iteration that fails after all retries |
 | `max_retries` | `--max-retries` | integer | `0` | Additional retry attempts per iteration on non-zero exit |
 | `retry_backoff_ms` | `--retry-backoff-ms` | integer | `500` | Base delay in milliseconds between retry attempts |
-| `retry_backoff_multiplier` | — | float | `1.0` | Exponential backoff multiplier. `1.0` = flat; `2.0` = doubles delay each retry. Delay for attempt N = `retry_backoff_ms × multiplier^(N-1)` |
+| `retry_backoff_multiplier` | `--retry-backoff-multiplier` | float | `1.0` | Exponential backoff multiplier. `1.0` = flat; `2.0` = doubles delay each retry. Delay for attempt N = `retry_backoff_ms × multiplier^(N-1)` |
 | `on_complete` | `--on-complete` | string | — | Shell command to run once after the loop finishes (runs via `sh -c`) |
 
 ### Prompt validation
@@ -105,7 +105,7 @@ Controls issue tracking and run-lifecycle commenting.
 | `issue_tracking.local_promise_path` | `--local-promise-path` | path | `.code-looper/promise.md` | Path to local promise file when mode is `local` |
 | `issue_tracking.comment_issue_number` | `--comment-issue` | integer | — | GitHub issue number to post run-lifecycle comments on |
 | `issue_tracking.comment_cadence` | `--comment-cadence` | `milestones`\|`every-iteration`\|`off-engine` | `milestones` | How often the engine posts issue comments |
-| `issue_tracking.auto_close_owned_issues` | — | bool | `false` | Close the linked issue at end-of-run if the agent left it open |
+| `issue_tracking.auto_close_owned_issues` | `--auto-close-owned-issues` | bool | `false` | Close the linked issue at end-of-run if the agent left it open |
 | `issue_tracking.standard_labels` | — | string array | `["bug","enhancement","tech-debt","discovered-during-loop"]` | Labels the engine ensures exist on the repo at startup (GitHub mode only) |
 
 ### Comment cadence values

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,149 @@
+# Configuration Reference
+
+Code Looper can be configured through a TOML file, CLI flags, or a combination of both. CLI flags always take precedence over values in the TOML file.
+
+## Precedence
+
+```
+CLI flags  >  TOML config file  >  built-in defaults
+```
+
+## Loading a config file
+
+Pass `--config path/to/config.toml` to load a base configuration. Any CLI flag explicitly set on the same invocation overrides the corresponding TOML value.
+
+---
+
+## Top-level fields
+
+| TOML key | CLI flag | Type | Default | Description |
+|----------|----------|------|---------|-------------|
+| `provider` | `--provider` | `claude` \| `copilot` \| `codex` | `claude` | Agent CLI to use for each iteration |
+| `iterations` | `--iterations` | integer or `-1` | `1` | How many iterations to run; `-1` runs forever |
+| `prompt_inline` | `--prompt-inline` | string | — | Prompt text passed directly (mutually exclusive with `prompt_file`) |
+| `prompt_file` | `--prompt-file` | path | — | Path to a markdown file whose contents become the prompt (mutually exclusive with `prompt_inline`) |
+| `log_level` | `--log-level` | `trace`\|`debug`\|`info`\|`warn`\|`error` | `info` | Tracing log level |
+| `workspace_dir` | `--workspace-dir` | path | cwd | Directory to use as the workspace root for prerequisite checks |
+| `skip_prereq_check` | `--skip-prereq-check` | bool | `false` | Skip instruction-file and MCP config validation at startup |
+| `allow_direct_github` | `--allow-direct-github` | bool | `false` | **Unsafe.** Allow GitHub access via `gh` CLI instead of requiring MCP |
+| `stop_on_failure` | `--stop-on-failure` | bool | `false` | Stop the loop after the first iteration that fails after all retries |
+| `max_retries` | `--max-retries` | integer | `0` | Additional retry attempts per iteration on non-zero exit |
+| `retry_backoff_ms` | `--retry-backoff-ms` | integer | `500` | Milliseconds to wait between retry attempts |
+| `on_complete` | `--on-complete` | string | — | Shell command to run once after the loop finishes (runs via `sh -c`) |
+
+### Prompt validation
+
+- `--prompt-inline` and `--prompt-file` are mutually exclusive. Passing both is a validation error.
+- When orchestration is enabled, a prompt is generated automatically; providing `--prompt-inline` or `--prompt-file` alongside `--orchestration` is still valid — the user prompt is appended to the generated preamble.
+
+---
+
+## `[orchestration]`
+
+Controls the policy engine that selects a workflow branch per iteration from repository context.
+
+| TOML key | CLI flag | Type | Default | Description |
+|----------|----------|------|---------|-------------|
+| `orchestration.enabled` | `--orchestration` | bool | `false` | Enable the policy engine |
+| `orchestration.repo_owner` | `--repo-owner` | string | — | GitHub owner (user or org); required when `enabled = true` |
+| `orchestration.repo_name` | `--repo-name` | string | — | GitHub repository name; required when `enabled = true` |
+
+---
+
+## `[issue_tracking]`
+
+Controls issue tracking and run-lifecycle commenting.
+
+| TOML key | CLI flag | Type | Default | Description |
+|----------|----------|------|---------|-------------|
+| `issue_tracking.mode` | `--issue-tracking-mode` | `github` \| `local` | `local` | Backend for issue tracking |
+| `issue_tracking.repo_owner` | `--issue-tracking-owner` | string | — | GitHub owner for issue tracking; falls back to `--repo-owner` |
+| `issue_tracking.repo_name` | `--issue-tracking-repo` | string | — | GitHub repo name for issue tracking; falls back to `--repo-name` |
+| `issue_tracking.local_promise_path` | `--local-promise-path` | path | `.code-looper/promise.md` | Path to local promise file when mode is `local` |
+| `issue_tracking.comment_issue_number` | `--comment-issue` | integer | — | GitHub issue number to post run-lifecycle comments on |
+| `issue_tracking.comment_cadence` | `--comment-cadence` | `milestones`\|`every-iteration`\|`off-engine` | `milestones` | How often the engine posts issue comments |
+| `issue_tracking.auto_close_owned_issues` | — | bool | `false` | Close the linked issue at end-of-run if the agent left it open |
+| `issue_tracking.standard_labels` | — | string array | `["bug","enhancement","tech-debt","discovered-during-loop"]` | Labels the engine ensures exist on the repo at startup (GitHub mode only) |
+
+### Comment cadence values
+
+| Value | Behavior |
+|-------|----------|
+| `milestones` | Comment at run start, run end, blockers, and failed iterations |
+| `every-iteration` | Comment after every iteration regardless of outcome |
+| `off-engine` | Engine never posts comments; the agent is still prompted to do so |
+
+---
+
+## `[pr_management]`
+
+Controls feature branch and pull-request lifecycle.
+
+| TOML key | CLI flag | Type | Default | Description |
+|----------|----------|------|---------|-------------|
+| `pr_management.mode` | `--pr-mode` | `no-pr`\|`single-pr`\|`multi-pr` | `no-pr` | PR strategy |
+| `pr_management.base_branch` | `--base-branch` | string | `main` | Branch to open PRs into |
+| `pr_management.branch_prefix` | `--branch-prefix` | string | `loop/` | Prefix for feature branches created by the loop |
+| `pr_management.require_human_review` | `--require-human-review` / `--no-require-human-review` | bool | `true` | When true, the loop never merges a PR itself |
+| `pr_management.allow_force_push` | — | bool | `false` | Allow force-push with `--force-with-lease` on feature branches |
+| `pr_management.ready_marker` | — | string | — | Sentinel string in agent output that triggers PR creation |
+| `pr_management.triage_priority` | — | `oldest`\|`newest`\|`least-conflicts` | `oldest` | PR ordering for `multi-pr` triage |
+| `pr_management.skip_labels` | — | string array | `["do-not-loop","wip"]` | Labels that cause a PR to be skipped during `multi-pr` triage |
+
+### PR mode values
+
+| Value | Behavior |
+|-------|----------|
+| `no-pr` | Commit and push to a feature branch only; never open a PR |
+| `single-pr` | Work on one feature branch; open a PR when work is shippable, then continue pushing to that branch until merged |
+| `multi-pr` | On each iteration, triage open PRs first (review, fix, merge); open new feature branches for issue work only when no PR can be advanced |
+
+---
+
+## `[telemetry]`
+
+Controls artifact collection and run summaries.
+
+| TOML key | CLI flag | Type | Default | Description |
+|----------|----------|------|---------|-------------|
+| `telemetry.stream_output` | `--stream-output` / `--no-stream-output` | bool | `true` | Stream provider stdout/stderr to the terminal in real time |
+| `telemetry.artifacts_dir` | `--artifacts-dir` | path | `.code-looper/runs` | Root directory for per-run artifact directories |
+| `telemetry.keep_runs` | `--keep-runs` | integer | `10` | Number of most-recent run directories to retain |
+| `telemetry.no_summary` | `--no-summary` | bool | `false` | Suppress the markdown summary and terminal summary at end of run |
+
+---
+
+## Example TOML config
+
+```toml
+provider = "claude"
+iterations = -1
+log_level = "info"
+stop_on_failure = false
+max_retries = 2
+retry_backoff_ms = 1000
+on_complete = "echo 'Loop finished' | tee -a loop.log"
+
+[orchestration]
+enabled = true
+repo_owner = "acme"
+repo_name = "my-project"
+
+[issue_tracking]
+mode = "github"
+repo_owner = "acme"
+repo_name = "my-project"
+comment_issue_number = 42
+comment_cadence = "milestones"
+auto_close_owned_issues = false
+
+[pr_management]
+mode = "single-pr"
+base_branch = "main"
+branch_prefix = "loop/"
+require_human_review = true
+
+[telemetry]
+stream_output = true
+keep_runs = 20
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,16 +1,39 @@
 # Configuration Reference
 
-Code Looper can be configured through a TOML file, CLI flags, or a combination of both. CLI flags always take precedence over values in the TOML file.
+Code Looper can be configured through a config file (TOML or YAML), CLI flags, or a combination of both. CLI flags always take precedence over values in the config file.
 
 ## Precedence
 
 ```
-CLI flags  >  TOML config file  >  built-in defaults
+CLI flags  >  config file (TOML or YAML)  >  built-in defaults
 ```
 
 ## Loading a config file
 
-Pass `--config path/to/config.toml` to load a base configuration. Any CLI flag explicitly set on the same invocation overrides the corresponding TOML value.
+Pass `--config path/to/config.toml` (or `.yaml` / `.yml`) to load a base configuration. Any CLI flag explicitly set on the same invocation overrides the corresponding value from the file.
+
+The format is detected automatically from the file extension:
+
+| Extension | Format |
+|-----------|--------|
+| `.yaml`, `.yml` | YAML |
+| `.toml` or anything else | TOML (default) |
+
+**TOML example (`looper.toml`):**
+
+```toml
+provider = "claude"
+iterations = 5
+log_level = "info"
+```
+
+**YAML equivalent (`looper.yaml`):**
+
+```yaml
+provider: claude
+iterations: 5
+log_level: info
+```
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -138,6 +138,10 @@ code-looper \
 
 ## Next steps
 
+- [docs/configuration.md](configuration.md) — Every config field, CLI flag, default, and precedence rule
+- [docs/providers.md](providers.md) — Provider adapter invocation, environment requirements, and known limitations
 - [docs/orchestration.md](orchestration.md) — Workflow branches, shippable signal, PR lifecycle, multi-PR triage
+- [docs/workspace-prerequisites.md](workspace-prerequisites.md) — What the prerequisite checker validates and how to fix each diagnostic
+- [docs/troubleshooting.md](troubleshooting.md) — Common failure modes and remediation steps
 - [docs/PRD.md](PRD.md) — Full product requirements and roadmap
 - [CLAUDE.md](../CLAUDE.md) — Contributor workflow and issue discipline

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,143 @@
+# Getting Started with Code Looper
+
+This guide walks you through installing prerequisites, building Code Looper, and running your first loop against a real repository.
+
+## Prerequisites
+
+| Requirement | Notes |
+|-------------|-------|
+| Rust stable | Install via [rustup.rs](https://rustup.rs) |
+| Git | Used for branch operations |
+| At least one provider CLI | `claude` (Claude Code), `gh copilot` (GitHub Copilot), or `codex` (OpenAI Codex) |
+| GitHub CLI (`gh`) | Required for GitHub-integrated workflows; install from [cli.github.com](https://cli.github.com) |
+| `GITHUB_TOKEN` env var | Required when `--issue-tracking-mode=github` or `--orchestration` is set |
+
+### Dev container (recommended)
+
+If you use VS Code or a compatible editor, the provided dev container already has everything installed. Open the repo in the container and skip to [Build](#build).
+
+## Build
+
+```bash
+git clone https://github.com/jamesbrayton/code-looper.git
+cd code-looper
+cargo build --release
+```
+
+The binary is written to `./target/release/code-looper`. Optionally add it to your `$PATH`:
+
+```bash
+cp target/release/code-looper ~/.local/bin/
+```
+
+## Run a minimal loop
+
+The simplest invocation runs one iteration with an inline prompt and streams the provider output to your terminal:
+
+```bash
+code-looper \
+  --provider claude \
+  --iterations 1 \
+  --prompt-inline "List the open TODO comments in this repository"
+```
+
+Key flags:
+
+| Flag | Description |
+|------|-------------|
+| `--provider` | `claude`, `copilot`, or `codex` |
+| `--iterations` | Positive integer, or `-1` for infinite |
+| `--prompt-inline` | Prompt text (mutually exclusive with `--prompt-file`) |
+| `--prompt-file` | Path to a markdown prompt file |
+
+## Use a config file
+
+For repeated runs, put your configuration in `looper.toml` at the repository root:
+
+```toml
+provider = "claude"
+iterations = 5
+
+[orchestration]
+enabled = true
+repo_owner = "my-org"
+repo_name  = "my-repo"
+
+[issue_tracking]
+mode        = "github"
+repo_owner  = "my-org"
+repo_name   = "my-repo"
+comment_issue_number = 42   # issue the engine will comment on
+```
+
+Then run without flags:
+
+```bash
+code-looper --config looper.toml
+```
+
+CLI flags override config file values when both are provided.
+
+## Connect to GitHub
+
+Set `GITHUB_TOKEN` in your environment (or `.env` file at the repo root) before enabling GitHub-backed features:
+
+```bash
+export GITHUB_TOKEN=ghp_...
+```
+
+The token needs `repo` scope for issue and PR operations.
+
+Run the prerequisite checker to confirm the workspace is ready:
+
+```bash
+code-looper --config looper.toml
+# The checker runs automatically at startup; use --skip-prereq-check to bypass it.
+```
+
+If checks fail, the engine prints a remediation message for each failure.
+
+## Enable orchestration
+
+Orchestration lets the engine pick the right workflow branch automatically — PR review when open PRs exist, issue work when there are open issues, backlog discovery otherwise:
+
+```bash
+code-looper \
+  --provider claude \
+  --iterations 3 \
+  --orchestration \
+  --repo-owner my-org \
+  --repo-name my-repo
+```
+
+See [docs/orchestration.md](orchestration.md) for details on workflow branch selection and PR lifecycle configuration.
+
+## Enable PR management
+
+To let the engine manage pull requests, set a PR mode:
+
+```bash
+# single-pr: open one PR and keep pushing to it
+code-looper \
+  --provider claude \
+  --iterations 5 \
+  --orchestration \
+  --repo-owner my-org \
+  --repo-name my-repo \
+  --pr-mode single-pr
+
+# multi-pr: triage open PRs every iteration before doing issue work
+code-looper \
+  --provider claude \
+  --iterations 5 \
+  --orchestration \
+  --repo-owner my-org \
+  --repo-name my-repo \
+  --pr-mode multi-pr
+```
+
+## Next steps
+
+- [docs/orchestration.md](orchestration.md) — Workflow branches, shippable signal, PR lifecycle, multi-PR triage
+- [docs/PRD.md](PRD.md) — Full product requirements and roadmap
+- [CLAUDE.md](../CLAUDE.md) — Contributor workflow and issue discipline

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ Key flags:
 
 ## Use a config file
 
-For repeated runs, put your configuration in `looper.toml` at the repository root:
+For repeated runs, put your configuration in `looper.toml` (or `looper.yaml` / `looper.yml`) at the repository root:
 
 ```toml
 provider = "claude"

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -14,6 +14,49 @@ Each iteration the orchestration policy engine evaluates the current repository 
 
 The engine resolves repository context once per iteration before selecting a branch.
 
+## Issue lifecycle
+
+When orchestration is enabled, the engine expects agents to actively manage GitHub Issues throughout the run.
+
+### Standard labels
+
+At startup (GitHub mode only) the engine ensures the following labels exist on the repository, creating any that are absent:
+
+| Label | Purpose |
+|-------|---------|
+| `bug` | Defects found during iteration |
+| `enhancement` | Feature requests or improvements |
+| `tech-debt` | Technical debt identified during work |
+| `discovered-during-loop` | New scope discovered while working on a different issue |
+
+The set is configurable via `issue_tracking.standard_labels` in `looper.toml`.
+
+### Issue creation (out-of-scope discovery)
+
+When the agent discovers work that falls outside the current issue's scope it should:
+
+1. Create a new issue via GitHub MCP with a descriptive title, body, and one or more standard labels.
+2. Add `discovered-during-loop` to the new issue.
+3. Leave a comment on the current issue linking to the newly created one.
+
+This keeps the current iteration focused and makes discovered work discoverable.
+
+### Issue closure
+
+When the agent has completed the current issue's checklist *and* the work is committed (or a PR is open), it should close the issue with a summary comment via GitHub MCP.
+
+The engine performs an end-of-run verification: after the loop finishes it checks whether the owned issue is still open.  Behaviour depends on the `auto_close_owned_issues` configuration flag:
+
+| Setting | Behaviour |
+|---------|-----------|
+| `false` *(default)* | Log a warning and leave the issue open for human review |
+| `true` | Close the issue automatically with `state_reason: completed` |
+
+### Linking
+
+- When a PR is opened for issue work, the PR body includes `Closes #<issue>` and the issue receives a back-reference comment.
+- New issues created during a run include a link back to the originating issue in their body.
+
 ## Shippable signal protocol
 
 The loop engine watches each iteration's stdout for a *shippable signal* — a marker the agent emits when it believes the current branch contains review-ready work.  When detected the engine opens (or updates) a pull request via the `gh` CLI.

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -199,8 +199,15 @@ branch and PR.
 
 ## MCP-only policy
 
-All GitHub mutations (PR create, PR comment, issue comment) flow through the
-`gh` CLI, which is the Code Looper–approved mutation path enforced by the
-policy guard layer.  Direct REST API calls without the CLI are not supported.
-The policy guard blocks disallowed paths at startup unless `--allow-direct-github`
-is explicitly set (not recommended).
+All GitHub **write** operations (PR create, PR comment, issue comment, label
+edits, etc.) must flow through the configured GitHub MCP server tools.  This
+is the Code Looper–approved mutation path: the policy guard layer prepends an
+`MCP_ONLY_PREAMBLE` to every provider prompt that explicitly forbids direct
+`gh` CLI write commands and raw GitHub REST API calls.
+
+Read-only GitHub context (open issues, PR metadata, etc.) is gathered via the
+GitHub MCP server by default.  The unsafe `--allow-direct-github` flag flips
+the **read** path to use the `gh` CLI directly (via `GhCliContextResolver`)
+*and* disables the MCP-only preamble — at which point write enforcement is no
+longer applied to provider prompts.  Use only when you know the workspace has
+no MCP server available and you accept the loss of write-path enforcement.

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -92,6 +92,55 @@ To enable automated merging (advanced, use with care):
 require_human_review = false
 ```
 
+## Multi-PR triage workflow
+
+When `mode = "multi-pr"`, the engine runs a **triage step** at the start of
+each iteration before invoking the agent.
+
+### PR discovery
+
+Open PRs are discovered by the `code-looper` label via `gh pr list`.
+
+### State classification
+
+Each candidate PR is classified into one of:
+
+| State | Meaning | Engine action |
+|-------|---------|---------------|
+| `ChecksFailing` | One or more CI checks have `conclusion: FAILURE` | Agent is prompted to fix failures and push |
+| `ChangesRequested` | `reviewDecision` is `CHANGES_REQUESTED` | Agent is prompted to address each review comment |
+| `ReadyToMerge` | Approved (or no review required) and checks pass | Merge directly (when `require_human_review = false`) or report blocked |
+| `NeedsReview` | Awaiting initial review | Skipped; engine proceeds to next PR |
+| `Skipped` | PR carries a skip label (`do-not-loop`, `wip`, …) | Ignored entirely |
+
+### Triage priority
+
+The `triage_priority` setting controls which PR is acted on first when multiple
+actionable PRs exist:
+
+| Value | Behaviour |
+|-------|-----------|
+| `oldest` *(default)* | Oldest PR first (ascending creation order) |
+| `newest` | Newest PR first |
+| `least-conflicts` | Same ordering as `oldest` (conflict detection not yet implemented) |
+
+### Fall-through
+
+If no open PR can be advanced (all skipped, all `NeedsReview`, or all blocked
+on human review) the triage step reports this and the iteration proceeds as
+normal issue-work.
+
+### Prompt override
+
+When an actionable PR is found, the engine **replaces** the normal iteration
+prompt with a triage-generated prompt.  The agent is directed to:
+
+- Fix failing CI checks (when `ChecksFailing`)
+- Address reviewer feedback (when `ChangesRequested`)
+
+The prompt includes the PR number and title so the agent can locate the correct
+branch and PR.
+
 ## Configuration reference (`[pr_management]`)
 
 | Key | Type | Default | Description |
@@ -102,6 +151,8 @@ require_human_review = false
 | `require_human_review` | bool | `true` | Gate merges on human approval |
 | `allow_force_push` | bool | `false` | Allow `--force-with-lease` pushes |
 | `ready_marker` | string | `"LOOPER_READY_FOR_REVIEW"` | Shippable sentinel |
+| `triage_priority` | `oldest` \| `newest` \| `least-conflicts` | `oldest` | Multi-PR ordering |
+| `skip_labels` | list of strings | `["do-not-loop","wip"]` | Labels that exclude a PR from triage |
 
 ## MCP-only policy
 

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -165,7 +165,7 @@ actionable PRs exist:
 |-------|-----------|
 | `oldest` *(default)* | Oldest PR first (ascending creation order) |
 | `newest` | Newest PR first |
-| `least-conflicts` | Same ordering as `oldest` (conflict detection not yet implemented) |
+| `least-conflicts` | PRs with `MERGEABLE` GitHub state first; `UNKNOWN` second; `CONFLICTING` last. Fetches all PR states upfront to sort before selecting an action. |
 
 ### Fall-through
 

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -1,0 +1,112 @@
+# Code Looper Orchestration
+
+This document describes how the loop engine selects workflow branches, the shippable-signal protocol, and PR lifecycle management.
+
+## Workflow branch selection
+
+Each iteration the orchestration policy engine evaluates the current repository context and selects one of three workflow branches:
+
+| Branch | When selected | Default prompt focus |
+|--------|--------------|---------------------|
+| `pr-review` | Open PRs exist | Review diffs, leave comments via MCP |
+| `issue-execution` | Open issues exist (no open PRs) | Pick highest-priority issue, implement, update via MCP |
+| `backlog-discovery` | No open PRs or issues | Identify improvements, create issues via MCP |
+
+The engine resolves repository context once per iteration before selecting a branch.
+
+## Shippable signal protocol
+
+The loop engine watches each iteration's stdout for a *shippable signal* — a marker the agent emits when it believes the current branch contains review-ready work.  When detected the engine opens (or updates) a pull request via the `gh` CLI.
+
+### Form 1 — Sentinel line (recommended)
+
+Include a line in your output that is **exactly** the sentinel string (no surrounding text on the same line).  The default sentinel is:
+
+```
+LOOPER_READY_FOR_REVIEW
+```
+
+Example agent output:
+
+```
+All tests pass.
+LOOPER_READY_FOR_REVIEW
+```
+
+The sentinel is case-sensitive and matched after trimming leading/trailing whitespace.
+
+### Form 2 — JSON block
+
+Emit a single-line JSON object with the `looper` key set to `"ready-for-review"`.  Optionally include a `summary` key whose value appears in the PR body:
+
+```json
+{"looper":"ready-for-review","summary":"Implemented user authentication module"}
+```
+
+The JSON block must appear on its own line and must start with `{`.
+
+### Signal priority
+
+If both forms are present in the same output, the sentinel line takes priority (it is found first in the scan).
+
+### Custom sentinel
+
+Override the sentinel string in `looper.toml`:
+
+```toml
+[pr_management]
+ready_marker = "MY_CUSTOM_SIGNAL"
+```
+
+## PR lifecycle
+
+### On first detection (no open PR)
+
+The engine opens a pull request:
+
+- **Head**: the active feature branch (e.g. `loop/42-my-feature`)
+- **Base**: `pr_management.base_branch` (default: `main`)
+- **Title**: `[LOOPER] #<issue>: <issue title>`
+- **Body**: links `Closes #<issue>`, optionally includes the agent's `summary`
+- **Labels**: `code-looper`, `needs-review`
+
+### On subsequent detections (PR already open)
+
+When `require_human_review = true` (the default): the engine logs a
+`BlockedOnHumanReview` event and takes no further automated action.  The PR
+remains open awaiting a human reviewer.
+
+When `require_human_review = false`: the engine appends a comment to the
+existing PR with the agent's update summary.
+
+### Human-review gating
+
+`require_human_review = true` (default) means the loop engine **never** calls
+`gh pr merge` itself.  Merge is left entirely to a human reviewer.  This is the
+safe default for all production usage.
+
+To enable automated merging (advanced, use with care):
+
+```toml
+[pr_management]
+require_human_review = false
+```
+
+## Configuration reference (`[pr_management]`)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `mode` | `no-pr` \| `single-pr` \| `multi-pr` | `no-pr` | PR strategy |
+| `base_branch` | string | `"main"` | Branch PRs target |
+| `branch_prefix` | string | `"loop/"` | Feature branch prefix |
+| `require_human_review` | bool | `true` | Gate merges on human approval |
+| `allow_force_push` | bool | `false` | Allow `--force-with-lease` pushes |
+| `ready_marker` | string | `"LOOPER_READY_FOR_REVIEW"` | Shippable sentinel |
+
+## MCP-only policy
+
+All GitHub mutations (PR create, PR comment, issue comment) flow through the
+`gh` CLI, which is the Code Looper–approved mutation path enforced by the
+policy guard layer.  Direct REST API calls without the CLI are not supported.
+The policy guard blocks disallowed paths at startup unless `--allow-direct-github`
+is explicitly set (not recommended).

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,127 @@
+# Provider Adapters
+
+Code Looper supports three provider adapters out of the box. Each adapter implements a common `ProviderAdapter` trait: it spawns the underlying CLI with the resolved prompt, captures stdout/stderr, and returns a normalized `ExecutionResult`.
+
+Select a provider with `--provider <name>` or set `provider = "<name>"` in your TOML config.
+
+---
+
+## Claude Code CLI (`claude`)
+
+**CLI flag value:** `claude` (default)
+
+### How it is invoked
+
+```
+claude -p --dangerously-skip-permissions "<prompt>"
+```
+
+- `-p` runs in headless/pipe mode (no interactive TUI).
+- `--dangerously-skip-permissions` bypasses the interactive permission confirmation prompt so the loop can run unattended.
+
+### Environment requirements
+
+| Requirement | Notes |
+|-------------|-------|
+| `claude` on `$PATH` | Install from [claude.ai/code](https://claude.ai/code) or via npm: `npm install -g @anthropic-ai/claude-code` |
+| Anthropic credentials | Log in once interactively with `claude` before running the loop; credentials are cached locally |
+
+### Known limitations
+
+- `--dangerously-skip-permissions` is required for unattended use. This means the agent may perform file writes and shell commands without per-action confirmation. Use orchestration policies and workspace prerequisite checks to constrain scope.
+- Long-running prompts can time out if the provider process does not complete within the system's process timeout.
+
+### Example
+
+```bash
+code-looper \
+  --provider claude \
+  --iterations 5 \
+  --prompt-inline "Review open GitHub issues and prioritize the backlog."
+```
+
+---
+
+## GitHub Copilot CLI (`copilot`)
+
+**CLI flag value:** `copilot`
+
+### How it is invoked
+
+```
+gh copilot suggest -t shell "<prompt>"
+```
+
+- Uses the GitHub CLI's `copilot suggest` subcommand with target type `shell`.
+- Stdout contains the suggested shell command or explanation; Code Looper captures it verbatim.
+
+### Environment requirements
+
+| Requirement | Notes |
+|-------------|-------|
+| `gh` on `$PATH` | Install from [cli.github.com](https://cli.github.com) |
+| GitHub Copilot CLI extension | Run `gh extension install github/gh-copilot` once |
+| `gh auth login` | Must be authenticated with a Copilot-enabled GitHub account |
+
+### Known limitations
+
+- `gh copilot suggest -t shell` is designed for shell-command suggestions, not multi-step agentic execution. Expect shorter, more narrowly scoped responses compared to Claude Code.
+- Does not natively support long context or file-read operations; complex prompt payloads may be truncated or produce lower-quality results.
+- Copilot CLI requires an active internet connection and a GitHub account with Copilot access.
+
+### Example
+
+```bash
+code-looper \
+  --provider copilot \
+  --iterations 3 \
+  --prompt-inline "List the top 3 failing tests in this repo and suggest fixes."
+```
+
+---
+
+## Codex CLI (`codex`)
+
+**CLI flag value:** `codex`
+
+### How it is invoked
+
+```
+codex "<prompt>"
+```
+
+- Passes the prompt as a positional argument to the `codex` binary.
+
+### Environment requirements
+
+| Requirement | Notes |
+|-------------|-------|
+| `codex` on `$PATH` | Install via npm: `npm install -g @openai/codex` |
+| OpenAI API key | Set `OPENAI_API_KEY` in your environment or `.env` file |
+
+### Known limitations
+
+- Codex CLI is a community-maintained tool; its interface and behavior may change more frequently than Claude Code or Copilot CLI.
+- Does not have built-in MCP tool support; all GitHub mutations must happen through prompt-guided `gh` CLI calls, which means `--allow-direct-github` may be required for orchestration flows.
+
+### Example
+
+```bash
+export OPENAI_API_KEY=sk-...
+code-looper \
+  --provider codex \
+  --iterations 2 \
+  --allow-direct-github \
+  --prompt-inline "Summarize recent commits and open a draft PR."
+```
+
+---
+
+## Adding a new provider adapter
+
+1. Add a new variant to `Provider` in `src/config.rs`.
+2. Implement the `ProviderAdapter` trait in `src/provider.rs` (implement `name()` and `execute()`).
+3. Wire the new variant in `build_adapter()` in `src/provider.rs`.
+4. Add at least one test in the `provider::tests` module.
+
+The adapter scaffold can be completed in under a day; see the PRD's "New provider adapter scaffold" success criterion.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -36,7 +36,7 @@ which claude    # or: gh copilot --help  or: codex --version
 **Symptom**
 
 ```
-[mcp-config] No .mcp.json found in '<dir>'
+[mcp-github-server] No .mcp.json found in '<dir>'
   → Remediation: Create .mcp.json at the repository root ...
 ```
 
@@ -48,7 +48,7 @@ Or the loop starts but GitHub orchestration calls fail mid-run.
 
 **Remediation**
 
-See [Workspace Prerequisites — mcp-config](workspace-prerequisites.md#check-mcp-config) for the minimal `.mcp.json` template and `GITHUB_TOKEN` setup.
+See [Workspace Prerequisites — mcp-github-server](workspace-prerequisites.md#check-mcp-github-server) for the minimal `.mcp.json` template and `GITHUB_TOKEN` setup.
 
 ---
 
@@ -120,7 +120,7 @@ The provider process exits non-zero on every attempt within an iteration. Common
 
 - Increase `--max-retries` and/or `--retry-backoff-ms` for transient failures.
 - Use `--stop-on-failure` if persistent failures mean the remaining iterations have no value.
-- Check the run transcript in `.code-looper/runs/<run-id>/transcript.txt` for the agent's output and error messages.
+- Check the per-iteration transcripts in `.code-looper/runs/<run-id>/iteration-<n>.log` for the agent's output and error messages (one log per iteration).
 - Review `--prompt-inline` / `--prompt-file` for ambiguities the agent might be interpreting as errors.
 
 ---

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,205 @@
+# Troubleshooting
+
+Common failure modes, their causes, and specific remediation steps.
+
+---
+
+## Provider CLI not found
+
+**Symptom**
+
+```
+error: provider process spawn failed: No such file or directory (os error 2)
+```
+
+**Cause**
+
+The selected provider binary (`claude`, `gh`, or `codex`) is not on `$PATH`.
+
+**Remediation**
+
+| Provider | Install command |
+|----------|----------------|
+| Claude Code | `npm install -g @anthropic-ai/claude-code` |
+| GitHub Copilot | `gh extension install github/gh-copilot` (requires `gh` first) |
+| Codex | `npm install -g @openai/codex` |
+
+After installing, verify the binary is accessible:
+```bash
+which claude    # or: gh copilot --help  or: codex --version
+```
+
+---
+
+## Missing MCP config
+
+**Symptom**
+
+```
+[mcp-config] No .mcp.json found in '<dir>'
+  → Remediation: Create .mcp.json at the repository root ...
+```
+
+Or the loop starts but GitHub orchestration calls fail mid-run.
+
+**Cause**
+
+`.mcp.json` is absent or does not contain a `"github"` key.
+
+**Remediation**
+
+See [Workspace Prerequisites — mcp-config](workspace-prerequisites.md#check-mcp-config) for the minimal `.mcp.json` template and `GITHUB_TOKEN` setup.
+
+---
+
+## Missing instruction file
+
+**Symptom**
+
+```
+[instruction-file] No instruction file found in '<dir>'
+```
+
+**Cause**
+
+None of `CLAUDE.md`, `AGENTS.md`, or `.github/copilot-instructions.md` exist in the workspace root.
+
+**Remediation**
+
+Create `CLAUDE.md` at the repository root. See [Workspace Prerequisites — instruction-file](workspace-prerequisites.md#check-instruction-file) for a template.
+
+---
+
+## `GITHUB_TOKEN` not set or expired
+
+**Symptom**
+
+```
+authentication error: ...
+```
+
+Or orchestration flows silently return empty PR/issue lists when repos have open items.
+
+**Cause**
+
+`GITHUB_TOKEN` is missing, expired, or lacks the required scopes.
+
+**Remediation**
+
+1. Generate a personal access token at `https://github.com/settings/tokens` with `repo`, `issues`, and `pull_requests` scopes.
+2. Export it:
+   ```bash
+   export GITHUB_TOKEN=ghp_...
+   ```
+   Or add it to a `.env` file in the repository root (`.env` is gitignored by default in Code Looper projects):
+   ```
+   GITHUB_TOKEN=ghp_...
+   ```
+3. Re-run `gh auth login` if using Copilot CLI, since it uses the `gh` credential store separately.
+
+---
+
+## Retry exhaustion
+
+**Symptom**
+
+```
+warn: iteration N failed after M retries; ...
+```
+
+The loop continues but logs warnings for each failed iteration.
+
+**Cause**
+
+The provider process exits non-zero on every attempt within an iteration. Common reasons:
+- The prompt causes the agent to hit a quota or rate limit.
+- The agent exits early due to a tool error or missing context.
+- A transient network error during a long-running operation.
+
+**Remediation**
+
+- Increase `--max-retries` and/or `--retry-backoff-ms` for transient failures.
+- Use `--stop-on-failure` if persistent failures mean the remaining iterations have no value.
+- Check the run transcript in `.code-looper/runs/<run-id>/transcript.txt` for the agent's output and error messages.
+- Review `--prompt-inline` / `--prompt-file` for ambiguities the agent might be interpreting as errors.
+
+---
+
+## Orchestration selects wrong workflow branch
+
+**Symptom**
+
+The loop runs but picks the `BacklogDiscovery` branch when open issues or PRs exist, or vice versa.
+
+**Cause**
+
+- `--repo-owner` or `--repo-name` is set incorrectly; the engine is reading a different repository than intended.
+- The GitHub MCP server cannot authenticate (see `GITHUB_TOKEN` section above).
+- Open items have labels like `do-not-loop` or `wip` that cause them to be skipped.
+
+**Remediation**
+
+1. Confirm `--repo-owner` and `--repo-name` match the target repository exactly (case-sensitive).
+2. Verify the token can access the repo:
+   ```bash
+   gh issue list --repo owner/name
+   ```
+3. Check for skip labels on PRs/issues: in `multi-pr` mode, PRs labeled `do-not-loop` or `wip` are skipped. Remove those labels or adjust `pr_management.skip_labels` in config.
+4. Enable debug logging to trace the policy decision:
+   ```bash
+   code-looper --log-level debug ...
+   ```
+
+---
+
+## Loop runs forever (`--iterations -1`) and consumes disk space
+
+**Symptom**
+
+Run artifacts accumulate in `.code-looper/runs/` and disk usage grows.
+
+**Cause**
+
+By default the loop retains the 10 most recent run directories. With very long-running or high-frequency loops, each run's transcript can be large.
+
+**Remediation**
+
+- Lower `--keep-runs` (e.g., `--keep-runs 3`) to prune older runs more aggressively.
+- Use `--no-summary` to suppress the markdown summary artifact.
+- Point `--artifacts-dir` at a path on a larger volume.
+- For CI environments where artifacts are not needed, combine `--no-summary` with `--keep-runs 1`.
+
+---
+
+## `auto_close_owned_issues` warning at end of run
+
+**Symptom**
+
+```
+warn: owned issue #N is still open at end of run. Set auto_close_owned_issues=true to close automatically.
+```
+
+**Cause**
+
+The loop finished all iterations but the linked issue (set via `--comment-issue`) is still open. The agent was prompted to close it but did not.
+
+**Remediation**
+
+- Enable `auto_close_owned_issues = true` in `[issue_tracking]` to have the engine close the issue automatically with a completion comment.
+- Or close the issue manually and mark it `completed`.
+
+---
+
+## Run artifacts missing after an interrupted run
+
+**Symptom**
+
+`.code-looper/runs/<run-id>/` exists but has no `manifest.json` or `summary.md`.
+
+**Cause**
+
+The process was killed (Ctrl-C, OOM, signal) before the end-of-run artifacts were written. The transcript file may still be present, written incrementally.
+
+**Remediation**
+
+The transcript (`transcript.txt`) is written per-iteration and is safe to read after an interrupted run. The manifest and summary are written only at clean run exit. Re-run the loop to get a complete artifact set for the next run.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -202,4 +202,4 @@ The process was killed (Ctrl-C, OOM, signal) before the end-of-run artifacts wer
 
 **Remediation**
 
-The transcript (`transcript.txt`) is written per-iteration and is safe to read after an interrupted run. The manifest and summary are written only at clean run exit. Re-run the loop to get a complete artifact set for the next run.
+Per-iteration transcripts are written as `.code-looper/runs/<run-id>/iteration-<n>.log` and are safe to read after an interrupted run. The manifest and summary are written only at clean run exit. Re-run the loop to get a complete artifact set for the next run.

--- a/docs/workspace-prerequisites.md
+++ b/docs/workspace-prerequisites.md
@@ -62,7 +62,42 @@ cargo test
 
 ---
 
-### Check: `mcp-config`
+### Check: `instruction-section`
+
+**What it looks for**
+
+Once an instruction file is found, the checker verifies that it contains the Code Looper section begin marker:
+
+```
+<!-- code-looper begin -->
+```
+
+This marker delimits the block that `code-looper bootstrap` manages. Its presence confirms the file has been configured for Code Looper use.
+
+**Failure message**
+
+```
+[instruction-section] '<file>' does not contain the Code Looper section (expected marker: `<!-- code-looper begin -->`).
+  → Remediation: Run `code-looper bootstrap` to inject the required Code Looper section into the instruction file.
+```
+
+Note: this check is skipped when `instruction-file` also fails — it only runs when an instruction file was found.
+
+**Remediation**
+
+Run `code-looper bootstrap` to append the Code Looper section automatically, or add the markers manually:
+
+```markdown
+<!-- code-looper begin -->
+## Code Looper
+
+... Code Looper configuration here ...
+<!-- code-looper end -->
+```
+
+---
+
+### Check: `mcp-github-server`
 
 **What it looks for**
 
@@ -75,13 +110,13 @@ Code Looper enforces MCP-only GitHub mutation by default. If the GitHub MCP serv
 **Failure messages**
 
 ```
-[mcp-config] No .mcp.json found in '<dir>'
-  → Remediation: Create .mcp.json at the repository root with a "github" server entry. See docs/workspace-prerequisites.md for a minimal template.
+[mcp-github-server] No .mcp.json found in '<dir>'
+  → Remediation: Create a .mcp.json that includes a "github" MCP server entry. See https://docs.anthropic.com/en/docs/claude-code/mcp for details.
 ```
 
 ```
-[mcp-config] .mcp.json exists but does not contain a "github" key
-  → Remediation: Add a "github" entry to .mcp.json. See docs/workspace-prerequisites.md for a minimal template.
+[mcp-github-server] <file> does not contain a "github" MCP server entry
+  → Remediation: Add a GitHub MCP server block under the "mcpServers" key in .mcp.json so that orchestration flows can use GitHub tools.
 ```
 
 **Remediation**

--- a/docs/workspace-prerequisites.md
+++ b/docs/workspace-prerequisites.md
@@ -1,0 +1,128 @@
+# Workspace Prerequisites
+
+Before starting the loop, Code Looper validates that the workspace satisfies a set of prerequisites. This ensures the agent has the configuration it needs and that GitHub operations are routed through the MCP server.
+
+## Running the check
+
+The prerequisite check runs automatically at startup unless disabled. To skip it:
+
+```bash
+code-looper --skip-prereq-check ...
+```
+
+Use `--skip-prereq-check` only when the workspace is not a git repository or the checks genuinely do not apply (for example, in CI environments where all prerequisites are known to be satisfied).
+
+## What is checked
+
+### Check: `instruction-file`
+
+**What it looks for**
+
+The checker looks for at least one of the following files in the workspace root:
+
+- `CLAUDE.md`
+- `AGENTS.md`
+- `.github/copilot-instructions.md`
+
+These files contain project-specific instructions for the agent. Without them, the agent will run without any project context, which typically produces generic or unhelpful results.
+
+**Failure message**
+
+```
+[instruction-file] No instruction file found in '<dir>'. Expected one of: CLAUDE.md, AGENTS.md, .github/copilot-instructions.md
+  → Remediation: Create a CLAUDE.md (or AGENTS.md) at the repository root with agent instructions for this project.
+```
+
+**Remediation**
+
+Create `CLAUDE.md` at the repository root. At a minimum, include:
+- What the project does
+- How to build and test it
+- Any conventions the agent should follow (commit style, branch naming, etc.)
+
+Example:
+```markdown
+# CLAUDE.md
+
+## Project
+
+A Rust CLI that does X.
+
+## Build
+
+```bash
+cargo build
+cargo test
+```
+
+## Conventions
+
+- Commit messages: `<type>: <summary> (#<issue>)`
+```
+
+---
+
+### Check: `mcp-config`
+
+**What it looks for**
+
+The checker looks for `.mcp.json` in the workspace root and verifies that it contains a `"github"` key, indicating that the GitHub MCP server is configured.
+
+**Why this matters**
+
+Code Looper enforces MCP-only GitHub mutation by default. If the GitHub MCP server is not configured, orchestration flows that need to read PR/issue state or post comments will fail at runtime. The startup check surfaces this early with actionable guidance rather than failing mid-run.
+
+**Failure messages**
+
+```
+[mcp-config] No .mcp.json found in '<dir>'
+  → Remediation: Create .mcp.json at the repository root with a "github" server entry. See docs/workspace-prerequisites.md for a minimal template.
+```
+
+```
+[mcp-config] .mcp.json exists but does not contain a "github" key
+  → Remediation: Add a "github" entry to .mcp.json. See docs/workspace-prerequisites.md for a minimal template.
+```
+
+**Remediation**
+
+Create `.mcp.json` at the repository root with at minimum a `github` entry:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+Ensure `GITHUB_TOKEN` is set in your environment (or in a `.env` file). The token needs at minimum `repo` scope for read operations, and `repo` + `issues` + `pull_requests` for write operations.
+
+---
+
+## Bypassing the MCP-only constraint
+
+The `--allow-direct-github` flag disables the MCP-only enforcement. This means:
+
+- The agent is not prompted to use MCP tools for GitHub mutations.
+- The orchestration engine may use direct `gh` CLI calls for context resolution.
+
+**This flag is unsafe for production use.** It exists primarily for local development and provider adapters (like `codex`) that lack MCP tool support. When set, direct `gh` mutations bypass the audit trail and policy guard layer.
+
+---
+
+## Workspace directory
+
+By default, prerequisite checks run against the current working directory. Override this with:
+
+```bash
+code-looper --workspace-dir /path/to/repo ...
+```
+
+This is useful when Code Looper is invoked from a directory other than the repository root.

--- a/docs/workspace-prerequisites.md
+++ b/docs/workspace-prerequisites.md
@@ -121,7 +121,32 @@ Code Looper enforces MCP-only GitHub mutation by default. If the GitHub MCP serv
 
 **Remediation**
 
-Create `.mcp.json` at the repository root with at minimum a `github` entry:
+Create `.mcp.json` at the repository root with at minimum a `github` entry.
+Either of the two common stubs below works — pick whichever matches your
+local tooling.  Note that `code-looper bootstrap` writes the Docker-based
+variant by default (see `MCP_STUB` in `src/bootstrap.rs`); the `npx` form
+is shown here for reference because it is the more portable option when
+Docker is not available.
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-e", "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+Or, using `npx`:
 
 ```json
 {

--- a/docs/workspace-prerequisites.md
+++ b/docs/workspace-prerequisites.md
@@ -126,3 +126,48 @@ code-looper --workspace-dir /path/to/repo ...
 ```
 
 This is useful when Code Looper is invoked from a directory other than the repository root.
+
+---
+
+## Bootstrap subcommand
+
+Instead of manually creating the required files, use the `bootstrap` subcommand
+to let Code Looper create or patch them automatically:
+
+```bash
+code-looper bootstrap
+```
+
+Bootstrap is idempotent — running it on an already-configured repository
+produces no changes and exits 0.
+
+### What bootstrap does
+
+| Prerequisite | Action |
+|---|---|
+| No instruction file found | Creates `CLAUDE.md` with a Code Looper section |
+| Instruction file lacks a Code Looper section | Appends a delimited block |
+| `.mcp.json` missing | Creates a minimal stub with the GitHub server entry |
+| `.mcp.json` lacks a `"github"` key | Merges the entry into the existing file |
+
+### Dry-run mode
+
+Preview changes without writing anything:
+
+```bash
+code-looper bootstrap --dry-run
+```
+
+### Custom workspace directory
+
+```bash
+code-looper bootstrap --workspace-dir /path/to/repo
+```
+
+### Safety guarantees
+
+- Existing content is never removed or overwritten.
+- The Code Looper section in instruction files is delimited by
+  `<!-- code-looper begin -->` and `<!-- code-looper end -->` markers, making
+  it easy to identify and remove if needed.
+- `.mcp.json` keys outside the `github` entry are not modified.

--- a/docs/workspace-prerequisites.md
+++ b/docs/workspace-prerequisites.md
@@ -41,7 +41,7 @@ Create `CLAUDE.md` at the repository root. At a minimum, include:
 - Any conventions the agent should follow (commit style, branch naming, etc.)
 
 Example:
-```markdown
+~~~markdown
 # CLAUDE.md
 
 ## Project
@@ -58,7 +58,7 @@ cargo test
 ## Conventions
 
 - Commit messages: `<type>: <summary> (#<issue>)`
-```
+~~~
 
 ---
 

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -82,10 +82,18 @@ impl std::fmt::Display for BootstrapAction {
         match self {
             BootstrapAction::Created(p) => write!(f, "[bootstrap] {}: created", p.display()),
             BootstrapAction::Appended(p) => {
-                write!(f, "[bootstrap] {}: appended Code Looper section", p.display())
+                write!(
+                    f,
+                    "[bootstrap] {}: appended Code Looper section",
+                    p.display()
+                )
             }
             BootstrapAction::MergedJson(p) => {
-                write!(f, "[bootstrap] {}: added \"github\" server entry", p.display())
+                write!(
+                    f,
+                    "[bootstrap] {}: added \"github\" server entry",
+                    p.display()
+                )
             }
             BootstrapAction::AlreadySatisfied(p) => {
                 write!(f, "[bootstrap] {}: already satisfied", p.display())
@@ -109,13 +117,20 @@ pub fn run_bootstrap(workspace_dir: &Path, dry_run: bool) -> anyhow::Result<Vec<
 
 // ── Instruction file ──────────────────────────────────────────────────────────
 
-fn bootstrap_instruction_file(workspace_dir: &Path, dry_run: bool) -> anyhow::Result<BootstrapAction> {
+fn bootstrap_instruction_file(
+    workspace_dir: &Path,
+    dry_run: bool,
+) -> anyhow::Result<BootstrapAction> {
     const CANDIDATES: &[&str] = &["CLAUDE.md", "AGENTS.md", ".github/copilot-instructions.md"];
 
     // Find the first existing instruction file.
     let existing = CANDIDATES.iter().find_map(|name| {
         let p = workspace_dir.join(name);
-        if p.is_file() { Some(p) } else { None }
+        if p.is_file() {
+            Some(p)
+        } else {
+            None
+        }
     });
 
     match existing {
@@ -123,8 +138,11 @@ fn bootstrap_instruction_file(workspace_dir: &Path, dry_run: bool) -> anyhow::Re
             // No instruction file at all → create CLAUDE.md.
             let path = workspace_dir.join("CLAUDE.md");
             if !dry_run {
-                std::fs::write(&path, format!("# Project Instructions\n\n{CLAUDE_MD_SECTION}\n"))
-                    .map_err(|e| anyhow::anyhow!("failed to create {}: {e}", path.display()))?;
+                std::fs::write(
+                    &path,
+                    format!("# Project Instructions\n\n{CLAUDE_MD_SECTION}\n"),
+                )
+                .map_err(|e| anyhow::anyhow!("failed to create {}: {e}", path.display()))?;
             }
             Ok(BootstrapAction::Created(path))
         }
@@ -138,7 +156,11 @@ fn bootstrap_instruction_file(workspace_dir: &Path, dry_run: bool) -> anyhow::Re
             } else {
                 // Append the delimited section.
                 if !dry_run {
-                    let separator = if contents.ends_with('\n') { "\n" } else { "\n\n" };
+                    let separator = if contents.ends_with('\n') {
+                        "\n"
+                    } else {
+                        "\n\n"
+                    };
                     let updated = format!("{contents}{separator}{CLAUDE_MD_SECTION}\n");
                     std::fs::write(&path, updated)
                         .map_err(|e| anyhow::anyhow!("failed to write {}: {e}", path.display()))?;
@@ -221,8 +243,16 @@ fn merge_github_server(json: &str) -> Option<String> {
         let inner = &json[insert_pos..];
         let needs_comma = !inner.trim_start().starts_with('}');
         let comma = if needs_comma { "," } else { "" };
-        let indented = github_entry.lines().map(|l| format!("    {l}")).collect::<Vec<_>>().join("\n");
-        let result = format!("{}\n{indented}{comma}{}", &json[..insert_pos], &json[insert_pos..]);
+        let indented = github_entry
+            .lines()
+            .map(|l| format!("    {l}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let result = format!(
+            "{}\n{indented}{comma}{}",
+            &json[..insert_pos],
+            &json[insert_pos..]
+        );
         return Some(result);
     }
 
@@ -290,7 +320,11 @@ mod tests {
     fn existing_claude_md_with_section_is_satisfied() {
         let dir = tmp();
         let path = dir.path().join("CLAUDE.md");
-        fs::write(&path, format!("# Proj\n{SECTION_BEGIN}\nstuff\n{SECTION_END}\n")).unwrap();
+        fs::write(
+            &path,
+            format!("# Proj\n{SECTION_BEGIN}\nstuff\n{SECTION_END}\n"),
+        )
+        .unwrap();
         let actions = run_bootstrap(dir.path(), false).unwrap();
         assert!(matches!(&actions[0], BootstrapAction::AlreadySatisfied(p) if p == &path));
         // Content must not change.
@@ -324,8 +358,11 @@ mod tests {
         let dir = tmp();
         let path = dir.path().join(".mcp.json");
         // Run bootstrap with a CLAUDE.md already present so only .mcp.json changes.
-        fs::write(dir.path().join("CLAUDE.md"), format!("{SECTION_BEGIN}\n{SECTION_END}\n"))
-            .unwrap();
+        fs::write(
+            dir.path().join("CLAUDE.md"),
+            format!("{SECTION_BEGIN}\n{SECTION_END}\n"),
+        )
+        .unwrap();
         let actions = run_bootstrap(dir.path(), false).unwrap();
         assert!(matches!(&actions[1], BootstrapAction::Created(p) if p == &path));
         let content = fs::read_to_string(&path).unwrap();
@@ -335,8 +372,11 @@ mod tests {
     #[test]
     fn mcp_json_with_github_key_is_satisfied() {
         let dir = tmp();
-        fs::write(dir.path().join("CLAUDE.md"), format!("{SECTION_BEGIN}\n{SECTION_END}\n"))
-            .unwrap();
+        fs::write(
+            dir.path().join("CLAUDE.md"),
+            format!("{SECTION_BEGIN}\n{SECTION_END}\n"),
+        )
+        .unwrap();
         let mcp_path = dir.path().join(".mcp.json");
         fs::write(&mcp_path, r#"{"mcpServers":{"github":{}}}"#).unwrap();
         let actions = run_bootstrap(dir.path(), false).unwrap();
@@ -346,22 +386,31 @@ mod tests {
     #[test]
     fn mcp_json_without_github_key_gets_merged() {
         let dir = tmp();
-        fs::write(dir.path().join("CLAUDE.md"), format!("{SECTION_BEGIN}\n{SECTION_END}\n"))
-            .unwrap();
+        fs::write(
+            dir.path().join("CLAUDE.md"),
+            format!("{SECTION_BEGIN}\n{SECTION_END}\n"),
+        )
+        .unwrap();
         let mcp_path = dir.path().join(".mcp.json");
         fs::write(&mcp_path, r#"{"mcpServers":{"context7":{}}}"#).unwrap();
         let actions = run_bootstrap(dir.path(), false).unwrap();
         assert!(matches!(&actions[1], BootstrapAction::MergedJson(p) if p == &mcp_path));
         let content = fs::read_to_string(&mcp_path).unwrap();
         assert!(content.contains("\"github\""));
-        assert!(content.contains("\"context7\""), "existing keys must be preserved");
+        assert!(
+            content.contains("\"context7\""),
+            "existing keys must be preserved"
+        );
     }
 
     #[test]
     fn dry_run_does_not_create_mcp_json() {
         let dir = tmp();
-        fs::write(dir.path().join("CLAUDE.md"), format!("{SECTION_BEGIN}\n{SECTION_END}\n"))
-            .unwrap();
+        fs::write(
+            dir.path().join("CLAUDE.md"),
+            format!("{SECTION_BEGIN}\n{SECTION_END}\n"),
+        )
+        .unwrap();
         let mcp_path = dir.path().join(".mcp.json");
         let actions = run_bootstrap(dir.path(), true).unwrap();
         assert!(matches!(&actions[1], BootstrapAction::Created(_)));
@@ -373,9 +422,16 @@ mod tests {
     #[test]
     fn fully_configured_workspace_produces_all_satisfied() {
         let dir = tmp();
-        fs::write(dir.path().join("CLAUDE.md"), format!("{SECTION_BEGIN}\n{SECTION_END}\n"))
-            .unwrap();
-        fs::write(dir.path().join(".mcp.json"), r#"{"mcpServers":{"github":{}}}"#).unwrap();
+        fs::write(
+            dir.path().join("CLAUDE.md"),
+            format!("{SECTION_BEGIN}\n{SECTION_END}\n"),
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join(".mcp.json"),
+            r#"{"mcpServers":{"github":{}}}"#,
+        )
+        .unwrap();
         let actions = run_bootstrap(dir.path(), false).unwrap();
         assert!(matches!(&actions[0], BootstrapAction::AlreadySatisfied(_)));
         assert!(matches!(&actions[1], BootstrapAction::AlreadySatisfied(_)));

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,0 +1,383 @@
+//! Bootstrap subcommand — create or patch workspace prerequisites so a
+//! repository is ready to run `code-looper`.
+//!
+//! For each prerequisite that the [`crate::workspace::PrerequisiteChecker`]
+//! validates, bootstrap produces a minimal, safe fix:
+//!
+//! | Prerequisite | Action |
+//! |---|---|
+//! | No instruction file | Create `CLAUDE.md` with a Code Looper section |
+//! | Instruction file lacks a Code Looper section | Append a delimited section |
+//! | `.mcp.json` missing | Create a minimal stub |
+//! | `.mcp.json` lacks a `"github"` key | Merge the entry into the existing file |
+//!
+//! All changes are idempotent.  In `--dry-run` mode nothing is written.
+
+use std::path::{Path, PathBuf};
+
+pub const SECTION_BEGIN: &str = "<!-- code-looper begin -->";
+pub const SECTION_END: &str = "<!-- code-looper end -->";
+
+/// Minimal Code Looper section to inject into an instruction file.
+const CLAUDE_MD_SECTION: &str = r#"<!-- code-looper begin -->
+## Code Looper
+
+This repository is configured to run with [Code Looper](https://github.com/jamesbrayton/code-looper).
+
+### GitHub mutation policy
+
+All GitHub operations (issue create/update/comment, PR review/comment/merge,
+branch actions) **must** be performed via the GitHub MCP server.  Direct `gh`
+CLI mutations are disabled by default.
+
+### Work-log discipline
+
+During loop runs the agent should:
+- Comment on the linked issue at meaningful milestones (scope clarified, first
+  implementation pass complete, tests added, blocker found, handoff).
+- Keep the issue body current (checklist, decisions, blockers/dependencies).
+- Create new issues (via GitHub MCP) when discovered work falls outside the
+  current issue's scope, using labels: `bug`, `enhancement`, `tech-debt`,
+  `discovered-during-loop`.
+- Close the issue with a summary comment when the checklist is complete and
+  the work is committed.
+<!-- code-looper end -->"#;
+
+/// Minimal `.mcp.json` stub created when no file exists at all.
+const MCP_STUB: &str = r#"{
+  "mcpServers": {
+    "github": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+      }
+    }
+  }
+}
+"#;
+
+/// A single action taken (or that would be taken) by bootstrap.
+#[derive(Debug, PartialEq)]
+pub enum BootstrapAction {
+    /// Created a new file at the given path.
+    Created(PathBuf),
+    /// Appended content to an existing file.
+    Appended(PathBuf),
+    /// Merged a JSON key into an existing file.
+    MergedJson(PathBuf),
+    /// The prerequisite was already satisfied; no change needed.
+    AlreadySatisfied(PathBuf),
+}
+
+impl std::fmt::Display for BootstrapAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BootstrapAction::Created(p) => write!(f, "[bootstrap] {}: created", p.display()),
+            BootstrapAction::Appended(p) => {
+                write!(f, "[bootstrap] {}: appended Code Looper section", p.display())
+            }
+            BootstrapAction::MergedJson(p) => {
+                write!(f, "[bootstrap] {}: added \"github\" server entry", p.display())
+            }
+            BootstrapAction::AlreadySatisfied(p) => {
+                write!(f, "[bootstrap] {}: already satisfied", p.display())
+            }
+        }
+    }
+}
+
+/// Run the bootstrap process for `workspace_dir`.
+///
+/// When `dry_run` is `true` the function returns the same actions it would
+/// have taken but writes nothing to disk.
+///
+/// Returns the list of actions taken (or that would be taken).
+pub fn run_bootstrap(workspace_dir: &Path, dry_run: bool) -> anyhow::Result<Vec<BootstrapAction>> {
+    Ok(vec![
+        bootstrap_instruction_file(workspace_dir, dry_run)?,
+        bootstrap_mcp_config(workspace_dir, dry_run)?,
+    ])
+}
+
+// ── Instruction file ──────────────────────────────────────────────────────────
+
+fn bootstrap_instruction_file(workspace_dir: &Path, dry_run: bool) -> anyhow::Result<BootstrapAction> {
+    const CANDIDATES: &[&str] = &["CLAUDE.md", "AGENTS.md", ".github/copilot-instructions.md"];
+
+    // Find the first existing instruction file.
+    let existing = CANDIDATES.iter().find_map(|name| {
+        let p = workspace_dir.join(name);
+        if p.is_file() { Some(p) } else { None }
+    });
+
+    match existing {
+        None => {
+            // No instruction file at all → create CLAUDE.md.
+            let path = workspace_dir.join("CLAUDE.md");
+            if !dry_run {
+                std::fs::write(&path, format!("# Project Instructions\n\n{CLAUDE_MD_SECTION}\n"))
+                    .map_err(|e| anyhow::anyhow!("failed to create {}: {e}", path.display()))?;
+            }
+            Ok(BootstrapAction::Created(path))
+        }
+        Some(path) => {
+            let contents = std::fs::read_to_string(&path)
+                .map_err(|e| anyhow::anyhow!("failed to read {}: {e}", path.display()))?;
+
+            if contents.contains(SECTION_BEGIN) && contents.contains(SECTION_END) {
+                // Complete section already present.
+                Ok(BootstrapAction::AlreadySatisfied(path))
+            } else {
+                // Append the delimited section.
+                if !dry_run {
+                    let separator = if contents.ends_with('\n') { "\n" } else { "\n\n" };
+                    let updated = format!("{contents}{separator}{CLAUDE_MD_SECTION}\n");
+                    std::fs::write(&path, updated)
+                        .map_err(|e| anyhow::anyhow!("failed to write {}: {e}", path.display()))?;
+                }
+                Ok(BootstrapAction::Appended(path))
+            }
+        }
+    }
+}
+
+// ── MCP config ────────────────────────────────────────────────────────────────
+
+fn bootstrap_mcp_config(workspace_dir: &Path, dry_run: bool) -> anyhow::Result<BootstrapAction> {
+    let path = workspace_dir.join(".mcp.json");
+
+    if !path.is_file() {
+        if !dry_run {
+            std::fs::write(&path, MCP_STUB)
+                .map_err(|e| anyhow::anyhow!("failed to create {}: {e}", path.display()))?;
+        }
+        return Ok(BootstrapAction::Created(path));
+    }
+
+    let contents = std::fs::read_to_string(&path)
+        .map_err(|e| anyhow::anyhow!("failed to read {}: {e}", path.display()))?;
+
+    if has_github_server(&contents) {
+        return Ok(BootstrapAction::AlreadySatisfied(path));
+    }
+
+    // The file exists but lacks a "github" entry.  Merge it in.
+    let merged = merge_github_server(&contents)
+        .ok_or_else(|| anyhow::anyhow!("could not parse {} as a JSON object", path.display()))?;
+
+    if !dry_run {
+        std::fs::write(&path, merged)
+            .map_err(|e| anyhow::anyhow!("failed to write {}: {e}", path.display()))?;
+    }
+
+    Ok(BootstrapAction::MergedJson(path))
+}
+
+/// Returns `true` when the JSON contains a `"github"` MCP server key.
+fn has_github_server(json: &str) -> bool {
+    // Same heuristic as workspace.rs — avoids a full JSON parse dependency.
+    let trimmed_key = "\"github\"";
+    json.contains(trimmed_key)
+}
+
+/// Insert a `"github"` server entry into a JSON object.
+///
+/// Supports two layouts:
+///   `{ "mcpServers": { … } }` — inserts under `mcpServers`
+///   `{ … }` — inserts directly at the top level
+///
+/// Returns `None` if the file does not look like a JSON object.
+fn merge_github_server(json: &str) -> Option<String> {
+    let github_entry = r#""github": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+      }
+    }"#;
+
+    // Locate `"mcpServers"` block if present.
+    if let Some(mcp_start) = json.find("\"mcpServers\"") {
+        // Find the opening `{` of the mcpServers value.
+        let after_key = &json[mcp_start + "\"mcpServers\"".len()..];
+        let brace_offset = after_key.find('{')?;
+        let insert_pos = mcp_start + "\"mcpServers\"".len() + brace_offset + 1;
+        // Determine whether there's already content in the object.
+        let inner = &json[insert_pos..];
+        let needs_comma = !inner.trim_start().starts_with('}');
+        let comma = if needs_comma { "," } else { "" };
+        let indented = github_entry.lines().map(|l| format!("    {l}")).collect::<Vec<_>>().join("\n");
+        let result = format!("{}\n{indented}{comma}{}", &json[..insert_pos], &json[insert_pos..]);
+        return Some(result);
+    }
+
+    // No mcpServers block: insert at the top-level object.
+    let open = json.find('{')?;
+    let insert_pos = open + 1;
+    let inner = &json[insert_pos..];
+    let needs_comma = !inner.trim_start().starts_with('}');
+    let comma = if needs_comma { "," } else { "" };
+    let result = format!(
+        "{}\n  {}{comma}{}",
+        &json[..insert_pos],
+        github_entry.lines().collect::<Vec<_>>().join("\n  "),
+        &json[insert_pos..]
+    );
+    Some(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn tmp() -> TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+
+    // ── Instruction file tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn creates_claude_md_when_no_instruction_file() {
+        let dir = tmp();
+        let path = dir.path().join("CLAUDE.md");
+        let actions = run_bootstrap(dir.path(), false).unwrap();
+        assert!(matches!(&actions[0], BootstrapAction::Created(p) if p == &path));
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains(SECTION_BEGIN));
+        assert!(content.contains(SECTION_END));
+    }
+
+    #[test]
+    fn second_run_is_no_op_for_claude_md() {
+        let dir = tmp();
+        run_bootstrap(dir.path(), false).unwrap();
+        let actions = run_bootstrap(dir.path(), false).unwrap();
+        assert!(matches!(&actions[0], BootstrapAction::AlreadySatisfied(_)));
+    }
+
+    #[test]
+    fn appends_section_to_existing_claude_md_without_section() {
+        let dir = tmp();
+        let path = dir.path().join("CLAUDE.md");
+        fs::write(&path, "# My Project\n\nExisting content.\n").unwrap();
+        let actions = run_bootstrap(dir.path(), false).unwrap();
+        assert!(matches!(&actions[0], BootstrapAction::Appended(p) if p == &path));
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("# My Project"));
+        assert!(content.contains("Existing content."));
+        assert!(content.contains(SECTION_BEGIN));
+        assert!(content.contains(SECTION_END));
+    }
+
+    #[test]
+    fn existing_claude_md_with_section_is_satisfied() {
+        let dir = tmp();
+        let path = dir.path().join("CLAUDE.md");
+        fs::write(&path, format!("# Proj\n{SECTION_BEGIN}\nstuff\n{SECTION_END}\n")).unwrap();
+        let actions = run_bootstrap(dir.path(), false).unwrap();
+        assert!(matches!(&actions[0], BootstrapAction::AlreadySatisfied(p) if p == &path));
+        // Content must not change.
+        let content = fs::read_to_string(&path).unwrap();
+        assert_eq!(content.matches(SECTION_BEGIN).count(), 1);
+    }
+
+    #[test]
+    fn dry_run_does_not_create_claude_md() {
+        let dir = tmp();
+        let path = dir.path().join("CLAUDE.md");
+        let actions = run_bootstrap(dir.path(), true).unwrap();
+        assert!(matches!(&actions[0], BootstrapAction::Created(_)));
+        assert!(!path.exists(), "dry-run must not create files");
+    }
+
+    #[test]
+    fn recognises_agents_md_as_instruction_file() {
+        let dir = tmp();
+        let path = dir.path().join("AGENTS.md");
+        fs::write(&path, "# Agents\n").unwrap();
+        let actions = run_bootstrap(dir.path(), false).unwrap();
+        // Should append (no section yet), not create a new CLAUDE.md.
+        assert!(matches!(&actions[0], BootstrapAction::Appended(p) if p == &path));
+    }
+
+    // ── MCP config tests ──────────────────────────────────────────────────────
+
+    #[test]
+    fn creates_mcp_json_when_missing() {
+        let dir = tmp();
+        let path = dir.path().join(".mcp.json");
+        // Run bootstrap with a CLAUDE.md already present so only .mcp.json changes.
+        fs::write(dir.path().join("CLAUDE.md"), format!("{SECTION_BEGIN}\n{SECTION_END}\n"))
+            .unwrap();
+        let actions = run_bootstrap(dir.path(), false).unwrap();
+        assert!(matches!(&actions[1], BootstrapAction::Created(p) if p == &path));
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("\"github\""));
+    }
+
+    #[test]
+    fn mcp_json_with_github_key_is_satisfied() {
+        let dir = tmp();
+        fs::write(dir.path().join("CLAUDE.md"), format!("{SECTION_BEGIN}\n{SECTION_END}\n"))
+            .unwrap();
+        let mcp_path = dir.path().join(".mcp.json");
+        fs::write(&mcp_path, r#"{"mcpServers":{"github":{}}}"#).unwrap();
+        let actions = run_bootstrap(dir.path(), false).unwrap();
+        assert!(matches!(&actions[1], BootstrapAction::AlreadySatisfied(p) if p == &mcp_path));
+    }
+
+    #[test]
+    fn mcp_json_without_github_key_gets_merged() {
+        let dir = tmp();
+        fs::write(dir.path().join("CLAUDE.md"), format!("{SECTION_BEGIN}\n{SECTION_END}\n"))
+            .unwrap();
+        let mcp_path = dir.path().join(".mcp.json");
+        fs::write(&mcp_path, r#"{"mcpServers":{"context7":{}}}"#).unwrap();
+        let actions = run_bootstrap(dir.path(), false).unwrap();
+        assert!(matches!(&actions[1], BootstrapAction::MergedJson(p) if p == &mcp_path));
+        let content = fs::read_to_string(&mcp_path).unwrap();
+        assert!(content.contains("\"github\""));
+        assert!(content.contains("\"context7\""), "existing keys must be preserved");
+    }
+
+    #[test]
+    fn dry_run_does_not_create_mcp_json() {
+        let dir = tmp();
+        fs::write(dir.path().join("CLAUDE.md"), format!("{SECTION_BEGIN}\n{SECTION_END}\n"))
+            .unwrap();
+        let mcp_path = dir.path().join(".mcp.json");
+        let actions = run_bootstrap(dir.path(), true).unwrap();
+        assert!(matches!(&actions[1], BootstrapAction::Created(_)));
+        assert!(!mcp_path.exists(), "dry-run must not create .mcp.json");
+    }
+
+    // ── Fully configured workspace ─────────────────────────────────────────────
+
+    #[test]
+    fn fully_configured_workspace_produces_all_satisfied() {
+        let dir = tmp();
+        fs::write(dir.path().join("CLAUDE.md"), format!("{SECTION_BEGIN}\n{SECTION_END}\n"))
+            .unwrap();
+        fs::write(dir.path().join(".mcp.json"), r#"{"mcpServers":{"github":{}}}"#).unwrap();
+        let actions = run_bootstrap(dir.path(), false).unwrap();
+        assert!(matches!(&actions[0], BootstrapAction::AlreadySatisfied(_)));
+        assert!(matches!(&actions[1], BootstrapAction::AlreadySatisfied(_)));
+    }
+}

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -37,7 +37,11 @@ pub fn derive_branch_name(
     title: &str,
     max_slug_length: usize,
 ) -> String {
-    let max_slug = if max_slug_length == 0 { DEFAULT_MAX_SLUG_LEN } else { max_slug_length };
+    let max_slug = if max_slug_length == 0 {
+        DEFAULT_MAX_SLUG_LEN
+    } else {
+        max_slug_length
+    };
 
     // Lower-case and replace non-alnum with '-'
     let raw: String = title
@@ -119,7 +123,12 @@ pub fn current_branch() -> Result<String, BranchError> {
 /// Return `true` if a local branch with `name` exists.
 fn local_branch_exists(name: &str) -> bool {
     Command::new("git")
-        .args(["show-ref", "--verify", "--quiet", &format!("refs/heads/{name}")])
+        .args([
+            "show-ref",
+            "--verify",
+            "--quiet",
+            &format!("refs/heads/{name}"),
+        ])
         .status()
         .map(|s| s.success())
         .unwrap_or(false)
@@ -128,7 +137,12 @@ fn local_branch_exists(name: &str) -> bool {
 /// Return `true` if a remote-tracking branch `origin/{name}` exists.
 fn remote_branch_exists(name: &str) -> bool {
     Command::new("git")
-        .args(["show-ref", "--verify", "--quiet", &format!("refs/remotes/origin/{name}")])
+        .args([
+            "show-ref",
+            "--verify",
+            "--quiet",
+            &format!("refs/remotes/origin/{name}"),
+        ])
         .status()
         .map(|s| s.success())
         .unwrap_or(false)
@@ -195,7 +209,12 @@ impl BranchManager {
 
     /// Derive the feature branch name for this issue.
     pub fn branch_name(&self, issue_number: u64, title: &str) -> String {
-        derive_branch_name(&self.config.branch_prefix, issue_number, title, self.max_slug_length)
+        derive_branch_name(
+            &self.config.branch_prefix,
+            issue_number,
+            title,
+            self.max_slug_length,
+        )
     }
 
     /// Ensure a feature branch exists for `issue_number`/`title` and check it
@@ -213,11 +232,17 @@ impl BranchManager {
 
         if local_branch_exists(&branch) {
             // Already exists locally — just switch to it
-            tracing::debug!(branch, "feature branch already exists locally; checking out");
+            tracing::debug!(
+                branch,
+                "feature branch already exists locally; checking out"
+            );
             git(&["checkout", &branch])?;
         } else if remote_branch_exists(&branch) {
             // Exists on remote but not locally — create tracking branch
-            tracing::debug!(branch, "feature branch exists on remote; creating local tracking branch");
+            tracing::debug!(
+                branch,
+                "feature branch exists on remote; creating local tracking branch"
+            );
             git(&["checkout", "-b", &branch, &format!("origin/{branch}")])?;
         } else {
             // New branch — create from latest base_branch
@@ -226,7 +251,12 @@ impl BranchManager {
             let _ = Command::new("git")
                 .args(["fetch", "origin", self.base()])
                 .status();
-            git(&["checkout", "-b", &branch, &format!("origin/{}", self.base())])?;
+            git(&[
+                "checkout",
+                "-b",
+                &branch,
+                &format!("origin/{}", self.base()),
+            ])?;
         }
 
         Ok(branch)
@@ -257,7 +287,11 @@ impl BranchManager {
             // in our local branch we let git reject it (correct behaviour).
         }
 
-        tracing::info!(branch, force = self.config.allow_force_push, "pushing feature branch");
+        tracing::info!(
+            branch,
+            force = self.config.allow_force_push,
+            "pushing feature branch"
+        );
         git(&args).map(|_| ())
     }
 
@@ -318,14 +352,20 @@ mod tests {
     }
 
     fn config_with_prefix(prefix: &str) -> PrManagementConfig {
-        PrManagementConfig { branch_prefix: prefix.to_string(), ..config() }
+        PrManagementConfig {
+            branch_prefix: prefix.to_string(),
+            ..config()
+        }
     }
 
     // ── derive_branch_name ────────────────────────────────────────────────────
 
     #[test]
     fn basic_name_derivation() {
-        assert_eq!(derive_branch_name("loop/", 42, "Fix auth bug", 40), "loop/42-fix-auth-bug");
+        assert_eq!(
+            derive_branch_name("loop/", 42, "Fix auth bug", 40),
+            "loop/42-fix-auth-bug"
+        );
     }
 
     #[test]
@@ -370,7 +410,10 @@ mod tests {
         // "aaa-bbb-ccc..." — truncation at 7 → "aaa-bbb" is fine, but "aaa-bbb-" → "aaa-bbb"
         let title = "aaa bbb ccc ddd"; // slug: "aaa-bbb-ccc-ddd", truncate at 8 → "aaa-bbb-" → "aaa-bbb"
         let name = derive_branch_name("loop/", 1, title, 8);
-        assert!(!name.ends_with('-'), "branch name must not end with dash: {name}");
+        assert!(
+            !name.ends_with('-'),
+            "branch name must not end with dash: {name}"
+        );
     }
 
     #[test]
@@ -390,7 +433,10 @@ mod tests {
 
     #[test]
     fn custom_prefix_propagated() {
-        assert_eq!(derive_branch_name("feat/", 1, "hello world", 40), "feat/1-hello-world");
+        assert_eq!(
+            derive_branch_name("feat/", 1, "hello world", 40),
+            "feat/1-hello-world"
+        );
     }
 
     #[test]
@@ -405,7 +451,10 @@ mod tests {
     #[test]
     fn branch_name_uses_config_prefix() {
         let manager = BranchManager::new(config_with_prefix("feat/"));
-        assert_eq!(manager.branch_name(1, "do something"), "feat/1-do-something");
+        assert_eq!(
+            manager.branch_name(1, "do something"),
+            "feat/1-do-something"
+        );
     }
 
     #[test]
@@ -437,7 +486,10 @@ mod tests {
 
     #[test]
     fn no_pr_push_false_skips_push() {
-        let cfg = PrManagementConfig { mode: PrMode::NoPr, ..config() };
+        let cfg = PrManagementConfig {
+            mode: PrMode::NoPr,
+            ..config()
+        };
         let mut mgr = BranchManager::new(cfg);
         mgr.no_pr_push = false;
         // Should return Ok without calling git (since no_pr_push=false in no-pr mode)

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -1,13 +1,16 @@
-/// Feature branch lifecycle management.
-///
-/// Centralises branch naming, creation, push, and cleanup so that all three
-/// PR strategies (`no-pr`, `single-pr`, `multi-pr`) use a single, tested
-/// surface instead of open-coding git commands.
-///
-/// # Safety invariants
-/// * Never operates on `base_branch` — any attempt returns an error.
-/// * Never force-pushes unless `allow_force_push` is explicitly `true`.
-/// * Never deletes a branch that has unmerged commits or uncommitted changes.
+//! Feature branch lifecycle management.
+//!
+//! Centralises branch naming, creation, push, and cleanup so that all three
+//! PR strategies (`no-pr`, `single-pr`, `multi-pr`) use a single, tested
+//! surface instead of open-coding git commands.
+//!
+//! # Safety invariants
+//! * Never operates on `base_branch` — any attempt returns an error.
+//! * Never force-pushes unless `allow_force_push` is explicitly `true`.
+//! * Never deletes a branch that has unmerged commits or uncommitted changes.
+// Planned API surface for PR strategies; items are tested but not yet called
+// from the main execution path.
+#![allow(dead_code)]
 use std::process::Command;
 
 use crate::config::PrManagementConfig;

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -8,9 +8,6 @@
 //! * Never operates on `base_branch` — any attempt returns an error.
 //! * Never force-pushes unless `allow_force_push` is explicitly `true`.
 //! * Never deletes a branch that has unmerged commits or uncommitted changes.
-// Planned API surface for PR strategies; items are tested but not yet called
-// from the main execution path.
-#![allow(dead_code)]
 use std::process::Command;
 
 use crate::config::PrManagementConfig;
@@ -87,9 +84,11 @@ pub enum BranchError {
     #[error("git command failed: {0}")]
     GitCommand(String),
 
+    #[allow(dead_code)]
     #[error("branch has uncommitted changes or unmerged commits — refusing to delete '{0}'")]
     UnsafeDelete(String),
 
+    #[allow(dead_code)]
     #[error("force-push is disabled; enable allow_force_push in config to proceed")]
     ForcePushDisabled,
 }
@@ -113,7 +112,7 @@ fn git(args: &[&str]) -> Result<String, BranchError> {
 }
 
 /// Return the name of the currently checked-out branch.
-fn current_branch() -> Result<String, BranchError> {
+pub fn current_branch() -> Result<String, BranchError> {
     git(&["rev-parse", "--abbrev-ref", "HEAD"])
 }
 
@@ -136,6 +135,7 @@ fn remote_branch_exists(name: &str) -> bool {
 }
 
 /// Return `true` if the working tree has uncommitted changes (tracked or staged).
+#[allow(dead_code)]
 fn has_uncommitted_changes() -> bool {
     Command::new("git")
         .args(["diff", "--quiet", "HEAD"])
@@ -146,6 +146,7 @@ fn has_uncommitted_changes() -> bool {
 
 /// Return `true` if `branch` contains commits not present in `base_branch`
 /// that are not yet merged (i.e. the branch tip is ahead of `base_branch`).
+#[allow(dead_code)]
 fn has_unmerged_commits(branch: &str, base_branch: &str) -> bool {
     // Count commits in branch that are not in base_branch
     let result = Command::new("git")
@@ -269,6 +270,7 @@ impl BranchManager {
     ///
     /// After deleting the local branch, deletes the remote branch when
     /// `delete_remote_branch_on_merge` is `true`.
+    #[allow(dead_code)]
     pub fn cleanup_branch(&self, branch: &str) -> Result<(), BranchError> {
         // Guard: never delete base_branch
         if branch == self.base() {
@@ -440,5 +442,26 @@ mod tests {
         mgr.no_pr_push = false;
         // Should return Ok without calling git (since no_pr_push=false in no-pr mode)
         assert!(mgr.push_branch("loop/1-some-branch").is_ok());
+    }
+
+    // ── current_branch ───────────────────────────────────────────────────────
+
+    #[test]
+    fn current_branch_returns_ok_in_git_repo() {
+        // We are always running inside the workspace git repo, so this must
+        // succeed and return a non-empty branch name.
+        let branch = current_branch();
+        assert!(branch.is_ok(), "current_branch() failed: {branch:?}");
+        let name = branch.unwrap();
+        assert!(!name.is_empty(), "current_branch() returned empty string");
+    }
+
+    #[test]
+    fn branch_manager_branch_name_with_zero_issue_has_trailing_separator() {
+        // When issue_number=0 and title="" the name is "{prefix}0-".
+        // This is the fallback used by the loop engine when no issue is linked.
+        let mgr = BranchManager::new(config());
+        let name = mgr.branch_name(0, "");
+        assert!(name.starts_with("loop/0"));
     }
 }

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -1,0 +1,441 @@
+/// Feature branch lifecycle management.
+///
+/// Centralises branch naming, creation, push, and cleanup so that all three
+/// PR strategies (`no-pr`, `single-pr`, `multi-pr`) use a single, tested
+/// surface instead of open-coding git commands.
+///
+/// # Safety invariants
+/// * Never operates on `base_branch` — any attempt returns an error.
+/// * Never force-pushes unless `allow_force_push` is explicitly `true`.
+/// * Never deletes a branch that has unmerged commits or uncommitted changes.
+use std::process::Command;
+
+use crate::config::PrManagementConfig;
+
+// ── Branch name derivation ────────────────────────────────────────────────────
+
+/// Maximum slug length used when `max_slug_length` is not configured.
+const DEFAULT_MAX_SLUG_LEN: usize = 40;
+
+/// Derive a deterministic, URL-safe branch name for a given issue.
+///
+/// The resulting name is `{prefix}{issue_number}-{slug}` where `slug` is the
+/// issue title lowercased, with non-alphanumeric characters replaced by `-`,
+/// consecutive dashes collapsed, leading/trailing dashes stripped, and the
+/// whole slug truncated to `max_slug_length` characters (trailing dash also
+/// stripped after truncation).
+///
+/// # Example
+/// ```
+/// use code_looper::branch::derive_branch_name;
+/// let name = derive_branch_name("loop/", 42, "Fix auth bug!", 40);
+/// assert_eq!(name, "loop/42-fix-auth-bug");
+/// ```
+pub fn derive_branch_name(
+    prefix: &str,
+    issue_number: u64,
+    title: &str,
+    max_slug_length: usize,
+) -> String {
+    let max_slug = if max_slug_length == 0 { DEFAULT_MAX_SLUG_LEN } else { max_slug_length };
+
+    // Lower-case and replace non-alnum with '-'
+    let raw: String = title
+        .to_lowercase()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+
+    // Collapse consecutive dashes and trim leading/trailing
+    let mut slug = String::new();
+    let mut prev_dash = true; // treat start as dash so leading ones are dropped
+    for ch in raw.chars() {
+        if ch == '-' {
+            if !prev_dash {
+                slug.push('-');
+            }
+            prev_dash = true;
+        } else {
+            slug.push(ch);
+            prev_dash = false;
+        }
+    }
+    // Strip trailing dash
+    let slug = slug.trim_end_matches('-');
+
+    // Truncate and strip any trailing dash introduced by truncation
+    let slug = if slug.len() > max_slug {
+        slug[..max_slug].trim_end_matches('-')
+    } else {
+        slug
+    };
+
+    format!("{prefix}{issue_number}-{slug}")
+}
+
+// ── Git helpers ───────────────────────────────────────────────────────────────
+
+/// Error type for branch operations.
+#[derive(Debug, thiserror::Error)]
+pub enum BranchError {
+    #[error("refused to operate on protected base branch '{0}'")]
+    BaseBranchProtected(String),
+
+    #[error("git command failed: {0}")]
+    GitCommand(String),
+
+    #[error("branch has uncommitted changes or unmerged commits — refusing to delete '{0}'")]
+    UnsafeDelete(String),
+
+    #[error("force-push is disabled; enable allow_force_push in config to proceed")]
+    ForcePushDisabled,
+}
+
+/// Run a git command and return trimmed stdout on success, or a `BranchError`
+/// on non-zero exit.
+fn git(args: &[&str]) -> Result<String, BranchError> {
+    let out = Command::new("git")
+        .args(args)
+        .output()
+        .map_err(|e| BranchError::GitCommand(format!("failed to spawn git: {e}")))?;
+    if out.status.success() {
+        Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+    } else {
+        let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+        Err(BranchError::GitCommand(format!(
+            "git {} failed: {stderr}",
+            args.join(" ")
+        )))
+    }
+}
+
+/// Return the name of the currently checked-out branch.
+fn current_branch() -> Result<String, BranchError> {
+    git(&["rev-parse", "--abbrev-ref", "HEAD"])
+}
+
+/// Return `true` if a local branch with `name` exists.
+fn local_branch_exists(name: &str) -> bool {
+    Command::new("git")
+        .args(["show-ref", "--verify", "--quiet", &format!("refs/heads/{name}")])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Return `true` if a remote-tracking branch `origin/{name}` exists.
+fn remote_branch_exists(name: &str) -> bool {
+    Command::new("git")
+        .args(["show-ref", "--verify", "--quiet", &format!("refs/remotes/origin/{name}")])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Return `true` if the working tree has uncommitted changes (tracked or staged).
+fn has_uncommitted_changes() -> bool {
+    Command::new("git")
+        .args(["diff", "--quiet", "HEAD"])
+        .status()
+        .map(|s| !s.success())
+        .unwrap_or(true)
+}
+
+/// Return `true` if `branch` contains commits not present in `base_branch`
+/// that are not yet merged (i.e. the branch tip is ahead of `base_branch`).
+fn has_unmerged_commits(branch: &str, base_branch: &str) -> bool {
+    // Count commits in branch that are not in base_branch
+    let result = Command::new("git")
+        .args(["rev-list", "--count", &format!("{base_branch}..{branch}")])
+        .output();
+    match result {
+        Ok(out) if out.status.success() => {
+            let count: u64 = String::from_utf8_lossy(&out.stdout)
+                .trim()
+                .parse()
+                .unwrap_or(1);
+            count > 0
+        }
+        _ => true, // assume unmerged on error — fail safe
+    }
+}
+
+// ── BranchManager ─────────────────────────────────────────────────────────────
+
+/// Manages the lifecycle of a single feature branch tied to one issue.
+pub struct BranchManager {
+    config: PrManagementConfig,
+    /// Maximum character length for the title slug portion of the branch name.
+    max_slug_length: usize,
+    /// Push to origin even in `no-pr` mode (default: `true`).
+    pub no_pr_push: bool,
+    /// Delete the remote branch after a PR merge (default: `true`).
+    pub delete_remote_branch_on_merge: bool,
+}
+
+impl BranchManager {
+    /// Create a new manager from `PrManagementConfig` with sensible defaults.
+    pub fn new(config: PrManagementConfig) -> Self {
+        Self {
+            config,
+            max_slug_length: DEFAULT_MAX_SLUG_LEN,
+            no_pr_push: true,
+            delete_remote_branch_on_merge: true,
+        }
+    }
+
+    /// The base branch name (e.g. `"main"`).
+    fn base(&self) -> &str {
+        &self.config.base_branch
+    }
+
+    /// Derive the feature branch name for this issue.
+    pub fn branch_name(&self, issue_number: u64, title: &str) -> String {
+        derive_branch_name(&self.config.branch_prefix, issue_number, title, self.max_slug_length)
+    }
+
+    /// Ensure a feature branch exists for `issue_number`/`title` and check it
+    /// out.  Idempotent: if the branch already exists locally or remotely,
+    /// reuses it without creating a duplicate.
+    ///
+    /// Returns the branch name.
+    pub fn ensure_branch(&self, issue_number: u64, title: &str) -> Result<String, BranchError> {
+        let branch = self.branch_name(issue_number, title);
+
+        // Guard: never operate on base_branch
+        if branch == self.base() {
+            return Err(BranchError::BaseBranchProtected(branch));
+        }
+
+        if local_branch_exists(&branch) {
+            // Already exists locally — just switch to it
+            tracing::debug!(branch, "feature branch already exists locally; checking out");
+            git(&["checkout", &branch])?;
+        } else if remote_branch_exists(&branch) {
+            // Exists on remote but not locally — create tracking branch
+            tracing::debug!(branch, "feature branch exists on remote; creating local tracking branch");
+            git(&["checkout", "-b", &branch, &format!("origin/{branch}")])?;
+        } else {
+            // New branch — create from latest base_branch
+            tracing::debug!(branch, base = self.base(), "creating new feature branch");
+            // Fetch latest base branch state first (best-effort)
+            let _ = Command::new("git")
+                .args(["fetch", "origin", self.base()])
+                .status();
+            git(&["checkout", "-b", &branch, &format!("origin/{}", self.base())])?;
+        }
+
+        Ok(branch)
+    }
+
+    /// Push the active feature branch to `origin`.
+    ///
+    /// In `no-pr` mode, the push happens only when `no_pr_push` is `true`
+    /// (the default), so work is not lost.  Force-push is only allowed when
+    /// `allow_force_push` is `true` in `config`.
+    pub fn push_branch(&self, branch: &str) -> Result<(), BranchError> {
+        // Guard: never push base_branch via this path
+        if branch == self.base() {
+            return Err(BranchError::BaseBranchProtected(branch.to_string()));
+        }
+
+        use crate::config::PrMode;
+        if self.config.mode == PrMode::NoPr && !self.no_pr_push {
+            tracing::debug!(branch, "no-pr mode with no_pr_push=false; skipping push");
+            return Ok(());
+        }
+
+        let mut args = vec!["push", "-u", "origin", branch];
+        if self.config.allow_force_push {
+            args.push("--force-with-lease");
+        } else {
+            // Non-force push — if the remote branch already has commits not
+            // in our local branch we let git reject it (correct behaviour).
+        }
+
+        tracing::info!(branch, force = self.config.allow_force_push, "pushing feature branch");
+        git(&args).map(|_| ())
+    }
+
+    /// Delete a feature branch after its PR has been merged.
+    ///
+    /// Safety checks:
+    /// * Refuses to delete `base_branch`.
+    /// * Refuses to delete a branch with uncommitted changes (when it is
+    ///   currently checked out) or with commits not yet in `base_branch`.
+    ///
+    /// After deleting the local branch, deletes the remote branch when
+    /// `delete_remote_branch_on_merge` is `true`.
+    pub fn cleanup_branch(&self, branch: &str) -> Result<(), BranchError> {
+        // Guard: never delete base_branch
+        if branch == self.base() {
+            return Err(BranchError::BaseBranchProtected(branch.to_string()));
+        }
+
+        // If this is the currently checked-out branch, refuse when there are
+        // uncommitted changes.
+        let on_branch = current_branch().ok().as_deref() == Some(branch);
+        if on_branch && has_uncommitted_changes() {
+            return Err(BranchError::UnsafeDelete(branch.to_string()));
+        }
+
+        // Refuse to delete if there are commits not in base_branch
+        if has_unmerged_commits(branch, self.base()) {
+            return Err(BranchError::UnsafeDelete(branch.to_string()));
+        }
+
+        // Switch away from the branch before deleting it (if currently on it)
+        if current_branch().ok().as_deref() == Some(branch) {
+            git(&["checkout", self.base()])?;
+        }
+
+        tracing::info!(branch, "deleting local feature branch after merge");
+        git(&["branch", "-d", branch])?;
+
+        if self.delete_remote_branch_on_merge && remote_branch_exists(branch) {
+            tracing::info!(branch, "deleting remote feature branch after merge");
+            git(&["push", "origin", "--delete", branch]).map(|_| ())?;
+        }
+
+        Ok(())
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{PrManagementConfig, PrMode};
+
+    fn config() -> PrManagementConfig {
+        PrManagementConfig::default()
+    }
+
+    fn config_with_prefix(prefix: &str) -> PrManagementConfig {
+        PrManagementConfig { branch_prefix: prefix.to_string(), ..config() }
+    }
+
+    // ── derive_branch_name ────────────────────────────────────────────────────
+
+    #[test]
+    fn basic_name_derivation() {
+        assert_eq!(derive_branch_name("loop/", 42, "Fix auth bug", 40), "loop/42-fix-auth-bug");
+    }
+
+    #[test]
+    fn special_characters_replaced() {
+        assert_eq!(
+            derive_branch_name("loop/", 1, "Add feature: fast-path (v2)!", 40),
+            "loop/1-add-feature-fast-path-v2"
+        );
+    }
+
+    #[test]
+    fn consecutive_dashes_collapsed() {
+        // Multiple punctuation in a row should produce a single dash
+        assert_eq!(
+            derive_branch_name("loop/", 7, "Fix   multiple   spaces", 40),
+            "loop/7-fix-multiple-spaces"
+        );
+    }
+
+    #[test]
+    fn leading_trailing_dashes_stripped() {
+        assert_eq!(
+            derive_branch_name("loop/", 3, "!!! urgent fix !!!", 40),
+            "loop/3-urgent-fix"
+        );
+    }
+
+    #[test]
+    fn title_truncated_to_max_slug_length() {
+        let long_title = "A".repeat(60);
+        let name = derive_branch_name("loop/", 10, &long_title, 20);
+        // "10-" is 3 chars, slug portion is 20 chars
+        let prefix_and_num = "loop/10-";
+        assert!(name.starts_with(prefix_and_num));
+        let slug = &name[prefix_and_num.len()..];
+        assert!(slug.len() <= 20, "slug too long: {slug}");
+    }
+
+    #[test]
+    fn truncation_strips_trailing_dash() {
+        // Title that produces a slug ending with dash at truncation boundary
+        // "aaa-bbb-ccc..." — truncation at 7 → "aaa-bbb" is fine, but "aaa-bbb-" → "aaa-bbb"
+        let title = "aaa bbb ccc ddd"; // slug: "aaa-bbb-ccc-ddd", truncate at 8 → "aaa-bbb-" → "aaa-bbb"
+        let name = derive_branch_name("loop/", 1, title, 8);
+        assert!(!name.ends_with('-'), "branch name must not end with dash: {name}");
+    }
+
+    #[test]
+    fn empty_title_produces_valid_name() {
+        let name = derive_branch_name("loop/", 5, "", 40);
+        // Should be "loop/5-" — not pretty but not a crash
+        assert!(name.starts_with("loop/5"));
+    }
+
+    #[test]
+    fn unicode_title_handled() {
+        let name = derive_branch_name("loop/", 99, "Add émoji 🚀 support", 40);
+        // Non-ASCII replaced with '-'
+        assert!(!name.contains(' '));
+        assert!(name.starts_with("loop/99-"));
+    }
+
+    #[test]
+    fn custom_prefix_propagated() {
+        assert_eq!(derive_branch_name("feat/", 1, "hello world", 40), "feat/1-hello-world");
+    }
+
+    #[test]
+    fn zero_max_slug_uses_default() {
+        // max_slug=0 uses DEFAULT_MAX_SLUG_LEN internally; just verify no panic
+        let name = derive_branch_name("loop/", 1, "a title", 0);
+        assert!(name.starts_with("loop/1-"));
+    }
+
+    // ── BranchManager ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn branch_name_uses_config_prefix() {
+        let manager = BranchManager::new(config_with_prefix("feat/"));
+        assert_eq!(manager.branch_name(1, "do something"), "feat/1-do-something");
+    }
+
+    #[test]
+    fn ensure_branch_rejects_base_branch_name() {
+        // Construct a pathological config where derived name equals base_branch
+        let cfg = PrManagementConfig {
+            base_branch: "loop/1-main".to_string(),
+            branch_prefix: "loop/".to_string(),
+            ..config()
+        };
+        let mgr = BranchManager::new(cfg);
+        let result = mgr.ensure_branch(1, "main");
+        assert!(matches!(result, Err(BranchError::BaseBranchProtected(_))));
+    }
+
+    #[test]
+    fn cleanup_rejects_base_branch() {
+        let mgr = BranchManager::new(config());
+        let result = mgr.cleanup_branch("main");
+        assert!(matches!(result, Err(BranchError::BaseBranchProtected(_))));
+    }
+
+    #[test]
+    fn push_rejects_base_branch() {
+        let mgr = BranchManager::new(config());
+        let result = mgr.push_branch("main");
+        assert!(matches!(result, Err(BranchError::BaseBranchProtected(_))));
+    }
+
+    #[test]
+    fn no_pr_push_false_skips_push() {
+        let cfg = PrManagementConfig { mode: PrMode::NoPr, ..config() };
+        let mut mgr = BranchManager::new(cfg);
+        mgr.no_pr_push = false;
+        // Should return Ok without calling git (since no_pr_push=false in no-pr mode)
+        assert!(mgr.push_branch("loop/1-some-branch").is_ok());
+    }
+}

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -500,8 +500,22 @@ mod tests {
 
     #[test]
     fn current_branch_returns_ok_in_git_repo() {
-        // We are always running inside the workspace git repo, so this must
-        // succeed and return a non-empty branch name.
+        // Skip when the test process is not running inside a git checkout
+        // (e.g., source-archive packaging contexts without VCS metadata).
+        // We deliberately don't `git init` a temp dir and `set_current_dir`
+        // into it: cargo runs unit tests in parallel by default, and
+        // `set_current_dir` is process-global, so doing so would race with
+        // any other test that observes CWD.
+        let in_git_repo = Command::new("git")
+            .args(["rev-parse", "--show-toplevel"])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !in_git_repo {
+            eprintln!("skipping current_branch_returns_ok_in_git_repo: not inside a git repo");
+            return;
+        }
+
         let branch = current_branch();
         assert!(branch.is_ok(), "current_branch() failed: {branch:?}");
         let name = branch.unwrap();

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -6,7 +6,11 @@
 //!
 //! # Safety invariants
 //! * Never operates on `base_branch` — any attempt returns an error.
-//! * Never force-pushes unless `allow_force_push` is explicitly `true`.
+//! * Never passes `--force-with-lease` to `git push` unless `allow_force_push`
+//!   is explicitly `true`.  The manager relies on git's default
+//!   non-fast-forward rejection to prevent accidental overwrites — there is
+//!   no separate "refuse the force push" error path (the aspirational
+//!   `BranchError::ForcePushDisabled` variant was removed in #79).
 //! * Never deletes a branch that has unmerged commits or uncommitted changes.
 use std::process::Command;
 
@@ -88,13 +92,15 @@ pub enum BranchError {
     #[error("git command failed: {0}")]
     GitCommand(String),
 
-    #[allow(dead_code)]
+    /// Returned by [`BranchManager::cleanup_branch`] when it would have to
+    /// delete a branch that has uncommitted changes (current worktree) or
+    /// commits not yet in `base_branch`.
+    ///
+    /// Only the single-PR cleanup path reaches this; multi-PR mode uses
+    /// [`BranchManager::cleanup_merged_remote_branch`] and never touches
+    /// the local branch.
     #[error("branch has uncommitted changes or unmerged commits — refusing to delete '{0}'")]
     UnsafeDelete(String),
-
-    #[allow(dead_code)]
-    #[error("force-push is disabled; enable allow_force_push in config to proceed")]
-    ForcePushDisabled,
 }
 
 /// Run a git command and return trimmed stdout on success, or a `BranchError`
@@ -181,14 +187,19 @@ fn has_unmerged_commits(branch: &str, base_branch: &str) -> bool {
 // ── BranchManager ─────────────────────────────────────────────────────────────
 
 /// Manages the lifecycle of a single feature branch tied to one issue.
+///
+/// Safety-affecting knobs (`no_pr_push`, `delete_remote_branch_on_merge`) are
+/// private and can only be changed at construction time via the `with_*`
+/// builder methods — the aim is that no consumer can flip a destructive flag
+/// *after* handing the manager to some inner component (see #73).
 pub struct BranchManager {
     config: PrManagementConfig,
     /// Maximum character length for the title slug portion of the branch name.
     max_slug_length: usize,
     /// Push to origin even in `no-pr` mode (default: `true`).
-    pub no_pr_push: bool,
+    no_pr_push: bool,
     /// Delete the remote branch after a PR merge (default: `true`).
-    pub delete_remote_branch_on_merge: bool,
+    delete_remote_branch_on_merge: bool,
 }
 
 impl BranchManager {
@@ -200,6 +211,30 @@ impl BranchManager {
             no_pr_push: true,
             delete_remote_branch_on_merge: true,
         }
+    }
+
+    /// Override the `no_pr_push` flag at construction time.
+    ///
+    /// When `false`, `push_branch` is a no-op in `no-pr` mode.  Meant for
+    /// tests and for rare configurations that explicitly want the loop to
+    /// keep work local.
+    #[allow(dead_code)]
+    pub fn with_no_pr_push(mut self, no_pr_push: bool) -> Self {
+        self.no_pr_push = no_pr_push;
+        self
+    }
+
+    /// Override the `delete_remote_branch_on_merge` flag at construction
+    /// time.
+    ///
+    /// When `false`, [`Self::cleanup_merged_remote_branch`] short-circuits
+    /// without touching the remote.  This field is destructive and must not
+    /// be mutable on a live `BranchManager` — use this builder on a fresh
+    /// instance instead.
+    #[allow(dead_code)]
+    pub fn with_delete_remote_branch_on_merge(mut self, enabled: bool) -> Self {
+        self.delete_remote_branch_on_merge = enabled;
+        self
     }
 
     /// The base branch name (e.g. `"main"`).
@@ -245,12 +280,39 @@ impl BranchManager {
             );
             git(&["checkout", "-b", &branch, &format!("origin/{branch}")])?;
         } else {
-            // New branch — create from latest base_branch
+            // New branch — create from latest base_branch.
+            //
+            // The fetch is still best-effort (we don't fail the iteration
+            // when `origin` is unreachable, since the user may be working
+            // offline), but we now *log loudly* when it fails or is skipped
+            // — a silent fetch failure followed by a checkout from a stale
+            // `origin/{base}` is the classic source of "why are my PRs full
+            // of conflicts" debugging sessions (see #68).
             tracing::debug!(branch, base = self.base(), "creating new feature branch");
-            // Fetch latest base branch state first (best-effort)
-            let _ = Command::new("git")
+            let fetch_status = Command::new("git")
                 .args(["fetch", "origin", self.base()])
                 .status();
+            match fetch_status {
+                Ok(status) if status.success() => {}
+                Ok(status) => {
+                    tracing::warn!(
+                        base = self.base(),
+                        exit_code = status.code(),
+                        "git fetch origin {base} failed; new branch will be created from \
+                         possibly-stale origin/{base} (expect merge conflicts)",
+                        base = self.base()
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        base = self.base(),
+                        error = %e,
+                        "could not spawn `git fetch`; new branch will be created from \
+                         possibly-stale origin/{base} (expect merge conflicts)",
+                        base = self.base()
+                    );
+                }
+            }
             git(&[
                 "checkout",
                 "-b",
@@ -295,7 +357,9 @@ impl BranchManager {
         git(&args).map(|_| ())
     }
 
-    /// Delete a feature branch after its PR has been merged.
+    /// Delete a feature branch that the engine itself checked out locally
+    /// (used by the `single-pr` flow when a PR is merged from the loop's
+    /// own worktree).
     ///
     /// Safety checks:
     /// * Refuses to delete `base_branch`.
@@ -304,6 +368,11 @@ impl BranchManager {
     ///
     /// After deleting the local branch, deletes the remote branch when
     /// `delete_remote_branch_on_merge` is `true`.
+    ///
+    /// **Do not call this from multi-PR mode** — the engine never checks
+    /// out the PR's local branch there, so this method would operate on
+    /// whatever branch the engine's CWD happens to be on (see #65).  Use
+    /// [`Self::cleanup_merged_remote_branch`] instead for multi-PR merges.
     #[allow(dead_code)]
     pub fn cleanup_branch(&self, branch: &str) -> Result<(), BranchError> {
         // Guard: never delete base_branch
@@ -337,6 +406,46 @@ impl BranchManager {
         }
 
         Ok(())
+    }
+
+    /// Delete the *remote* feature branch for a PR the engine did not check
+    /// out locally.
+    ///
+    /// Used by the multi-PR triage flow after `gh pr merge` succeeds.  In
+    /// that flow the engine never created or checked out the local branch,
+    /// so the original [`Self::cleanup_branch`] (which runs `git branch -d`
+    /// against whatever the engine's CWD happens to be on) is actively
+    /// wrong — see #65.  This method is the remote-only alternative:
+    ///
+    /// * Refuses to delete `base_branch`.
+    /// * Skips silently when `delete_remote_branch_on_merge` is `false`.
+    /// * Skips silently when the remote branch no longer exists (another
+    ///   process may have deleted it already).
+    /// * Never touches the local worktree — no `git checkout`, no
+    ///   `git branch -d`.
+    pub fn cleanup_merged_remote_branch(&self, branch: &str) -> Result<(), BranchError> {
+        if branch == self.base() {
+            return Err(BranchError::BaseBranchProtected(branch.to_string()));
+        }
+        if !self.delete_remote_branch_on_merge {
+            tracing::debug!(
+                branch,
+                "delete_remote_branch_on_merge=false; skipping remote cleanup"
+            );
+            return Ok(());
+        }
+        if !remote_branch_exists(branch) {
+            tracing::debug!(
+                branch,
+                "remote branch no longer exists; skipping remote cleanup"
+            );
+            return Ok(());
+        }
+        tracing::info!(
+            branch,
+            "deleting remote feature branch after multi-PR merge"
+        );
+        git(&["push", "origin", "--delete", branch]).map(|_| ())
     }
 }
 
@@ -478,6 +587,28 @@ mod tests {
     }
 
     #[test]
+    fn cleanup_merged_remote_branch_rejects_base_branch() {
+        let mgr = BranchManager::new(config());
+        let result = mgr.cleanup_merged_remote_branch("main");
+        assert!(matches!(result, Err(BranchError::BaseBranchProtected(_))));
+    }
+
+    #[test]
+    fn cleanup_merged_remote_branch_is_noop_when_disabled() {
+        // When `delete_remote_branch_on_merge=false`, the method must return
+        // Ok without shelling out to git at all — even the base-branch guard
+        // is the only early-exit before the disabled check.  We can't cheaply
+        // mock git from here, but this at least verifies the disabled path
+        // short-circuits for a non-base branch.
+        let mgr = BranchManager::new(config()).with_delete_remote_branch_on_merge(false);
+        let result = mgr.cleanup_merged_remote_branch("loop/1-some-feature");
+        assert!(
+            result.is_ok(),
+            "disabled flag should short-circuit without attempting git: {result:?}"
+        );
+    }
+
+    #[test]
     fn push_rejects_base_branch() {
         let mgr = BranchManager::new(config());
         let result = mgr.push_branch("main");
@@ -490,8 +621,7 @@ mod tests {
             mode: PrMode::NoPr,
             ..config()
         };
-        let mut mgr = BranchManager::new(cfg);
-        mgr.no_pr_push = false;
+        let mgr = BranchManager::new(cfg).with_no_pr_push(false);
         // Should return Ok without calling git (since no_pr_push=false in no-pr mode)
         assert!(mgr.push_branch("loop/1-some-branch").is_ok());
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -76,7 +76,9 @@ pub struct Cli {
     #[arg(long, conflicts_with = "prompt_inline")]
     pub prompt_file: Option<PathBuf>,
 
-    /// Path to a TOML config file to load as a base configuration.
+    /// Path to a config file to load as a base configuration.
+    /// Supports TOML (`.toml`, default) and YAML (`.yaml` / `.yml`).
+    /// Format is detected automatically from the file extension.
     #[arg(long)]
     pub config: Option<PathBuf>,
 
@@ -219,7 +221,7 @@ impl Cli {
     /// Merge CLI overrides onto a base `LoopConfig`.
     ///
     /// The base is either `LoopConfig::default()` or values loaded from a
-    /// TOML config file; any CLI flag that is explicitly set takes precedence.
+    /// TOML / YAML config file; any CLI flag that is explicitly set takes precedence.
     pub fn apply_overrides(self, mut base: LoopConfig) -> LoopConfig {
         if let Some(p) = self.provider {
             base.provider = p;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use crate::config::{IssueTrackingMode, LoopConfig, Provider};
+use crate::config::{IssueTrackingMode, LoopConfig, PrMode, Provider};
 use clap::Parser;
 use std::path::PathBuf;
 
@@ -113,6 +113,23 @@ pub struct Cli {
     /// at the end of each run.  Useful for scripted / CI use.
     #[arg(long)]
     pub no_summary: bool,
+
+    /// PR iteration mode: `no-pr` (default), `single-pr`, or `multi-pr`.
+    #[arg(long)]
+    pub pr_mode: Option<PrMode>,
+
+    /// Branch to open PRs into (default: `main`).
+    #[arg(long)]
+    pub base_branch: Option<String>,
+
+    /// Prefix for feature branches created by the loop (default: `loop/`).
+    #[arg(long)]
+    pub branch_prefix: Option<String>,
+
+    /// Require human review before the loop merges a PR (default: on).
+    /// Pass `--no-require-human-review` to allow automated merges.
+    #[arg(long, default_missing_value = "true", num_args = 0..=1)]
+    pub require_human_review: Option<bool>,
 }
 
 impl Cli {
@@ -192,6 +209,18 @@ impl Cli {
         if self.no_summary {
             base.telemetry.no_summary = true;
         }
+        if let Some(mode) = self.pr_mode {
+            base.pr_management.mode = mode;
+        }
+        if let Some(branch) = self.base_branch {
+            base.pr_management.base_branch = branch;
+        }
+        if let Some(prefix) = self.branch_prefix {
+            base.pr_management.branch_prefix = prefix;
+        }
+        if let Some(review) = self.require_human_review {
+            base.pr_management.require_human_review = review;
+        }
         base
     }
 }
@@ -231,6 +260,10 @@ mod tests {
             artifacts_dir: None,
             keep_runs: None,
             no_summary: false,
+            pr_mode: None,
+            base_branch: None,
+            branch_prefix: None,
+            require_human_review: None,
         }
     }
 
@@ -428,5 +461,44 @@ mod tests {
         assert!(config.telemetry.stream_output);
         assert_eq!(config.telemetry.keep_runs, 10);
         assert!(!config.telemetry.no_summary);
+    }
+
+    #[test]
+    fn cli_pr_mode_propagates() {
+        use crate::config::PrMode;
+        let cli = Cli { pr_mode: Some(PrMode::SinglePr), ..blank_cli() };
+        let config = cli.apply_overrides(default_config());
+        assert_eq!(config.pr_management.mode, PrMode::SinglePr);
+    }
+
+    #[test]
+    fn cli_base_branch_propagates() {
+        let cli = Cli { base_branch: Some("develop".to_string()), ..blank_cli() };
+        let config = cli.apply_overrides(default_config());
+        assert_eq!(config.pr_management.base_branch, "develop");
+    }
+
+    #[test]
+    fn cli_branch_prefix_propagates() {
+        let cli = Cli { branch_prefix: Some("feat/".to_string()), ..blank_cli() };
+        let config = cli.apply_overrides(default_config());
+        assert_eq!(config.pr_management.branch_prefix, "feat/");
+    }
+
+    #[test]
+    fn cli_require_human_review_false_propagates() {
+        let cli = Cli { require_human_review: Some(false), ..blank_cli() };
+        let config = cli.apply_overrides(default_config());
+        assert!(!config.pr_management.require_human_review);
+    }
+
+    #[test]
+    fn cli_pr_management_defaults() {
+        use crate::config::PrMode;
+        let config = blank_cli().apply_overrides(default_config());
+        assert_eq!(config.pr_management.mode, PrMode::NoPr);
+        assert_eq!(config.pr_management.base_branch, "main");
+        assert_eq!(config.pr_management.branch_prefix, "loop/");
+        assert!(config.pr_management.require_human_review);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,7 +61,7 @@ pub struct Cli {
     pub command: Option<Commands>,
 
     /// Provider to use for loop execution.
-    #[arg(long)]
+    #[arg(long, global = true)]
     pub provider: Option<Provider>,
 
     /// Number of iterations (-1 for infinite looping).
@@ -79,11 +79,14 @@ pub struct Cli {
     /// Path to a config file to load as a base configuration.
     /// Supports TOML (`.toml`, default) and YAML (`.yaml` / `.yml`).
     /// Format is detected automatically from the file extension.
-    #[arg(long)]
+    /// Marked `global` so it can appear before *or* after a subcommand:
+    /// `code-looper --config foo.toml serve` and `code-looper serve --config foo.toml`
+    /// are equivalent.
+    #[arg(long, global = true)]
     pub config: Option<PathBuf>,
 
     /// Log level: trace, debug, info, warn, or error.
-    #[arg(long)]
+    #[arg(long, global = true)]
     pub log_level: Option<String>,
 
     /// Enable orchestration policy engine (auto-selects workflow branch from repo context).
@@ -433,6 +436,45 @@ mod tests {
         let config = cli.apply_overrides(base);
         assert_eq!(config.prompt_inline.as_deref(), Some("new prompt"));
         assert!(config.prompt_file.is_none());
+    }
+
+    /// `--config`, `--provider`, and `--log-level` are marked `global = true`
+    /// so they may appear *before* or *after* a subcommand.  Lock both
+    /// orderings in so a future regression in clap-attribute placement is
+    /// caught immediately.
+    #[test]
+    fn config_flag_works_before_subcommand() {
+        let cli = Cli::try_parse_from(["code-looper", "--config", "looper.toml", "serve"]).unwrap();
+        assert_eq!(
+            cli.config.as_deref().and_then(|p| p.to_str()),
+            Some("looper.toml")
+        );
+        assert!(matches!(cli.command, Some(Commands::Serve { .. })));
+    }
+
+    #[test]
+    fn config_flag_works_after_subcommand() {
+        let cli = Cli::try_parse_from(["code-looper", "serve", "--config", "looper.toml"]).unwrap();
+        assert_eq!(
+            cli.config.as_deref().and_then(|p| p.to_str()),
+            Some("looper.toml")
+        );
+        assert!(matches!(cli.command, Some(Commands::Serve { .. })));
+    }
+
+    #[test]
+    fn provider_and_log_level_flags_work_after_subcommand() {
+        let cli = Cli::try_parse_from([
+            "code-looper",
+            "serve",
+            "--provider",
+            "codex",
+            "--log-level",
+            "debug",
+        ])
+        .unwrap();
+        assert_eq!(cli.provider, Some(Provider::Codex));
+        assert_eq!(cli.log_level.as_deref(), Some("debug"));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,6 +25,31 @@ pub enum Commands {
         #[arg(long)]
         dry_run: bool,
     },
+
+    /// Start Code Looper in service mode, listening for JSON-lines requests
+    /// over a local TCP socket.
+    ///
+    /// Clients connect and send one request per line (newline-delimited JSON).
+    /// The server responds with one JSON object per line.
+    ///
+    /// Supported commands:
+    ///
+    ///   {"cmd":"run","prompt":"<text>"}           — execute one provider iteration
+    ///   {"cmd":"run","prompt":"<text>","provider":"codex"} — override provider
+    ///   {"cmd":"status"}                          — service uptime and run counts
+    ///   {"cmd":"shutdown"}                        — stop the service
+    ///
+    /// Example (using netcat):
+    ///   echo '{"cmd":"status"}' | nc 127.0.0.1 7979
+    Serve {
+        /// TCP port to listen on.  Defaults to 7979.
+        #[arg(long, default_value_t = 7979)]
+        port: u16,
+
+        /// Address to bind to.  Defaults to 127.0.0.1 (loopback only).
+        #[arg(long, default_value = "127.0.0.1")]
+        bind_addr: String,
+    },
 }
 
 /// Pluggable loop engine for coding-agent CLIs.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -93,6 +93,26 @@ pub struct Cli {
     /// Path to the local promise markdown file (when --issue-tracking-mode=local).
     #[arg(long)]
     pub local_promise_path: Option<PathBuf>,
+
+    /// Stream provider stdout/stderr to the terminal in real time (default: on).
+    /// Use --no-stream-output to disable.
+    #[arg(long, default_missing_value = "true", num_args = 0..=1)]
+    pub stream_output: Option<bool>,
+
+    /// Root directory for per-run artifact directories (transcripts, manifest,
+    /// summary).  Defaults to `.code-looper/runs`.
+    #[arg(long)]
+    pub artifacts_dir: Option<PathBuf>,
+
+    /// Number of most-recent run directories to retain.  Older runs are pruned
+    /// after each new run.  Default: 10.
+    #[arg(long)]
+    pub keep_runs: Option<usize>,
+
+    /// Suppress writing the markdown summary and the condensed terminal summary
+    /// at the end of each run.  Useful for scripted / CI use.
+    #[arg(long)]
+    pub no_summary: bool,
 }
 
 impl Cli {
@@ -160,6 +180,18 @@ impl Cli {
         if let Some(path) = self.local_promise_path {
             base.issue_tracking.local_promise_path = Some(path);
         }
+        if let Some(s) = self.stream_output {
+            base.telemetry.stream_output = s;
+        }
+        if let Some(dir) = self.artifacts_dir {
+            base.telemetry.artifacts_dir = dir;
+        }
+        if let Some(n) = self.keep_runs {
+            base.telemetry.keep_runs = n;
+        }
+        if self.no_summary {
+            base.telemetry.no_summary = true;
+        }
         base
     }
 }
@@ -195,6 +227,10 @@ mod tests {
             issue_tracking_owner: None,
             issue_tracking_repo: None,
             local_promise_path: None,
+            stream_output: None,
+            artifacts_dir: None,
+            keep_runs: None,
+            no_summary: false,
         }
     }
 
@@ -356,5 +392,41 @@ mod tests {
         assert_eq!(config.issue_tracking.mode, IssueTrackingMode::Local);
         assert!(config.issue_tracking.repo_owner.is_none());
         assert!(config.issue_tracking.repo_name.is_none());
+    }
+
+    #[test]
+    fn cli_stream_output_false_propagates() {
+        let cli = Cli { stream_output: Some(false), ..blank_cli() };
+        let config = cli.apply_overrides(default_config());
+        assert!(!config.telemetry.stream_output);
+    }
+
+    #[test]
+    fn cli_artifacts_dir_propagates() {
+        let cli = Cli { artifacts_dir: Some("/tmp/runs".into()), ..blank_cli() };
+        let config = cli.apply_overrides(default_config());
+        assert_eq!(config.telemetry.artifacts_dir, std::path::PathBuf::from("/tmp/runs"));
+    }
+
+    #[test]
+    fn cli_keep_runs_propagates() {
+        let cli = Cli { keep_runs: Some(5), ..blank_cli() };
+        let config = cli.apply_overrides(default_config());
+        assert_eq!(config.telemetry.keep_runs, 5);
+    }
+
+    #[test]
+    fn cli_no_summary_propagates() {
+        let cli = Cli { no_summary: true, ..blank_cli() };
+        let config = cli.apply_overrides(default_config());
+        assert!(config.telemetry.no_summary);
+    }
+
+    #[test]
+    fn cli_telemetry_defaults() {
+        let config = blank_cli().apply_overrides(default_config());
+        assert!(config.telemetry.stream_output);
+        assert_eq!(config.telemetry.keep_runs, 10);
+        assert!(!config.telemetry.no_summary);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use crate::config::{LoopConfig, Provider};
+use crate::config::{IssueTrackingMode, LoopConfig, Provider};
 use clap::Parser;
 use std::path::PathBuf;
 
@@ -75,6 +75,24 @@ pub struct Cli {
     /// Shell command to run once after the loop finishes (run via `sh -c`).
     #[arg(long)]
     pub on_complete: Option<String>,
+
+    /// Issue tracking mode: `github` (production) or `local` (dev/debug).
+    #[arg(long)]
+    pub issue_tracking_mode: Option<IssueTrackingMode>,
+
+    /// GitHub repository owner for issue tracking (when --issue-tracking-mode=github).
+    /// Falls back to --repo-owner if not set.
+    #[arg(long)]
+    pub issue_tracking_owner: Option<String>,
+
+    /// GitHub repository name for issue tracking (when --issue-tracking-mode=github).
+    /// Falls back to --repo-name if not set.
+    #[arg(long)]
+    pub issue_tracking_repo: Option<String>,
+
+    /// Path to the local promise markdown file (when --issue-tracking-mode=local).
+    #[arg(long)]
+    pub local_promise_path: Option<PathBuf>,
 }
 
 impl Cli {
@@ -130,6 +148,18 @@ impl Cli {
         if let Some(cmd) = self.on_complete {
             base.on_complete = Some(cmd);
         }
+        if let Some(mode) = self.issue_tracking_mode {
+            base.issue_tracking.mode = mode;
+        }
+        if let Some(owner) = self.issue_tracking_owner {
+            base.issue_tracking.repo_owner = Some(owner);
+        }
+        if let Some(repo) = self.issue_tracking_repo {
+            base.issue_tracking.repo_name = Some(repo);
+        }
+        if let Some(path) = self.local_promise_path {
+            base.issue_tracking.local_promise_path = Some(path);
+        }
         base
     }
 }
@@ -161,6 +191,10 @@ mod tests {
             max_retries: None,
             retry_backoff_ms: None,
             on_complete: None,
+            issue_tracking_mode: None,
+            issue_tracking_owner: None,
+            issue_tracking_repo: None,
+            local_promise_path: None,
         }
     }
 
@@ -287,5 +321,40 @@ mod tests {
         assert_eq!(config.max_retries, 0);
         assert_eq!(config.retry_backoff_ms, 500);
         assert!(config.on_complete.is_none());
+    }
+
+    #[test]
+    fn cli_issue_tracking_mode_propagates() {
+        let cli = Cli {
+            issue_tracking_mode: Some(IssueTrackingMode::Github),
+            issue_tracking_owner: Some("acme".to_string()),
+            issue_tracking_repo: Some("proj".to_string()),
+            ..blank_cli()
+        };
+        let config = cli.apply_overrides(default_config());
+        assert_eq!(config.issue_tracking.mode, IssueTrackingMode::Github);
+        assert_eq!(config.issue_tracking.repo_owner.as_deref(), Some("acme"));
+        assert_eq!(config.issue_tracking.repo_name.as_deref(), Some("proj"));
+    }
+
+    #[test]
+    fn cli_local_promise_path_propagates() {
+        let cli = Cli {
+            local_promise_path: Some("/tmp/promise.md".into()),
+            ..blank_cli()
+        };
+        let config = cli.apply_overrides(default_config());
+        assert_eq!(
+            config.issue_tracking.local_promise_path,
+            Some(std::path::PathBuf::from("/tmp/promise.md"))
+        );
+    }
+
+    #[test]
+    fn cli_defaults_leave_issue_tracking_at_local() {
+        let config = blank_cli().apply_overrides(default_config());
+        assert_eq!(config.issue_tracking.mode, IssueTrackingMode::Local);
+        assert!(config.issue_tracking.repo_owner.is_none());
+        assert!(config.issue_tracking.repo_name.is_none());
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,11 +1,40 @@
 use crate::config::{CommentCadence, IssueTrackingMode, LoopConfig, PrMode, Provider};
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use std::path::PathBuf;
+
+/// Subcommands available in addition to the default loop run.
+#[derive(Debug, Subcommand)]
+pub enum Commands {
+    /// Initialise or patch workspace prerequisites so a repository is ready
+    /// to run code-looper.
+    ///
+    /// Checks the same prerequisites as the startup validator and, for each
+    /// gap, produces a minimal, idempotent fix:
+    ///
+    /// - No instruction file → creates `CLAUDE.md` with a Code Looper section.
+    /// - Instruction file lacks a Code Looper section → appends a delimited block.
+    /// - `.mcp.json` missing → creates a minimal stub with the GitHub server entry.
+    /// - `.mcp.json` lacks a `"github"` key → merges the entry in.
+    Bootstrap {
+        /// Directory to treat as the workspace root.  Defaults to the current
+        /// working directory.
+        #[arg(long)]
+        workspace_dir: Option<PathBuf>,
+
+        /// Print what would be created or modified without writing anything.
+        #[arg(long)]
+        dry_run: bool,
+    },
+}
 
 /// Pluggable loop engine for coding-agent CLIs.
 #[derive(Debug, Parser)]
 #[command(name = "code-looper", version, about)]
 pub struct Cli {
+    /// Subcommand (optional; omit to run the default loop).
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+
     /// Provider to use for loop execution.
     #[arg(long)]
     pub provider: Option<Provider>,
@@ -252,6 +281,7 @@ mod tests {
 
     fn blank_cli() -> Cli {
         Cli {
+            command: None,
             provider: None,
             iterations: None,
             prompt_inline: None,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -130,6 +130,12 @@ pub struct Cli {
     #[arg(long)]
     pub on_complete: Option<String>,
 
+    /// Maximum seconds a single provider invocation may run before being killed.
+    /// When the timeout fires the iteration is recorded as `timeout` and may be
+    /// retried if `--max-retries` is set.  Omit or set to 0 to disable.
+    #[arg(long)]
+    pub iteration_timeout_secs: Option<u64>,
+
     /// Issue tracking mode: `github` (production) or `local` (dev/debug).
     #[arg(long)]
     pub issue_tracking_mode: Option<IssueTrackingMode>,
@@ -249,6 +255,11 @@ impl Cli {
         if let Some(cmd) = self.on_complete {
             base.on_complete = Some(cmd);
         }
+        if let Some(secs) = self.iteration_timeout_secs {
+            if secs > 0 {
+                base.iteration_timeout_secs = Some(secs);
+            }
+        }
         if let Some(mode) = self.issue_tracking_mode {
             base.issue_tracking.mode = mode;
         }
@@ -323,6 +334,7 @@ mod tests {
             max_retries: None,
             retry_backoff_ms: None,
             on_complete: None,
+            iteration_timeout_secs: None,
             issue_tracking_mode: None,
             issue_tracking_owner: None,
             issue_tracking_repo: None,
@@ -463,6 +475,22 @@ mod tests {
         assert_eq!(config.max_retries, 0);
         assert_eq!(config.retry_backoff_ms, 500);
         assert!(config.on_complete.is_none());
+        assert!(config.iteration_timeout_secs.is_none());
+    }
+
+    #[test]
+    fn cli_iteration_timeout_secs_propagates() {
+        let cli = Cli { iteration_timeout_secs: Some(30), ..blank_cli() };
+        let config = cli.apply_overrides(default_config());
+        assert_eq!(config.iteration_timeout_secs, Some(30));
+    }
+
+    #[test]
+    fn cli_iteration_timeout_secs_zero_is_ignored() {
+        // 0 means "no timeout" — treated the same as omitting the flag.
+        let cli = Cli { iteration_timeout_secs: Some(0), ..blank_cli() };
+        let config = cli.apply_overrides(default_config());
+        assert!(config.iteration_timeout_secs.is_none());
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use crate::config::{IssueTrackingMode, LoopConfig, PrMode, Provider};
+use crate::config::{CommentCadence, IssueTrackingMode, LoopConfig, PrMode, Provider};
 use clap::Parser;
 use std::path::PathBuf;
 
@@ -93,6 +93,16 @@ pub struct Cli {
     /// Path to the local promise markdown file (when --issue-tracking-mode=local).
     #[arg(long)]
     pub local_promise_path: Option<PathBuf>,
+
+    /// GitHub issue number the engine should post run-lifecycle comments on.
+    /// Requires --issue-tracking-mode=github.
+    #[arg(long)]
+    pub comment_issue: Option<u32>,
+
+    /// How often the engine posts comments to the linked issue.
+    /// One of: `milestones` (default), `every-iteration`, `off-engine`.
+    #[arg(long)]
+    pub comment_cadence: Option<CommentCadence>,
 
     /// Stream provider stdout/stderr to the terminal in real time (default: on).
     /// Use --no-stream-output to disable.
@@ -197,6 +207,12 @@ impl Cli {
         if let Some(path) = self.local_promise_path {
             base.issue_tracking.local_promise_path = Some(path);
         }
+        if let Some(n) = self.comment_issue {
+            base.issue_tracking.comment_issue_number = Some(n);
+        }
+        if let Some(cadence) = self.comment_cadence {
+            base.issue_tracking.comment_cadence = cadence;
+        }
         if let Some(s) = self.stream_output {
             base.telemetry.stream_output = s;
         }
@@ -256,6 +272,8 @@ mod tests {
             issue_tracking_owner: None,
             issue_tracking_repo: None,
             local_promise_path: None,
+            comment_issue: None,
+            comment_cadence: None,
             stream_output: None,
             artifacts_dir: None,
             keep_runs: None,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -354,14 +354,20 @@ mod tests {
 
     #[test]
     fn cli_overrides_provider() {
-        let cli = Cli { provider: Some(Provider::Copilot), ..blank_cli() };
+        let cli = Cli {
+            provider: Some(Provider::Copilot),
+            ..blank_cli()
+        };
         let config = cli.apply_overrides(default_config());
         assert_eq!(config.provider, Provider::Copilot);
     }
 
     #[test]
     fn cli_overrides_iterations() {
-        let cli = Cli { iterations: Some(10), ..blank_cli() };
+        let cli = Cli {
+            iterations: Some(10),
+            ..blank_cli()
+        };
         let config = cli.apply_overrides(default_config());
         assert_eq!(config.iterations, 10);
     }
@@ -371,7 +377,10 @@ mod tests {
         let mut base = default_config();
         base.prompt_file = Some("old.md".into());
 
-        let cli = Cli { prompt_inline: Some("new prompt".to_string()), ..blank_cli() };
+        let cli = Cli {
+            prompt_inline: Some("new prompt".to_string()),
+            ..blank_cli()
+        };
         let config = cli.apply_overrides(base);
         assert_eq!(config.prompt_inline.as_deref(), Some("new prompt"));
         assert!(config.prompt_file.is_none());
@@ -410,14 +419,20 @@ mod tests {
 
     #[test]
     fn cli_skip_prereq_check_sets_flag() {
-        let cli = Cli { skip_prereq_check: true, ..blank_cli() };
+        let cli = Cli {
+            skip_prereq_check: true,
+            ..blank_cli()
+        };
         let config = cli.apply_overrides(default_config());
         assert!(config.skip_prereq_check);
     }
 
     #[test]
     fn cli_allow_direct_github_sets_flag() {
-        let cli = Cli { allow_direct_github: true, ..blank_cli() };
+        let cli = Cli {
+            allow_direct_github: true,
+            ..blank_cli()
+        };
         let config = cli.apply_overrides(default_config());
         assert!(config.allow_direct_github);
     }
@@ -442,28 +457,40 @@ mod tests {
 
     #[test]
     fn cli_stop_on_failure_sets_flag() {
-        let cli = Cli { stop_on_failure: true, ..blank_cli() };
+        let cli = Cli {
+            stop_on_failure: true,
+            ..blank_cli()
+        };
         let config = cli.apply_overrides(default_config());
         assert!(config.stop_on_failure);
     }
 
     #[test]
     fn cli_max_retries_propagates() {
-        let cli = Cli { max_retries: Some(3), ..blank_cli() };
+        let cli = Cli {
+            max_retries: Some(3),
+            ..blank_cli()
+        };
         let config = cli.apply_overrides(default_config());
         assert_eq!(config.max_retries, 3);
     }
 
     #[test]
     fn cli_retry_backoff_ms_propagates() {
-        let cli = Cli { retry_backoff_ms: Some(1000), ..blank_cli() };
+        let cli = Cli {
+            retry_backoff_ms: Some(1000),
+            ..blank_cli()
+        };
         let config = cli.apply_overrides(default_config());
         assert_eq!(config.retry_backoff_ms, 1000);
     }
 
     #[test]
     fn cli_on_complete_propagates() {
-        let cli = Cli { on_complete: Some("echo done".to_string()), ..blank_cli() };
+        let cli = Cli {
+            on_complete: Some("echo done".to_string()),
+            ..blank_cli()
+        };
         let config = cli.apply_overrides(default_config());
         assert_eq!(config.on_complete.as_deref(), Some("echo done"));
     }
@@ -480,7 +507,10 @@ mod tests {
 
     #[test]
     fn cli_iteration_timeout_secs_propagates() {
-        let cli = Cli { iteration_timeout_secs: Some(30), ..blank_cli() };
+        let cli = Cli {
+            iteration_timeout_secs: Some(30),
+            ..blank_cli()
+        };
         let config = cli.apply_overrides(default_config());
         assert_eq!(config.iteration_timeout_secs, Some(30));
     }
@@ -488,7 +518,10 @@ mod tests {
     #[test]
     fn cli_iteration_timeout_secs_zero_is_ignored() {
         // 0 means "no timeout" — treated the same as omitting the flag.
-        let cli = Cli { iteration_timeout_secs: Some(0), ..blank_cli() };
+        let cli = Cli {
+            iteration_timeout_secs: Some(0),
+            ..blank_cli()
+        };
         let config = cli.apply_overrides(default_config());
         assert!(config.iteration_timeout_secs.is_none());
     }
@@ -530,28 +563,43 @@ mod tests {
 
     #[test]
     fn cli_stream_output_false_propagates() {
-        let cli = Cli { stream_output: Some(false), ..blank_cli() };
+        let cli = Cli {
+            stream_output: Some(false),
+            ..blank_cli()
+        };
         let config = cli.apply_overrides(default_config());
         assert!(!config.telemetry.stream_output);
     }
 
     #[test]
     fn cli_artifacts_dir_propagates() {
-        let cli = Cli { artifacts_dir: Some("/tmp/runs".into()), ..blank_cli() };
+        let cli = Cli {
+            artifacts_dir: Some("/tmp/runs".into()),
+            ..blank_cli()
+        };
         let config = cli.apply_overrides(default_config());
-        assert_eq!(config.telemetry.artifacts_dir, std::path::PathBuf::from("/tmp/runs"));
+        assert_eq!(
+            config.telemetry.artifacts_dir,
+            std::path::PathBuf::from("/tmp/runs")
+        );
     }
 
     #[test]
     fn cli_keep_runs_propagates() {
-        let cli = Cli { keep_runs: Some(5), ..blank_cli() };
+        let cli = Cli {
+            keep_runs: Some(5),
+            ..blank_cli()
+        };
         let config = cli.apply_overrides(default_config());
         assert_eq!(config.telemetry.keep_runs, 5);
     }
 
     #[test]
     fn cli_no_summary_propagates() {
-        let cli = Cli { no_summary: true, ..blank_cli() };
+        let cli = Cli {
+            no_summary: true,
+            ..blank_cli()
+        };
         let config = cli.apply_overrides(default_config());
         assert!(config.telemetry.no_summary);
     }
@@ -567,28 +615,40 @@ mod tests {
     #[test]
     fn cli_pr_mode_propagates() {
         use crate::config::PrMode;
-        let cli = Cli { pr_mode: Some(PrMode::SinglePr), ..blank_cli() };
+        let cli = Cli {
+            pr_mode: Some(PrMode::SinglePr),
+            ..blank_cli()
+        };
         let config = cli.apply_overrides(default_config());
         assert_eq!(config.pr_management.mode, PrMode::SinglePr);
     }
 
     #[test]
     fn cli_base_branch_propagates() {
-        let cli = Cli { base_branch: Some("develop".to_string()), ..blank_cli() };
+        let cli = Cli {
+            base_branch: Some("develop".to_string()),
+            ..blank_cli()
+        };
         let config = cli.apply_overrides(default_config());
         assert_eq!(config.pr_management.base_branch, "develop");
     }
 
     #[test]
     fn cli_branch_prefix_propagates() {
-        let cli = Cli { branch_prefix: Some("feat/".to_string()), ..blank_cli() };
+        let cli = Cli {
+            branch_prefix: Some("feat/".to_string()),
+            ..blank_cli()
+        };
         let config = cli.apply_overrides(default_config());
         assert_eq!(config.pr_management.branch_prefix, "feat/");
     }
 
     #[test]
     fn cli_require_human_review_false_propagates() {
-        let cli = Cli { require_human_review: Some(false), ..blank_cli() };
+        let cli = Cli {
+            require_human_review: Some(false),
+            ..blank_cli()
+        };
         let config = cli.apply_overrides(default_config());
         assert!(!config.pr_management.require_human_review);
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -126,6 +126,12 @@ pub struct Cli {
     #[arg(long)]
     pub retry_backoff_ms: Option<u64>,
 
+    /// Exponential backoff multiplier applied per retry attempt.
+    /// Delay for attempt N = retry_backoff_ms × multiplier^(N-1).
+    /// `1.0` (default) gives flat backoff; `2.0` doubles the delay each retry.
+    #[arg(long)]
+    pub retry_backoff_multiplier: Option<f64>,
+
     /// Shell command to run once after the loop finishes (run via `sh -c`).
     #[arg(long)]
     pub on_complete: Option<String>,
@@ -163,6 +169,13 @@ pub struct Cli {
     /// One of: `milestones` (default), `every-iteration`, `off-engine`.
     #[arg(long)]
     pub comment_cadence: Option<CommentCadence>,
+
+    /// Close the linked issue at end-of-run if the agent left it open after
+    /// completing all checklist items.  When not set (default), the engine
+    /// only logs a warning.  Requires --issue-tracking-mode=github and
+    /// --comment-issue.
+    #[arg(long)]
+    pub auto_close_owned_issues: bool,
 
     /// Stream provider stdout/stderr to the terminal in real time (default: on).
     /// Use --no-stream-output to disable.
@@ -252,6 +265,9 @@ impl Cli {
         if let Some(ms) = self.retry_backoff_ms {
             base.retry_backoff_ms = ms;
         }
+        if let Some(m) = self.retry_backoff_multiplier {
+            base.retry_backoff_multiplier = m;
+        }
         if let Some(cmd) = self.on_complete {
             base.on_complete = Some(cmd);
         }
@@ -277,6 +293,9 @@ impl Cli {
         }
         if let Some(cadence) = self.comment_cadence {
             base.issue_tracking.comment_cadence = cadence;
+        }
+        if self.auto_close_owned_issues {
+            base.issue_tracking.auto_close_owned_issues = true;
         }
         if let Some(s) = self.stream_output {
             base.telemetry.stream_output = s;
@@ -333,6 +352,7 @@ mod tests {
             stop_on_failure: false,
             max_retries: None,
             retry_backoff_ms: None,
+            retry_backoff_multiplier: None,
             on_complete: None,
             iteration_timeout_secs: None,
             issue_tracking_mode: None,
@@ -341,6 +361,7 @@ mod tests {
             local_promise_path: None,
             comment_issue: None,
             comment_cadence: None,
+            auto_close_owned_issues: false,
             stream_output: None,
             artifacts_dir: None,
             keep_runs: None,
@@ -661,5 +682,38 @@ mod tests {
         assert_eq!(config.pr_management.base_branch, "main");
         assert_eq!(config.pr_management.branch_prefix, "loop/");
         assert!(config.pr_management.require_human_review);
+    }
+
+    #[test]
+    fn cli_retry_backoff_multiplier_propagates() {
+        let cli = Cli {
+            retry_backoff_multiplier: Some(2.0),
+            ..blank_cli()
+        };
+        let config = cli.apply_overrides(default_config());
+        assert_eq!(config.retry_backoff_multiplier, 2.0);
+    }
+
+    #[test]
+    fn cli_retry_backoff_multiplier_default_is_flat() {
+        // When not set via CLI, the TOML/config default (1.0 = flat) is preserved.
+        let config = blank_cli().apply_overrides(default_config());
+        assert_eq!(config.retry_backoff_multiplier, 1.0);
+    }
+
+    #[test]
+    fn cli_auto_close_owned_issues_sets_flag() {
+        let cli = Cli {
+            auto_close_owned_issues: true,
+            ..blank_cli()
+        };
+        let config = cli.apply_overrides(default_config());
+        assert!(config.issue_tracking.auto_close_owned_issues);
+    }
+
+    #[test]
+    fn cli_auto_close_owned_issues_default_false() {
+        let config = blank_cli().apply_overrides(default_config());
+        assert!(!config.issue_tracking.auto_close_owned_issues);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,8 +47,26 @@ pub enum Commands {
         port: u16,
 
         /// Address to bind to.  Defaults to 127.0.0.1 (loopback only).
+        ///
+        /// By default, any bind address outside the loopback range
+        /// (`127.0.0.0/8` / `::1`) is refused — the service has no built-in
+        /// authentication and exposes a `run` command that executes arbitrary
+        /// prompts through the configured provider with
+        /// `--dangerously-skip-permissions`.  To deliberately expose the
+        /// service on a LAN or container-external interface, also pass
+        /// `--unsafe-bind` and put the deployment behind its own auth layer.
         #[arg(long, default_value = "127.0.0.1")]
         bind_addr: String,
+
+        /// [UNSAFE] Allow binding to a non-loopback address.
+        ///
+        /// Service mode has no auth, no TLS, and no peer check; anyone who can
+        /// reach the socket can trigger provider runs with
+        /// `--dangerously-skip-permissions`.  Only enable this when the
+        /// service is already behind an external auth/firewall boundary you
+        /// control.
+        #[arg(long)]
+        unsafe_bind: bool,
     },
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -224,6 +224,15 @@ pub struct Cli {
     /// Example: `--provider-extra-arg --model --provider-extra-arg claude-opus-4-5`
     #[arg(long, action = clap::ArgAction::Append)]
     pub provider_extra_arg: Vec<String>,
+
+    /// Exit code that should be treated as a permanent failure and never
+    /// retried, even when `--max-retries` is set.  Can be repeated.
+    ///
+    /// Use this to short-circuit retries for codes that indicate a
+    /// configuration or argument error rather than a transient fault.
+    /// Example: `--non-retryable-exit-code 2 --non-retryable-exit-code 127`
+    #[arg(long, action = clap::ArgAction::Append)]
+    pub non_retryable_exit_code: Vec<i32>,
 }
 
 impl Cli {
@@ -335,6 +344,9 @@ impl Cli {
         if !self.provider_extra_arg.is_empty() {
             base.provider_extra_args = self.provider_extra_arg;
         }
+        if !self.non_retryable_exit_code.is_empty() {
+            base.non_retryable_exit_codes = self.non_retryable_exit_code;
+        }
         base
     }
 }
@@ -385,6 +397,7 @@ mod tests {
             branch_prefix: None,
             require_human_review: None,
             provider_extra_arg: vec![],
+            non_retryable_exit_code: vec![],
         }
     }
 
@@ -757,5 +770,32 @@ mod tests {
     fn cli_provider_extra_arg_default_empty() {
         let config = blank_cli().apply_overrides(default_config());
         assert!(config.provider_extra_args.is_empty());
+    }
+
+    // ── non_retryable_exit_code ───────────────────────────────────────────────
+
+    #[test]
+    fn cli_non_retryable_exit_code_propagates() {
+        let cli = Cli {
+            non_retryable_exit_code: vec![2, 127],
+            ..blank_cli()
+        };
+        let config = cli.apply_overrides(default_config());
+        assert_eq!(config.non_retryable_exit_codes, [2, 127]);
+    }
+
+    #[test]
+    fn cli_non_retryable_exit_code_default_empty() {
+        let config = blank_cli().apply_overrides(default_config());
+        assert!(config.non_retryable_exit_codes.is_empty());
+    }
+
+    #[test]
+    fn cli_non_retryable_exit_code_empty_does_not_override_base() {
+        let mut base = default_config();
+        base.non_retryable_exit_codes = vec![2];
+        let config = blank_cli().apply_overrides(base);
+        // Empty CLI vec should NOT overwrite config-file-provided codes.
+        assert_eq!(config.non_retryable_exit_codes, [2]);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -215,6 +215,15 @@ pub struct Cli {
     /// Pass `--no-require-human-review` to allow automated merges.
     #[arg(long, default_missing_value = "true", num_args = 0..=1)]
     pub require_human_review: Option<bool>,
+
+    /// Extra argument to append to the provider CLI invocation.
+    /// Can be repeated to supply multiple arguments.
+    /// Arguments are inserted after the adapter's hardcoded flags but before
+    /// the prompt, so they are treated as option flags by the provider CLI.
+    ///
+    /// Example: `--provider-extra-arg --model --provider-extra-arg claude-opus-4-5`
+    #[arg(long, action = clap::ArgAction::Append)]
+    pub provider_extra_arg: Vec<String>,
 }
 
 impl Cli {
@@ -323,6 +332,9 @@ impl Cli {
         if let Some(review) = self.require_human_review {
             base.pr_management.require_human_review = review;
         }
+        if !self.provider_extra_arg.is_empty() {
+            base.provider_extra_args = self.provider_extra_arg;
+        }
         base
     }
 }
@@ -372,6 +384,7 @@ mod tests {
             base_branch: None,
             branch_prefix: None,
             require_human_review: None,
+            provider_extra_arg: vec![],
         }
     }
 
@@ -717,5 +730,32 @@ mod tests {
     fn cli_auto_close_owned_issues_default_false() {
         let config = blank_cli().apply_overrides(default_config());
         assert!(!config.issue_tracking.auto_close_owned_issues);
+    }
+
+    // ── provider_extra_arg ────────────────────────────────────────────────────
+
+    #[test]
+    fn cli_provider_extra_arg_propagates() {
+        let cli = Cli {
+            provider_extra_arg: vec!["--model".to_string(), "claude-opus-4-5".to_string()],
+            ..blank_cli()
+        };
+        let config = cli.apply_overrides(default_config());
+        assert_eq!(config.provider_extra_args, ["--model", "claude-opus-4-5"]);
+    }
+
+    #[test]
+    fn cli_provider_extra_arg_empty_does_not_override_base() {
+        let mut base = default_config();
+        base.provider_extra_args = vec!["--from-config".to_string()];
+        let config = blank_cli().apply_overrides(base);
+        // Empty CLI vec should NOT overwrite config-file-provided args.
+        assert_eq!(config.provider_extra_args, ["--from-config"]);
+    }
+
+    #[test]
+    fn cli_provider_extra_arg_default_empty() {
+        let config = blank_cli().apply_overrides(default_config());
+        assert!(config.provider_extra_args.is_empty());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -151,6 +151,10 @@ pub struct PrManagementConfig {
     /// gate.  Default: `true`.
     #[serde(default = "default_require_human_review")]
     pub require_human_review: bool,
+    /// When `true` the loop is allowed to force-push feature branches using
+    /// `--force-with-lease`.  Default: `false` (safe default).
+    #[serde(default)]
+    pub allow_force_push: bool,
 }
 
 impl Default for PrManagementConfig {
@@ -160,6 +164,7 @@ impl Default for PrManagementConfig {
             base_branch: default_base_branch(),
             branch_prefix: default_branch_prefix(),
             require_human_review: default_require_human_review(),
+            allow_force_push: false,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -482,6 +482,11 @@ pub struct LoopConfig {
     /// The command is run via the system shell (`sh -c` on Unix).
     #[serde(default)]
     pub on_complete: Option<String>,
+    /// Maximum seconds a single provider invocation may run before it is killed
+    /// and the iteration is classified as `IterationOutcome::Timeout`.
+    /// `None` (default) means no timeout — the provider runs until it exits.
+    #[serde(default)]
+    pub iteration_timeout_secs: Option<u64>,
     /// Issue tracking configuration.
     #[serde(default)]
     pub issue_tracking: IssueTrackingConfig,
@@ -525,6 +530,7 @@ impl Default for LoopConfig {
             retry_backoff_ms: default_retry_backoff_ms(),
             retry_backoff_multiplier: default_retry_backoff_multiplier(),
             on_complete: None,
+            iteration_timeout_secs: None,
             issue_tracking: IssueTrackingConfig::default(),
             pr_management: PrManagementConfig::default(),
             telemetry: TelemetryConfig::default(),
@@ -799,6 +805,24 @@ on_complete = "echo done"
         assert_eq!(config.max_retries, 2);
         assert_eq!(config.retry_backoff_ms, 250);
         assert_eq!(config.on_complete.as_deref(), Some("echo done"));
+        assert!(config.iteration_timeout_secs.is_none());
+    }
+
+    #[test]
+    fn parse_toml_iteration_timeout_secs() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"
+provider = "claude"
+iterations = 1
+log_level = "info"
+iteration_timeout_secs = 120
+"#
+        )
+        .unwrap();
+        let config = LoopConfig::from_toml_file(file.path()).unwrap();
+        assert_eq!(config.iteration_timeout_secs, Some(120));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,9 +8,11 @@ use std::path::PathBuf;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, clap::ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum IssueTrackingMode {
-    /// GitHub Issues via the `gh` CLI (default for production use).
+    /// GitHub Issues via the `gh` CLI (recommended for production use —
+    /// not the type's `Default`; see [`default_issue_tracking_mode`], which
+    /// returns `Local` so existing configs keep working without changes).
     Github,
-    /// Local markdown file — dev/debug only.
+    /// Local markdown file — dev/debug only.  This is the type's `Default`.
     Local,
 }
 
@@ -32,7 +34,11 @@ pub enum CommentCadence {
     Milestones,
     /// Comment after every iteration regardless of outcome.
     EveryIteration,
-    /// Engine never posts comments; the agent is still prompted to do so.
+    /// Engine never posts comments.  The agent may still be instructed to
+    /// comment via the prompt (for example through the lifecycle guidance
+    /// injected by `code-looper bootstrap` into `CLAUDE.md`), but that is
+    /// independent of this cadence setting — switching to `OffEngine` does
+    /// not add any prompt content asking the agent to comment.
     OffEngine,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,10 +74,29 @@ pub struct IssueTrackingConfig {
     /// How often the engine posts comments to the linked issue.
     #[serde(default)]
     pub comment_cadence: CommentCadence,
+    /// When `true` the engine closes the owned issue at end-of-run if the
+    /// agent left it open after completing all checklist items.  When `false`
+    /// (default) the engine only logs a warning.
+    #[serde(default)]
+    pub auto_close_owned_issues: bool,
+    /// Labels the engine ensures exist on the GitHub repository before the
+    /// first iteration.  Only applied when `mode = "github"`.
+    /// Default: `["bug", "enhancement", "tech-debt", "discovered-during-loop"]`.
+    #[serde(default = "default_standard_labels")]
+    pub standard_labels: Vec<String>,
 }
 
 fn default_issue_tracking_mode() -> IssueTrackingMode {
     IssueTrackingMode::Local
+}
+
+fn default_standard_labels() -> Vec<String> {
+    vec![
+        "bug".to_string(),
+        "enhancement".to_string(),
+        "tech-debt".to_string(),
+        "discovered-during-loop".to_string(),
+    ]
 }
 
 impl Default for IssueTrackingConfig {
@@ -89,6 +108,8 @@ impl Default for IssueTrackingConfig {
             local_promise_path: None,
             comment_issue_number: None,
             comment_cadence: CommentCadence::default(),
+            auto_close_owned_issues: false,
+            standard_labels: default_standard_labels(),
         }
     }
 }
@@ -806,6 +827,44 @@ local_promise_path = ".code-looper/dev.md"
             };
             assert!(config.validate().is_ok());
         }
+    }
+
+    #[test]
+    fn issue_tracking_defaults_include_standard_labels() {
+        let config = LoopConfig::default();
+        assert!(!config.issue_tracking.standard_labels.is_empty());
+        assert!(config.issue_tracking.standard_labels.contains(&"bug".to_string()));
+        assert!(
+            config.issue_tracking.standard_labels.contains(&"discovered-during-loop".to_string())
+        );
+        assert!(!config.issue_tracking.auto_close_owned_issues);
+    }
+
+    #[test]
+    fn parse_toml_with_auto_close_and_custom_labels() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"
+provider = "claude"
+iterations = 1
+log_level = "info"
+
+[issue_tracking]
+mode = "github"
+repo_owner = "acme"
+repo_name = "my-repo"
+auto_close_owned_issues = true
+standard_labels = ["bug", "wip", "my-team"]
+"#
+        )
+        .unwrap();
+        let config = LoopConfig::from_toml_file(file.path()).unwrap();
+        assert!(config.issue_tracking.auto_close_owned_issues);
+        assert_eq!(
+            config.issue_tracking.standard_labels,
+            vec!["bug".to_string(), "wip".to_string(), "my-team".to_string()]
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -279,16 +279,116 @@ impl Default for TelemetryConfig {
     }
 }
 
+/// Condition that must be satisfied for a policy rule to match.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyCondition {
+    /// Matches when the repository has at least one open pull request.
+    HasOpenPrs,
+    /// Matches when the repository has at least one open issue (and no open PRs
+    /// unless a prior rule already handled them).
+    HasOpenIssues,
+    /// Always matches — use as the final fallback rule.
+    Always,
+}
+
+impl std::fmt::Display for PolicyCondition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PolicyCondition::HasOpenPrs => write!(f, "has_open_prs"),
+            PolicyCondition::HasOpenIssues => write!(f, "has_open_issues"),
+            PolicyCondition::Always => write!(f, "always"),
+        }
+    }
+}
+
+/// Workflow branch to execute when a policy rule matches.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PolicyWorkflow {
+    /// Review open pull requests.
+    PrReview,
+    /// Work on open GitHub issues.
+    IssueExecution,
+    /// Discover and create backlog items.
+    BacklogDiscovery,
+}
+
+impl std::fmt::Display for PolicyWorkflow {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PolicyWorkflow::PrReview => write!(f, "pr-review"),
+            PolicyWorkflow::IssueExecution => write!(f, "issue-execution"),
+            PolicyWorkflow::BacklogDiscovery => write!(f, "backlog-discovery"),
+        }
+    }
+}
+
+/// A single rule in the orchestration policy chain.
+///
+/// Rules are evaluated in order; the first rule whose condition matches the
+/// current repository context determines the workflow branch and prompt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PolicyRule {
+    /// Condition that triggers this rule.
+    pub condition: PolicyCondition,
+    /// Workflow to execute when the condition matches.
+    pub workflow: PolicyWorkflow,
+    /// Optional prompt override for this rule.  When `None` the workflow's
+    /// built-in default prompt is used.
+    #[serde(default)]
+    pub prompt_override: Option<String>,
+}
+
+/// Returns the default policy chain, which mirrors the hardcoded behaviour that
+/// existed before pluggable policies were introduced.
+pub fn default_policy_rules() -> Vec<PolicyRule> {
+    vec![
+        PolicyRule {
+            condition: PolicyCondition::HasOpenPrs,
+            workflow: PolicyWorkflow::PrReview,
+            prompt_override: None,
+        },
+        PolicyRule {
+            condition: PolicyCondition::HasOpenIssues,
+            workflow: PolicyWorkflow::IssueExecution,
+            prompt_override: None,
+        },
+        PolicyRule {
+            condition: PolicyCondition::Always,
+            workflow: PolicyWorkflow::BacklogDiscovery,
+            prompt_override: None,
+        },
+    ]
+}
+
 /// Orchestration policy engine configuration.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OrchestrationConfig {
     /// Enable the policy engine; when true the engine selects a workflow branch
     /// per iteration and generates the prompt automatically.
+    #[serde(default)]
     pub enabled: bool,
     /// GitHub repository owner (user or org). Required when enabled.
     pub repo_owner: Option<String>,
     /// GitHub repository name. Required when enabled.
     pub repo_name: Option<String>,
+    /// Ordered list of policy rules evaluated against repository context each
+    /// iteration.  First matching rule wins.  Defaults to the standard three-
+    /// rule chain (pr-review → issue-execution → backlog-discovery).
+    #[serde(default = "default_policy_rules")]
+    pub policies: Vec<PolicyRule>,
+}
+
+impl Default for OrchestrationConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            repo_owner: None,
+            repo_name: None,
+            policies: default_policy_rules(),
+        }
+    }
 }
 
 
@@ -345,9 +445,17 @@ pub struct LoopConfig {
     /// `0` means no retries (fail fast).
     #[serde(default)]
     pub max_retries: u32,
-    /// Milliseconds to wait between retry attempts.
+    /// Milliseconds to wait between retry attempts (base delay for attempt 1).
     #[serde(default = "default_retry_backoff_ms")]
     pub retry_backoff_ms: u64,
+    /// Exponential backoff multiplier applied per retry attempt.
+    ///
+    /// The delay for attempt N (1-indexed) is computed as:
+    /// `retry_backoff_ms * retry_backoff_multiplier^(N-1)`.
+    ///
+    /// `1.0` (default) gives flat backoff; `2.0` doubles the delay each retry.
+    #[serde(default = "default_retry_backoff_multiplier")]
+    pub retry_backoff_multiplier: f64,
     /// Optional shell command to execute once after the loop finishes.
     /// The command is run via the system shell (`sh -c` on Unix).
     #[serde(default)]
@@ -367,6 +475,10 @@ fn default_retry_backoff_ms() -> u64 {
     500
 }
 
+fn default_retry_backoff_multiplier() -> f64 {
+    1.0
+}
+
 impl Default for LoopConfig {
     fn default() -> Self {
         Self {
@@ -382,6 +494,7 @@ impl Default for LoopConfig {
             stop_on_failure: false,
             max_retries: 0,
             retry_backoff_ms: default_retry_backoff_ms(),
+            retry_backoff_multiplier: default_retry_backoff_multiplier(),
             on_complete: None,
             issue_tracking: IssueTrackingConfig::default(),
             pr_management: PrManagementConfig::default(),
@@ -573,6 +686,7 @@ prompt_inline = "run the tests"
                 enabled: true,
                 repo_owner: None,
                 repo_name: None,
+                ..OrchestrationConfig::default()
             },
             ..Default::default()
         };
@@ -586,6 +700,7 @@ prompt_inline = "run the tests"
                 enabled: true,
                 repo_owner: Some("owner".to_string()),
                 repo_name: None,
+                ..OrchestrationConfig::default()
             },
             ..Default::default()
         };
@@ -599,6 +714,7 @@ prompt_inline = "run the tests"
                 enabled: true,
                 repo_owner: Some("owner".to_string()),
                 repo_name: Some("repo".to_string()),
+                ..OrchestrationConfig::default()
             },
             ..Default::default()
         };
@@ -678,6 +794,113 @@ repo_name = "my-repo"
         assert_eq!(config.orchestration.repo_name.as_deref(), Some("my-repo"));
     }
 
+    // ── Pluggable policy tests ────────────────────────────────────────────────
+
+    #[test]
+    fn default_orchestration_has_three_policy_rules() {
+        let cfg = OrchestrationConfig::default();
+        assert_eq!(cfg.policies.len(), 3);
+        assert_eq!(cfg.policies[0].condition, PolicyCondition::HasOpenPrs);
+        assert_eq!(cfg.policies[1].condition, PolicyCondition::HasOpenIssues);
+        assert_eq!(cfg.policies[2].condition, PolicyCondition::Always);
+    }
+
+    #[test]
+    fn parse_toml_with_custom_policies() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"
+provider = "claude"
+iterations = 1
+log_level = "info"
+
+[orchestration]
+enabled = true
+repo_owner = "acme"
+repo_name = "my-repo"
+
+[[orchestration.policies]]
+condition = "always"
+workflow = "issue-execution"
+prompt_override = "Only work on issues."
+"#
+        )
+        .unwrap();
+        let config = LoopConfig::from_toml_file(file.path()).unwrap();
+        assert_eq!(config.orchestration.policies.len(), 1);
+        let rule = &config.orchestration.policies[0];
+        assert_eq!(rule.condition, PolicyCondition::Always);
+        assert_eq!(rule.workflow, PolicyWorkflow::IssueExecution);
+        assert_eq!(rule.prompt_override.as_deref(), Some("Only work on issues."));
+    }
+
+    #[test]
+    fn parse_toml_with_multiple_policies() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"
+provider = "claude"
+iterations = 1
+log_level = "info"
+
+[orchestration]
+enabled = true
+repo_owner = "acme"
+repo_name = "my-repo"
+
+[[orchestration.policies]]
+condition = "has_open_prs"
+workflow = "pr-review"
+
+[[orchestration.policies]]
+condition = "always"
+workflow = "backlog-discovery"
+"#
+        )
+        .unwrap();
+        let config = LoopConfig::from_toml_file(file.path()).unwrap();
+        assert_eq!(config.orchestration.policies.len(), 2);
+        assert_eq!(config.orchestration.policies[0].condition, PolicyCondition::HasOpenPrs);
+        assert_eq!(config.orchestration.policies[1].condition, PolicyCondition::Always);
+    }
+
+    #[test]
+    fn policy_workflow_display() {
+        assert_eq!(PolicyWorkflow::PrReview.to_string(), "pr-review");
+        assert_eq!(PolicyWorkflow::IssueExecution.to_string(), "issue-execution");
+        assert_eq!(PolicyWorkflow::BacklogDiscovery.to_string(), "backlog-discovery");
+    }
+
+    // ── Exponential backoff config tests ─────────────────────────────────────
+
+    #[test]
+    fn default_retry_backoff_multiplier_is_one() {
+        let config = LoopConfig::default();
+        assert_eq!(config.retry_backoff_multiplier, 1.0);
+    }
+
+    #[test]
+    fn parse_toml_with_exponential_backoff() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"
+provider = "claude"
+iterations = 3
+log_level = "info"
+max_retries = 3
+retry_backoff_ms = 100
+retry_backoff_multiplier = 2.0
+"#
+        )
+        .unwrap();
+        let config = LoopConfig::from_toml_file(file.path()).unwrap();
+        assert_eq!(config.retry_backoff_ms, 100);
+        assert_eq!(config.retry_backoff_multiplier, 2.0);
+    }
+
     // ── Issue tracking config tests ───────────────────────────────────────────
 
     #[test]
@@ -746,6 +969,7 @@ repo_name = "my-repo"
                 enabled: true,
                 repo_owner: Some("org".to_string()),
                 repo_name: Some("project".to_string()),
+                ..OrchestrationConfig::default()
             },
             ..Default::default()
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -411,6 +411,32 @@ impl std::fmt::Display for Provider {
     }
 }
 
+/// A single repository target for multi-repo orchestration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RepoTarget {
+    /// Filesystem path to the repository root.
+    /// Relative paths are resolved from the working directory at startup.
+    pub path: PathBuf,
+    /// Optional human-readable label used in run logs and summaries.
+    /// Defaults to the final path component when omitted.
+    pub name: Option<String>,
+    /// Optional per-repo prompt that overrides the top-level `prompt_inline`
+    /// or `prompt_file` setting for this specific target.
+    pub prompt_override: Option<String>,
+}
+
+impl RepoTarget {
+    /// Return the display name: explicit `name` or the last path component.
+    pub fn display_name(&self) -> String {
+        self.name.clone().unwrap_or_else(|| {
+            self.path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| self.path.display().to_string())
+        })
+    }
+}
+
 /// Resolved runtime configuration for a single loop run.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LoopConfig {
@@ -469,6 +495,13 @@ pub struct LoopConfig {
     /// Telemetry / artifact collection configuration.
     #[serde(default)]
     pub telemetry: TelemetryConfig,
+    /// Additional repository targets for multi-repo orchestration.
+    ///
+    /// When non-empty, code-looper runs the configured loop for each entry in
+    /// sequence instead of the default single-repo mode.  Each entry may
+    /// supply a `prompt_override` to use a different prompt for that repo.
+    #[serde(default)]
+    pub multi_repo: Vec<RepoTarget>,
 }
 
 fn default_retry_backoff_ms() -> u64 {
@@ -499,6 +532,7 @@ impl Default for LoopConfig {
             issue_tracking: IssueTrackingConfig::default(),
             pr_management: PrManagementConfig::default(),
             telemetry: TelemetryConfig::default(),
+            multi_repo: Vec::new(),
         }
     }
 }
@@ -1159,5 +1193,90 @@ require_human_review = false
         assert_eq!(config.pr_management.base_branch, "develop");
         assert_eq!(config.pr_management.branch_prefix, "feat/");
         assert!(!config.pr_management.require_human_review);
+    }
+
+    // ── Multi-repo config tests ───────────────────────────────────────────────
+
+    #[test]
+    fn multi_repo_is_empty_by_default() {
+        assert!(LoopConfig::default().multi_repo.is_empty());
+    }
+
+    #[test]
+    fn parse_toml_with_multi_repo_entries() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"
+provider = "claude"
+iterations = 1
+log_level = "info"
+
+[[multi_repo]]
+path = "/repos/project-a"
+name = "project-a"
+
+[[multi_repo]]
+path = "/repos/project-b"
+prompt_override = "Run linting only"
+"#
+        )
+        .unwrap();
+        let config = LoopConfig::from_toml_file(file.path()).unwrap();
+        assert_eq!(config.multi_repo.len(), 2);
+
+        let a = &config.multi_repo[0];
+        assert_eq!(a.path, std::path::PathBuf::from("/repos/project-a"));
+        assert_eq!(a.name.as_deref(), Some("project-a"));
+        assert!(a.prompt_override.is_none());
+
+        let b = &config.multi_repo[1];
+        assert_eq!(b.path, std::path::PathBuf::from("/repos/project-b"));
+        assert!(b.name.is_none());
+        assert_eq!(b.prompt_override.as_deref(), Some("Run linting only"));
+    }
+
+    #[test]
+    fn repo_target_display_name_uses_explicit_name() {
+        let t = RepoTarget {
+            path: "/repos/my-project".into(),
+            name: Some("custom".to_string()),
+            prompt_override: None,
+        };
+        assert_eq!(t.display_name(), "custom");
+    }
+
+    #[test]
+    fn repo_target_display_name_falls_back_to_dir() {
+        let t = RepoTarget {
+            path: "/repos/my-project".into(),
+            name: None,
+            prompt_override: None,
+        };
+        assert_eq!(t.display_name(), "my-project");
+    }
+
+    #[test]
+    fn multi_repo_serde_round_trip() {
+        let config = LoopConfig {
+            multi_repo: vec![
+                RepoTarget {
+                    path: "/tmp/repo-a".into(),
+                    name: Some("repo-a".to_string()),
+                    prompt_override: None,
+                },
+                RepoTarget {
+                    path: "/tmp/repo-b".into(),
+                    name: None,
+                    prompt_override: Some("custom task".to_string()),
+                },
+            ],
+            ..LoopConfig::default()
+        };
+        let serialized = toml::to_string(&config).unwrap();
+        let deserialized: LoopConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(deserialized.multi_repo.len(), 2);
+        assert_eq!(deserialized.multi_repo[0], config.multi_repo[0]);
+        assert_eq!(deserialized.multi_repo[1], config.multi_repo[1]);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -176,6 +176,10 @@ pub struct PrManagementConfig {
     /// `--force-with-lease`.  Default: `false` (safe default).
     #[serde(default)]
     pub allow_force_push: bool,
+    /// Sentinel string the loop looks for in agent output to trigger PR
+    /// creation.  Default: `LOOPER_READY_FOR_REVIEW`.
+    #[serde(default)]
+    pub ready_marker: Option<String>,
 }
 
 impl Default for PrManagementConfig {
@@ -186,6 +190,7 @@ impl Default for PrManagementConfig {
             branch_prefix: default_branch_prefix(),
             require_human_review: default_require_human_review(),
             allow_force_push: false,
+            ready_marker: None,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -156,6 +156,37 @@ fn default_require_human_review() -> bool {
     true
 }
 
+fn default_triage_priority() -> TriagePriority {
+    TriagePriority::Oldest
+}
+
+fn default_skip_labels() -> Vec<String> {
+    vec!["do-not-loop".to_string(), "wip".to_string()]
+}
+
+/// How the multi-PR triage step orders open PRs when selecting which one to
+/// advance first.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, clap::ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum TriagePriority {
+    /// Oldest PR first (by creation date).  This is the default.
+    Oldest,
+    /// Newest PR first (by creation date).
+    Newest,
+    /// PRs with the fewest merge conflicts first.
+    LeastConflicts,
+}
+
+impl std::fmt::Display for TriagePriority {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TriagePriority::Oldest => write!(f, "oldest"),
+            TriagePriority::Newest => write!(f, "newest"),
+            TriagePriority::LeastConflicts => write!(f, "least-conflicts"),
+        }
+    }
+}
+
 /// Pull-request management configuration (`[pr_management]` TOML section).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PrManagementConfig {
@@ -180,6 +211,13 @@ pub struct PrManagementConfig {
     /// creation.  Default: `LOOPER_READY_FOR_REVIEW`.
     #[serde(default)]
     pub ready_marker: Option<String>,
+    /// Ordering policy for PR triage in `multi-pr` mode.  Default: `oldest`.
+    #[serde(default = "default_triage_priority")]
+    pub triage_priority: TriagePriority,
+    /// Labels that cause a PR to be skipped during `multi-pr` triage.
+    /// Default: `["do-not-loop", "wip"]`.
+    #[serde(default = "default_skip_labels")]
+    pub skip_labels: Vec<String>,
 }
 
 impl Default for PrManagementConfig {
@@ -191,6 +229,8 @@ impl Default for PrManagementConfig {
             require_human_review: default_require_human_review(),
             allow_force_push: false,
             ready_marker: None,
+            triage_priority: default_triage_priority(),
+            skip_labels: default_skip_labels(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -258,11 +258,15 @@ pub struct TelemetryConfig {
     pub no_summary: bool,
 }
 
-fn default_stream_output() -> bool { true }
+fn default_stream_output() -> bool {
+    true
+}
 fn default_artifacts_dir() -> std::path::PathBuf {
     std::path::PathBuf::from(".code-looper/runs")
 }
-fn default_keep_runs() -> usize { 10 }
+fn default_keep_runs() -> usize {
+    10
+}
 
 impl Default for TelemetryConfig {
     fn default() -> Self {
@@ -386,7 +390,6 @@ impl Default for OrchestrationConfig {
         }
     }
 }
-
 
 /// Supported agent CLI providers.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, clap::ValueEnum)]
@@ -886,7 +889,10 @@ prompt_override = "Only work on issues."
         let rule = &config.orchestration.policies[0];
         assert_eq!(rule.condition, PolicyCondition::Always);
         assert_eq!(rule.workflow, PolicyWorkflow::IssueExecution);
-        assert_eq!(rule.prompt_override.as_deref(), Some("Only work on issues."));
+        assert_eq!(
+            rule.prompt_override.as_deref(),
+            Some("Only work on issues.")
+        );
     }
 
     #[test]
@@ -916,15 +922,27 @@ workflow = "backlog-discovery"
         .unwrap();
         let config = LoopConfig::from_toml_file(file.path()).unwrap();
         assert_eq!(config.orchestration.policies.len(), 2);
-        assert_eq!(config.orchestration.policies[0].condition, PolicyCondition::HasOpenPrs);
-        assert_eq!(config.orchestration.policies[1].condition, PolicyCondition::Always);
+        assert_eq!(
+            config.orchestration.policies[0].condition,
+            PolicyCondition::HasOpenPrs
+        );
+        assert_eq!(
+            config.orchestration.policies[1].condition,
+            PolicyCondition::Always
+        );
     }
 
     #[test]
     fn policy_workflow_display() {
         assert_eq!(PolicyWorkflow::PrReview.to_string(), "pr-review");
-        assert_eq!(PolicyWorkflow::IssueExecution.to_string(), "issue-execution");
-        assert_eq!(PolicyWorkflow::BacklogDiscovery.to_string(), "backlog-discovery");
+        assert_eq!(
+            PolicyWorkflow::IssueExecution.to_string(),
+            "issue-execution"
+        );
+        assert_eq!(
+            PolicyWorkflow::BacklogDiscovery.to_string(),
+            "backlog-discovery"
+        );
     }
 
     // ── Exponential backoff config tests ─────────────────────────────────────
@@ -1156,10 +1174,14 @@ local_promise_path = ".code-looper/dev.md"
     fn issue_tracking_defaults_include_standard_labels() {
         let config = LoopConfig::default();
         assert!(!config.issue_tracking.standard_labels.is_empty());
-        assert!(config.issue_tracking.standard_labels.contains(&"bug".to_string()));
-        assert!(
-            config.issue_tracking.standard_labels.contains(&"discovered-during-loop".to_string())
-        );
+        assert!(config
+            .issue_tracking
+            .standard_labels
+            .contains(&"bug".to_string()));
+        assert!(config
+            .issue_tracking
+            .standard_labels
+            .contains(&"discovered-during-loop".to_string()));
         assert!(!config.issue_tracking.auto_close_owned_issues);
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,34 @@ impl std::fmt::Display for IssueTrackingMode {
     }
 }
 
+/// Controls how often the loop engine posts comments to the active issue.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, clap::ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum CommentCadence {
+    /// Comment at run start, run end, blockers, and failed iterations (default).
+    Milestones,
+    /// Comment after every iteration regardless of outcome.
+    EveryIteration,
+    /// Engine never posts comments; the agent is still prompted to do so.
+    OffEngine,
+}
+
+impl Default for CommentCadence {
+    fn default() -> Self {
+        Self::Milestones
+    }
+}
+
+impl std::fmt::Display for CommentCadence {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CommentCadence::Milestones => write!(f, "milestones"),
+            CommentCadence::EveryIteration => write!(f, "every-iteration"),
+            CommentCadence::OffEngine => write!(f, "off-engine"),
+        }
+    }
+}
+
 /// Issue tracking configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IssueTrackingConfig {
@@ -40,6 +68,12 @@ pub struct IssueTrackingConfig {
     /// Path to the local promise markdown file (when `mode = "local"`).
     /// Defaults to `.code-looper/promise.md`.
     pub local_promise_path: Option<PathBuf>,
+    /// GitHub issue number the engine should post run-lifecycle comments on.
+    /// When `None` (or mode is `local`), engine comments are skipped.
+    pub comment_issue_number: Option<u32>,
+    /// How often the engine posts comments to the linked issue.
+    #[serde(default)]
+    pub comment_cadence: CommentCadence,
 }
 
 fn default_issue_tracking_mode() -> IssueTrackingMode {
@@ -53,6 +87,8 @@ impl Default for IssueTrackingConfig {
             repo_owner: None,
             repo_name: None,
             local_promise_path: None,
+            comment_issue_number: None,
+            comment_cadence: CommentCadence::default(),
         }
     }
 }
@@ -589,7 +625,7 @@ repo_name = "my-repo"
                 mode: IssueTrackingMode::Github,
                 repo_owner: None,
                 repo_name: None,
-                local_promise_path: None,
+                ..IssueTrackingConfig::default()
             },
             ..Default::default()
         };
@@ -604,7 +640,7 @@ repo_name = "my-repo"
                 mode: IssueTrackingMode::Github,
                 repo_owner: Some("owner".to_string()),
                 repo_name: None,
-                local_promise_path: None,
+                ..IssueTrackingConfig::default()
             },
             ..Default::default()
         };
@@ -619,7 +655,7 @@ repo_name = "my-repo"
                 mode: IssueTrackingMode::Github,
                 repo_owner: Some("owner".to_string()),
                 repo_name: Some("repo".to_string()),
-                local_promise_path: None,
+                ..IssueTrackingConfig::default()
             },
             ..Default::default()
         };
@@ -633,7 +669,7 @@ repo_name = "my-repo"
                 mode: IssueTrackingMode::Github,
                 repo_owner: None,
                 repo_name: None,
-                local_promise_path: None,
+                ..IssueTrackingConfig::default()
             },
             orchestration: OrchestrationConfig {
                 enabled: true,
@@ -650,9 +686,7 @@ repo_name = "my-repo"
         let config = LoopConfig {
             issue_tracking: IssueTrackingConfig {
                 mode: IssueTrackingMode::Local,
-                repo_owner: None,
-                repo_name: None,
-                local_promise_path: None,
+                ..IssueTrackingConfig::default()
             },
             ..Default::default()
         };
@@ -748,7 +782,7 @@ local_promise_path = ".code-looper/dev.md"
                 mode: IssueTrackingMode::Github,
                 repo_owner: Some("owner".to_string()),
                 repo_name: Some("repo".to_string()),
-                local_promise_path: None,
+                ..IssueTrackingConfig::default()
             },
             ..LoopConfig::default()
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -506,6 +506,18 @@ pub struct LoopConfig {
     /// supply a `prompt_override` to use a different prompt for that repo.
     #[serde(default)]
     pub multi_repo: Vec<RepoTarget>,
+    /// Extra CLI arguments appended to the provider invocation, after the
+    /// adapter's hardcoded flags but before the prompt.
+    ///
+    /// Example (TOML):
+    /// ```toml
+    /// provider_extra_args = ["--model", "claude-opus-4-5"]
+    /// ```
+    ///
+    /// Each element becomes a separate argument (`Command::arg`), so shell
+    /// metacharacters are not interpreted.
+    #[serde(default)]
+    pub provider_extra_args: Vec<String>,
 }
 
 fn default_retry_backoff_ms() -> u64 {
@@ -538,6 +550,7 @@ impl Default for LoopConfig {
             pr_management: PrManagementConfig::default(),
             telemetry: TelemetryConfig::default(),
             multi_repo: Vec::new(),
+            provider_extra_args: Vec::new(),
         }
     }
 }
@@ -1509,5 +1522,43 @@ prompt_override = "Run linting only"
         assert!(config.orchestration.enabled);
         assert_eq!(config.orchestration.repo_owner.as_deref(), Some("acme"));
         assert_eq!(config.orchestration.repo_name.as_deref(), Some("my-repo"));
+    }
+
+    // ── provider_extra_args ───────────────────────────────────────────────────
+
+    #[test]
+    fn default_provider_extra_args_is_empty() {
+        let config = LoopConfig::default();
+        assert!(config.provider_extra_args.is_empty());
+    }
+
+    #[test]
+    fn parse_toml_provider_extra_args() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"
+provider = "claude"
+iterations = 1
+log_level = "info"
+provider_extra_args = ["--model", "claude-opus-4-5"]
+"#
+        )
+        .unwrap();
+        let config = LoopConfig::from_toml_file(file.path()).unwrap();
+        assert_eq!(config.provider_extra_args, ["--model", "claude-opus-4-5"]);
+    }
+
+    #[test]
+    fn parse_yaml_provider_extra_args() {
+        let file = write_temp_file(
+            ".yaml",
+            "provider: codex\niterations: 1\nlog_level: info\nprovider_extra_args:\n  - --approval-mode\n  - full-auto\n",
+        );
+        let config = LoopConfig::from_yaml_file(file.path()).unwrap();
+        assert_eq!(
+            config.provider_extra_args,
+            ["--approval-mode", "full-auto"]
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,21 +24,16 @@ impl std::fmt::Display for IssueTrackingMode {
 }
 
 /// Controls how often the loop engine posts comments to the active issue.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, clap::ValueEnum)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, clap::ValueEnum)]
 #[serde(rename_all = "kebab-case")]
 pub enum CommentCadence {
     /// Comment at run start, run end, blockers, and failed iterations (default).
+    #[default]
     Milestones,
     /// Comment after every iteration regardless of outcome.
     EveryIteration,
     /// Engine never posts comments; the agent is still prompted to do so.
     OffEngine,
-}
-
-impl Default for CommentCadence {
-    fn default() -> Self {
-        Self::Milestones
-    }
 }
 
 impl std::fmt::Display for CommentCadence {
@@ -117,6 +112,7 @@ impl Default for IssueTrackingConfig {
 // ── PR management ────────────────────────────────────────────────────────────
 
 /// PR iteration mode.
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, clap::ValueEnum)]
 #[serde(rename_all = "kebab-case")]
 pub enum PrMode {

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,6 +57,77 @@ impl Default for IssueTrackingConfig {
     }
 }
 
+// ── PR management ────────────────────────────────────────────────────────────
+
+/// PR iteration mode.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, clap::ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+pub enum PrMode {
+    /// Commit and push to a feature branch only; never open a PR.
+    NoPr,
+    /// Work on one feature branch; open a PR when work is shippable, then
+    /// continue pushing to that branch until merged.
+    SinglePr,
+    /// On each iteration, triage open PRs first (review, fix, merge); open new
+    /// feature branches for issue work only when no PR can be advanced.
+    MultiPr,
+}
+
+impl std::fmt::Display for PrMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PrMode::NoPr => write!(f, "no-pr"),
+            PrMode::SinglePr => write!(f, "single-pr"),
+            PrMode::MultiPr => write!(f, "multi-pr"),
+        }
+    }
+}
+
+fn default_pr_mode() -> PrMode {
+    PrMode::NoPr
+}
+
+fn default_base_branch() -> String {
+    "main".to_string()
+}
+
+fn default_branch_prefix() -> String {
+    "loop/".to_string()
+}
+
+fn default_require_human_review() -> bool {
+    true
+}
+
+/// Pull-request management configuration (`[pr_management]` TOML section).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PrManagementConfig {
+    /// PR strategy mode.  Default: `no-pr`.
+    #[serde(default = "default_pr_mode")]
+    pub mode: PrMode,
+    /// Branch to open PRs into.  Default: `main`.
+    #[serde(default = "default_base_branch")]
+    pub base_branch: String,
+    /// Prefix for feature branches created by the loop.  Default: `loop/`.
+    #[serde(default = "default_branch_prefix")]
+    pub branch_prefix: String,
+    /// When `true` the loop never merges a PR itself — human review is the
+    /// gate.  Default: `true`.
+    #[serde(default = "default_require_human_review")]
+    pub require_human_review: bool,
+}
+
+impl Default for PrManagementConfig {
+    fn default() -> Self {
+        Self {
+            mode: default_pr_mode(),
+            base_branch: default_base_branch(),
+            branch_prefix: default_branch_prefix(),
+            require_human_review: default_require_human_review(),
+        }
+    }
+}
+
 // ── Orchestration ─────────────────────────────────────────────────────────────
 
 // ── Telemetry ─────────────────────────────────────────────────────────────────
@@ -177,6 +248,9 @@ pub struct LoopConfig {
     /// Issue tracking configuration.
     #[serde(default)]
     pub issue_tracking: IssueTrackingConfig,
+    /// Pull-request management configuration.
+    #[serde(default)]
+    pub pr_management: PrManagementConfig,
     /// Telemetry / artifact collection configuration.
     #[serde(default)]
     pub telemetry: TelemetryConfig,
@@ -203,6 +277,7 @@ impl Default for LoopConfig {
             retry_backoff_ms: default_retry_backoff_ms(),
             on_complete: None,
             issue_tracking: IssueTrackingConfig::default(),
+            pr_management: PrManagementConfig::default(),
             telemetry: TelemetryConfig::default(),
         }
     }
@@ -246,6 +321,15 @@ impl LoopConfig {
                     "--on-complete must not be an empty string".to_string(),
                 ));
             }
+        }
+        // multi-pr mode requires GitHub issue tracking (local mode can't track PRs).
+        if self.pr_management.mode == PrMode::MultiPr
+            && self.issue_tracking.mode != IssueTrackingMode::Github
+        {
+            return Err(LooperError::InvalidArgument(
+                "pr_management.mode=\"multi-pr\" requires issue_tracking.mode=\"github\""
+                    .to_string(),
+            ));
         }
         // When github mode is active, owner and repo must be resolvable.
         if self.issue_tracking.mode == IssueTrackingMode::Github {
@@ -622,5 +706,91 @@ local_promise_path = ".code-looper/dev.md"
             Some(PathBuf::from(".code-looper/dev.md"))
         );
         assert!(config.validate().is_ok());
+    }
+
+    // ── PR management config tests ─────────────────────────────────────────────
+
+    #[test]
+    fn pr_management_defaults() {
+        let config = LoopConfig::default();
+        assert_eq!(config.pr_management.mode, PrMode::NoPr);
+        assert_eq!(config.pr_management.base_branch, "main");
+        assert_eq!(config.pr_management.branch_prefix, "loop/");
+        assert!(config.pr_management.require_human_review);
+    }
+
+    #[test]
+    fn multi_pr_requires_github_issue_tracking() {
+        let config = LoopConfig {
+            pr_management: PrManagementConfig {
+                mode: PrMode::MultiPr,
+                ..PrManagementConfig::default()
+            },
+            issue_tracking: IssueTrackingConfig {
+                mode: IssueTrackingMode::Local,
+                ..IssueTrackingConfig::default()
+            },
+            ..LoopConfig::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("multi-pr"));
+        assert!(err.to_string().contains("github"));
+    }
+
+    #[test]
+    fn multi_pr_with_github_issue_tracking_is_valid() {
+        let config = LoopConfig {
+            pr_management: PrManagementConfig {
+                mode: PrMode::MultiPr,
+                ..PrManagementConfig::default()
+            },
+            issue_tracking: IssueTrackingConfig {
+                mode: IssueTrackingMode::Github,
+                repo_owner: Some("owner".to_string()),
+                repo_name: Some("repo".to_string()),
+                local_promise_path: None,
+            },
+            ..LoopConfig::default()
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn no_pr_and_single_pr_work_with_local_issue_tracking() {
+        for mode in [PrMode::NoPr, PrMode::SinglePr] {
+            let config = LoopConfig {
+                pr_management: PrManagementConfig {
+                    mode,
+                    ..PrManagementConfig::default()
+                },
+                ..LoopConfig::default()
+            };
+            assert!(config.validate().is_ok());
+        }
+    }
+
+    #[test]
+    fn parse_toml_with_pr_management() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"
+provider = "claude"
+iterations = 1
+log_level = "info"
+
+[pr_management]
+mode = "single-pr"
+base_branch = "develop"
+branch_prefix = "feat/"
+require_human_review = false
+"#
+        )
+        .unwrap();
+        let config = LoopConfig::from_toml_file(file.path()).unwrap();
+        assert_eq!(config.pr_management.mode, PrMode::SinglePr);
+        assert_eq!(config.pr_management.base_branch, "develop");
+        assert_eq!(config.pr_management.branch_prefix, "feat/");
+        assert!(!config.pr_management.require_human_review);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -59,6 +59,48 @@ impl Default for IssueTrackingConfig {
 
 // ── Orchestration ─────────────────────────────────────────────────────────────
 
+// ── Telemetry ─────────────────────────────────────────────────────────────────
+
+/// Telemetry / artifact collection configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TelemetryConfig {
+    /// Stream provider stdout/stderr to the terminal in real time (tagged).
+    /// Default: `true`.
+    #[serde(default = "default_stream_output")]
+    pub stream_output: bool,
+    /// Root directory for per-run artifact directories.
+    /// Default: `.code-looper/runs`.
+    #[serde(default = "default_artifacts_dir")]
+    pub artifacts_dir: std::path::PathBuf,
+    /// Number of most-recent run directories to retain.
+    /// Older runs are pruned after each new run completes.
+    /// Default: 10.
+    #[serde(default = "default_keep_runs")]
+    pub keep_runs: usize,
+    /// When `true`, skip writing the markdown summary and printing the
+    /// condensed terminal summary.  Useful for scripted/CI use.
+    /// Default: `false`.
+    #[serde(default)]
+    pub no_summary: bool,
+}
+
+fn default_stream_output() -> bool { true }
+fn default_artifacts_dir() -> std::path::PathBuf {
+    std::path::PathBuf::from(".code-looper/runs")
+}
+fn default_keep_runs() -> usize { 10 }
+
+impl Default for TelemetryConfig {
+    fn default() -> Self {
+        Self {
+            stream_output: default_stream_output(),
+            artifacts_dir: default_artifacts_dir(),
+            keep_runs: default_keep_runs(),
+            no_summary: false,
+        }
+    }
+}
+
 /// Orchestration policy engine configuration.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct OrchestrationConfig {
@@ -135,6 +177,9 @@ pub struct LoopConfig {
     /// Issue tracking configuration.
     #[serde(default)]
     pub issue_tracking: IssueTrackingConfig,
+    /// Telemetry / artifact collection configuration.
+    #[serde(default)]
+    pub telemetry: TelemetryConfig,
 }
 
 fn default_retry_backoff_ms() -> u64 {
@@ -158,6 +203,7 @@ impl Default for LoopConfig {
             retry_backoff_ms: default_retry_backoff_ms(),
             on_complete: None,
             issue_tracking: IssueTrackingConfig::default(),
+            telemetry: TelemetryConfig::default(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,63 @@ use crate::error::LooperError;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+// ── Issue tracking ────────────────────────────────────────────────────────────
+
+/// Issue tracking backend mode.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, clap::ValueEnum)]
+#[serde(rename_all = "lowercase")]
+pub enum IssueTrackingMode {
+    /// GitHub Issues via the `gh` CLI (default for production use).
+    Github,
+    /// Local markdown file — dev/debug only.
+    Local,
+}
+
+impl std::fmt::Display for IssueTrackingMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IssueTrackingMode::Github => write!(f, "github"),
+            IssueTrackingMode::Local => write!(f, "local"),
+        }
+    }
+}
+
+/// Issue tracking configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssueTrackingConfig {
+    /// Backend mode (`github` or `local`).  Defaults to `local` so that
+    /// existing configs work without changes — but production use should
+    /// always set `github`.
+    #[serde(default = "default_issue_tracking_mode")]
+    pub mode: IssueTrackingMode,
+    /// GitHub repository owner (required when `mode = "github"`, unless
+    /// inherited from `[orchestration].repo_owner`).
+    pub repo_owner: Option<String>,
+    /// GitHub repository name (required when `mode = "github"`, unless
+    /// inherited from `[orchestration].repo_name`).
+    pub repo_name: Option<String>,
+    /// Path to the local promise markdown file (when `mode = "local"`).
+    /// Defaults to `.code-looper/promise.md`.
+    pub local_promise_path: Option<PathBuf>,
+}
+
+fn default_issue_tracking_mode() -> IssueTrackingMode {
+    IssueTrackingMode::Local
+}
+
+impl Default for IssueTrackingConfig {
+    fn default() -> Self {
+        Self {
+            mode: IssueTrackingMode::Local,
+            repo_owner: None,
+            repo_name: None,
+            local_promise_path: None,
+        }
+    }
+}
+
+// ── Orchestration ─────────────────────────────────────────────────────────────
+
 /// Orchestration policy engine configuration.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct OrchestrationConfig {
@@ -75,6 +132,9 @@ pub struct LoopConfig {
     /// The command is run via the system shell (`sh -c` on Unix).
     #[serde(default)]
     pub on_complete: Option<String>,
+    /// Issue tracking configuration.
+    #[serde(default)]
+    pub issue_tracking: IssueTrackingConfig,
 }
 
 fn default_retry_backoff_ms() -> u64 {
@@ -97,6 +157,7 @@ impl Default for LoopConfig {
             max_retries: 0,
             retry_backoff_ms: default_retry_backoff_ms(),
             on_complete: None,
+            issue_tracking: IssueTrackingConfig::default(),
         }
     }
 }
@@ -137,6 +198,33 @@ impl LoopConfig {
             if cmd.trim().is_empty() {
                 return Err(LooperError::InvalidArgument(
                     "--on-complete must not be an empty string".to_string(),
+                ));
+            }
+        }
+        // When github mode is active, owner and repo must be resolvable.
+        if self.issue_tracking.mode == IssueTrackingMode::Github {
+            let owner = self
+                .issue_tracking
+                .repo_owner
+                .as_deref()
+                .or(self.orchestration.repo_owner.as_deref());
+            let repo = self
+                .issue_tracking
+                .repo_name
+                .as_deref()
+                .or(self.orchestration.repo_name.as_deref());
+            if owner.is_none() {
+                return Err(LooperError::InvalidArgument(
+                    "issue_tracking.mode=\"github\" requires repo_owner \
+                     (set issue_tracking.repo_owner or orchestration.repo_owner)"
+                        .to_string(),
+                ));
+            }
+            if repo.is_none() {
+                return Err(LooperError::InvalidArgument(
+                    "issue_tracking.mode=\"github\" requires repo_name \
+                     (set issue_tracking.repo_name or orchestration.repo_name)"
+                        .to_string(),
                 ));
             }
         }
@@ -351,5 +439,142 @@ repo_name = "my-repo"
         assert!(config.orchestration.enabled);
         assert_eq!(config.orchestration.repo_owner.as_deref(), Some("acme"));
         assert_eq!(config.orchestration.repo_name.as_deref(), Some("my-repo"));
+    }
+
+    // ── Issue tracking config tests ───────────────────────────────────────────
+
+    #[test]
+    fn issue_tracking_defaults_to_local() {
+        let config = LoopConfig::default();
+        assert_eq!(config.issue_tracking.mode, IssueTrackingMode::Local);
+        assert!(config.issue_tracking.repo_owner.is_none());
+        assert!(config.issue_tracking.repo_name.is_none());
+        assert!(config.issue_tracking.local_promise_path.is_none());
+    }
+
+    #[test]
+    fn github_mode_without_credentials_is_invalid() {
+        let config = LoopConfig {
+            issue_tracking: IssueTrackingConfig {
+                mode: IssueTrackingMode::Github,
+                repo_owner: None,
+                repo_name: None,
+                local_promise_path: None,
+            },
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("repo_owner"));
+    }
+
+    #[test]
+    fn github_mode_without_repo_name_is_invalid() {
+        let config = LoopConfig {
+            issue_tracking: IssueTrackingConfig {
+                mode: IssueTrackingMode::Github,
+                repo_owner: Some("owner".to_string()),
+                repo_name: None,
+                local_promise_path: None,
+            },
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("repo_name"));
+    }
+
+    #[test]
+    fn github_mode_with_credentials_is_valid() {
+        let config = LoopConfig {
+            issue_tracking: IssueTrackingConfig {
+                mode: IssueTrackingMode::Github,
+                repo_owner: Some("owner".to_string()),
+                repo_name: Some("repo".to_string()),
+                local_promise_path: None,
+            },
+            ..Default::default()
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn github_mode_inherits_orchestration_credentials() {
+        let config = LoopConfig {
+            issue_tracking: IssueTrackingConfig {
+                mode: IssueTrackingMode::Github,
+                repo_owner: None,
+                repo_name: None,
+                local_promise_path: None,
+            },
+            orchestration: OrchestrationConfig {
+                enabled: true,
+                repo_owner: Some("org".to_string()),
+                repo_name: Some("project".to_string()),
+            },
+            ..Default::default()
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn local_mode_is_always_valid() {
+        let config = LoopConfig {
+            issue_tracking: IssueTrackingConfig {
+                mode: IssueTrackingMode::Local,
+                repo_owner: None,
+                repo_name: None,
+                local_promise_path: None,
+            },
+            ..Default::default()
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn parse_toml_with_issue_tracking_github() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"
+provider = "claude"
+iterations = 1
+log_level = "info"
+
+[issue_tracking]
+mode = "github"
+repo_owner = "acme"
+repo_name = "my-repo"
+"#
+        )
+        .unwrap();
+        let config = LoopConfig::from_toml_file(file.path()).unwrap();
+        assert_eq!(config.issue_tracking.mode, IssueTrackingMode::Github);
+        assert_eq!(config.issue_tracking.repo_owner.as_deref(), Some("acme"));
+        assert_eq!(config.issue_tracking.repo_name.as_deref(), Some("my-repo"));
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn parse_toml_with_issue_tracking_local() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"
+provider = "claude"
+iterations = 1
+log_level = "info"
+
+[issue_tracking]
+mode = "local"
+local_promise_path = ".code-looper/dev.md"
+"#
+        )
+        .unwrap();
+        let config = LoopConfig::from_toml_file(file.path()).unwrap();
+        assert_eq!(config.issue_tracking.mode, IssueTrackingMode::Local);
+        assert_eq!(
+            config.issue_tracking.local_promise_path,
+            Some(PathBuf::from(".code-looper/dev.md"))
+        );
+        assert!(config.validate().is_ok());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -542,12 +542,57 @@ impl Default for LoopConfig {
     }
 }
 
+/// Supported config file formats, detected from the file extension.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConfigFormat {
+    /// TOML (`.toml`) — default format.
+    Toml,
+    /// YAML (`.yaml` or `.yml`).
+    Yaml,
+}
+
+impl ConfigFormat {
+    /// Detect format from a file path's extension.
+    /// `.yaml` and `.yml` map to [`ConfigFormat::Yaml`]; everything else is
+    /// treated as [`ConfigFormat::Toml`].
+    pub fn detect(path: &std::path::Path) -> Self {
+        match path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(str::to_lowercase)
+            .as_deref()
+        {
+            Some("yaml") | Some("yml") => ConfigFormat::Yaml,
+            _ => ConfigFormat::Toml,
+        }
+    }
+}
+
 impl LoopConfig {
     /// Load config from a TOML file.
     pub fn from_toml_file(path: &std::path::Path) -> Result<Self, LooperError> {
         let content = std::fs::read_to_string(path)?;
         let config: Self = toml::from_str(&content)?;
         Ok(config)
+    }
+
+    /// Load config from a YAML file (`.yaml` / `.yml`).
+    pub fn from_yaml_file(path: &std::path::Path) -> Result<Self, LooperError> {
+        let content = std::fs::read_to_string(path)?;
+        let config: Self = serde_yaml::from_str(&content)
+            .map_err(|e| LooperError::InvalidArgument(format!("YAML parse error: {e}")))?;
+        Ok(config)
+    }
+
+    /// Load config from a file, auto-detecting format by extension.
+    ///
+    /// `.yaml` / `.yml` extensions are parsed as YAML; everything else is
+    /// parsed as TOML.
+    pub fn from_file(path: &std::path::Path) -> Result<Self, LooperError> {
+        match ConfigFormat::detect(path) {
+            ConfigFormat::Yaml => Self::from_yaml_file(path),
+            ConfigFormat::Toml => Self::from_toml_file(path),
+        }
     }
 
     /// Validate that the config is internally consistent.
@@ -1320,5 +1365,117 @@ prompt_override = "Run linting only"
         assert_eq!(deserialized.multi_repo.len(), 2);
         assert_eq!(deserialized.multi_repo[0], config.multi_repo[0]);
         assert_eq!(deserialized.multi_repo[1], config.multi_repo[1]);
+    }
+
+    // ── YAML config tests ─────────────────────────────────────────────────────
+
+    /// Helper: write content to a temp file with the given suffix.
+    fn write_temp_file(suffix: &str, content: &str) -> NamedTempFile {
+        let file = tempfile::Builder::new().suffix(suffix).tempfile().unwrap();
+        std::fs::write(file.path(), content).unwrap();
+        file
+    }
+
+    #[test]
+    fn parse_yaml_config_file() {
+        let file = write_temp_file(
+            ".yaml",
+            "provider: copilot\niterations: 7\nlog_level: debug\n",
+        );
+        let config = LoopConfig::from_yaml_file(file.path()).unwrap();
+        assert_eq!(config.provider, Provider::Copilot);
+        assert_eq!(config.iterations, 7);
+        assert_eq!(config.log_level, "debug");
+    }
+
+    #[test]
+    fn parse_yml_config_file() {
+        let file = write_temp_file(
+            ".yml",
+            "provider: codex\niterations: 3\nlog_level: info\nprompt_inline: \"run lints\"\n",
+        );
+        let config = LoopConfig::from_yaml_file(file.path()).unwrap();
+        assert_eq!(config.provider, Provider::Codex);
+        assert_eq!(config.prompt_inline.as_deref(), Some("run lints"));
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn from_file_detects_yaml_extension() {
+        let file = write_temp_file(
+            ".yaml",
+            "provider: claude\niterations: 2\nlog_level: info\n",
+        );
+        let config = LoopConfig::from_file(file.path()).unwrap();
+        assert_eq!(config.provider, Provider::Claude);
+        assert_eq!(config.iterations, 2);
+    }
+
+    #[test]
+    fn from_file_detects_toml_extension() {
+        let file = write_temp_file(
+            ".toml",
+            "provider = \"copilot\"\niterations = 4\nlog_level = \"info\"\n",
+        );
+        let config = LoopConfig::from_file(file.path()).unwrap();
+        assert_eq!(config.provider, Provider::Copilot);
+        assert_eq!(config.iterations, 4);
+    }
+
+    #[test]
+    fn from_file_defaults_to_toml_for_unknown_extension() {
+        let file = write_temp_file(
+            ".conf",
+            "provider = \"codex\"\niterations = 1\nlog_level = \"info\"\n",
+        );
+        let config = LoopConfig::from_file(file.path()).unwrap();
+        assert_eq!(config.provider, Provider::Codex);
+    }
+
+    #[test]
+    fn config_format_detect_yaml() {
+        assert_eq!(
+            ConfigFormat::detect(std::path::Path::new("looper.yaml")),
+            ConfigFormat::Yaml
+        );
+        assert_eq!(
+            ConfigFormat::detect(std::path::Path::new("looper.yml")),
+            ConfigFormat::Yaml
+        );
+        assert_eq!(
+            ConfigFormat::detect(std::path::Path::new("looper.YAML")),
+            ConfigFormat::Yaml
+        );
+    }
+
+    #[test]
+    fn config_format_detect_toml() {
+        assert_eq!(
+            ConfigFormat::detect(std::path::Path::new("looper.toml")),
+            ConfigFormat::Toml
+        );
+        assert_eq!(
+            ConfigFormat::detect(std::path::Path::new("looper")),
+            ConfigFormat::Toml
+        );
+    }
+
+    #[test]
+    fn yaml_parse_error_returns_invalid_argument() {
+        let file = write_temp_file(".yaml", "provider: [invalid yaml structure\n");
+        let err = LoopConfig::from_yaml_file(file.path()).unwrap_err();
+        assert!(err.to_string().contains("YAML parse error"));
+    }
+
+    #[test]
+    fn parse_yaml_with_orchestration() {
+        let file = write_temp_file(
+            ".yaml",
+            "provider: claude\niterations: 1\nlog_level: info\norchestration:\n  enabled: true\n  repo_owner: acme\n  repo_name: my-repo\n",
+        );
+        let config = LoopConfig::from_yaml_file(file.path()).unwrap();
+        assert!(config.orchestration.enabled);
+        assert_eq!(config.orchestration.repo_owner.as_deref(), Some("acme"));
+        assert_eq!(config.orchestration.repo_name.as_deref(), Some("my-repo"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -518,6 +518,17 @@ pub struct LoopConfig {
     /// metacharacters are not interpreted.
     #[serde(default)]
     pub provider_extra_args: Vec<String>,
+    /// Exit codes that are treated as permanent failures and never retried,
+    /// even when `max_retries > 0`.
+    ///
+    /// Use this to short-circuit retries for codes that indicate a
+    /// configuration or argument error rather than a transient fault.
+    /// Example values: `2` (bad CLI args), `126` (permission denied),
+    /// `127` (command not found from a shell wrapper).
+    ///
+    /// Default: empty — all non-zero exits are retried up to `max_retries`.
+    #[serde(default)]
+    pub non_retryable_exit_codes: Vec<i32>,
 }
 
 fn default_retry_backoff_ms() -> u64 {
@@ -551,6 +562,7 @@ impl Default for LoopConfig {
             telemetry: TelemetryConfig::default(),
             multi_repo: Vec::new(),
             provider_extra_args: Vec::new(),
+            non_retryable_exit_codes: Vec::new(),
         }
     }
 }
@@ -1556,9 +1568,41 @@ provider_extra_args = ["--model", "claude-opus-4-5"]
             "provider: codex\niterations: 1\nlog_level: info\nprovider_extra_args:\n  - --approval-mode\n  - full-auto\n",
         );
         let config = LoopConfig::from_yaml_file(file.path()).unwrap();
-        assert_eq!(
-            config.provider_extra_args,
-            ["--approval-mode", "full-auto"]
+        assert_eq!(config.provider_extra_args, ["--approval-mode", "full-auto"]);
+    }
+
+    // ── non_retryable_exit_codes ──────────────────────────────────────────────
+
+    #[test]
+    fn default_non_retryable_exit_codes_is_empty() {
+        let config = LoopConfig::default();
+        assert!(config.non_retryable_exit_codes.is_empty());
+    }
+
+    #[test]
+    fn parse_toml_non_retryable_exit_codes() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            r#"
+provider = "claude"
+iterations = 1
+log_level = "info"
+non_retryable_exit_codes = [2, 126, 127]
+"#
+        )
+        .unwrap();
+        let config = LoopConfig::from_toml_file(file.path()).unwrap();
+        assert_eq!(config.non_retryable_exit_codes, [2, 126, 127]);
+    }
+
+    #[test]
+    fn parse_yaml_non_retryable_exit_codes() {
+        let file = write_temp_file(
+            ".yaml",
+            "provider: claude\niterations: 1\nlog_level: info\nnon_retryable_exit_codes:\n  - 2\n  - 127\n",
         );
+        let config = LoopConfig::from_yaml_file(file.path()).unwrap();
+        assert_eq!(config.non_retryable_exit_codes, [2, 127]);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -619,6 +619,14 @@ impl LoopConfig {
                 ));
             }
         }
+        if let Some(path) = &self.prompt_file {
+            if !path.exists() {
+                return Err(LooperError::InvalidArgument(format!(
+                    "--prompt-file '{}' does not exist",
+                    path.display()
+                )));
+            }
+        }
         if let Some(cmd) = &self.on_complete {
             if cmd.trim().is_empty() {
                 return Err(LooperError::InvalidArgument(
@@ -685,6 +693,30 @@ mod tests {
             ..Default::default()
         };
         assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn prompt_file_pointing_to_missing_path_is_invalid() {
+        let config = LoopConfig {
+            prompt_file: Some("/nonexistent/path/to/prompt.md".into()),
+            ..Default::default()
+        };
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("does not exist"),
+            "expected 'does not exist' in error: {err}"
+        );
+    }
+
+    #[test]
+    fn prompt_file_pointing_to_existing_file_is_valid() {
+        let mut f = NamedTempFile::new().unwrap();
+        writeln!(f, "prompt content").unwrap();
+        let config = LoopConfig {
+            prompt_file: Some(f.path().to_path_buf()),
+            ..Default::default()
+        };
+        assert!(config.validate().is_ok());
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,4 +20,9 @@ pub enum LooperError {
 
     #[error("provider '{binary}' timed out after {timeout_secs}s")]
     ProviderTimeout { binary: String, timeout_secs: u64 },
+
+    #[error(
+        "executable '{binary}' is not in the provider allowlist; permitted binaries: {allowed}"
+    )]
+    DisallowedExecutable { binary: String, allowed: String },
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,4 +17,7 @@ pub enum LooperError {
         #[source]
         source: std::io::Error,
     },
+
+    #[error("provider '{binary}' timed out after {timeout_secs}s")]
+    ProviderTimeout { binary: String, timeout_secs: u64 },
 }

--- a/src/issue_tracker.rs
+++ b/src/issue_tracker.rs
@@ -1,0 +1,748 @@
+use serde::Deserialize;
+use std::process::Command;
+use std::sync::Mutex;
+use thiserror::Error;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/// Current open/closed state of an issue.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IssueState {
+    Open,
+    Closed,
+}
+
+/// A GitHub issue returned by the tracker.
+#[derive(Debug, Clone)]
+pub struct Issue {
+    pub id: u64,
+    pub number: u32,
+    pub title: String,
+    pub body: String,
+    pub state: IssueState,
+    pub labels: Vec<String>,
+    pub assignees: Vec<String>,
+    pub url: String,
+}
+
+/// Payload for creating a new issue.
+#[derive(Debug, Clone, Default)]
+pub struct IssueDraft {
+    pub title: String,
+    pub body: String,
+    pub labels: Vec<String>,
+    pub assignees: Vec<String>,
+}
+
+/// Filter criteria for listing issues.
+#[derive(Debug, Clone, Default)]
+pub struct IssueFilter {
+    pub state: Option<IssueState>,
+    pub labels: Vec<String>,
+    pub assignee: Option<String>,
+    pub search: Option<String>,
+}
+
+/// Reason an issue is being closed.
+#[derive(Debug, Clone)]
+pub enum CloseReason {
+    Completed,
+    NotPlanned,
+    Duplicate(u32),
+}
+
+// ── Error ─────────────────────────────────────────────────────────────────────
+
+/// Errors produced by any `IssueTracker` implementation.
+#[derive(Debug, Error)]
+pub enum IssueTrackerError {
+    #[error("authentication error: {0}")]
+    Auth(String),
+    #[error("resource not found: {0}")]
+    NotFound(String),
+    #[error("rate limited: {0}")]
+    RateLimited(String),
+    #[error("transport error: {0}")]
+    Transport(String),
+    #[error("validation error: {0}")]
+    Validation(String),
+}
+
+// ── Trait ─────────────────────────────────────────────────────────────────────
+
+/// Abstraction over issue-tracking systems (GitHub Issues, Jira, Linear, …).
+///
+/// All mutation operations must go through MCP-compliant paths in production
+/// use.  Implementations are responsible for honouring whatever auth and
+/// policy constraints apply to their backend.
+pub trait IssueTracker: Send + Sync {
+    fn list_open_issues(&self, filter: &IssueFilter) -> Result<Vec<Issue>, IssueTrackerError>;
+    fn get_issue(&self, number: u32) -> Result<Issue, IssueTrackerError>;
+    fn create_issue(&self, draft: IssueDraft) -> Result<Issue, IssueTrackerError>;
+    fn update_issue_body(&self, number: u32, body: &str) -> Result<(), IssueTrackerError>;
+    fn add_comment(&self, number: u32, body: &str) -> Result<(), IssueTrackerError>;
+    fn close_issue(&self, number: u32, reason: CloseReason) -> Result<(), IssueTrackerError>;
+    fn reopen_issue(&self, number: u32) -> Result<(), IssueTrackerError>;
+    /// Record an association between an issue and a pull request by posting a
+    /// cross-reference comment on the issue.
+    fn link_issue_to_pr(&self, issue_number: u32, pr_number: u32)
+        -> Result<(), IssueTrackerError>;
+}
+
+// ── GitHub CLI implementation ─────────────────────────────────────────────────
+
+/// Implements `IssueTracker` by shelling out to the `gh` CLI.
+///
+/// All write operations use `gh issue` sub-commands.  Authentication is
+/// handled by the developer's existing `gh auth` session — no tokens are
+/// handled directly by Code Looper.
+pub struct GitHubIssueTracker {
+    pub owner: String,
+    pub repo: String,
+}
+
+impl GitHubIssueTracker {
+    pub fn new(owner: impl Into<String>, repo: impl Into<String>) -> Self {
+        Self { owner: owner.into(), repo: repo.into() }
+    }
+
+    fn repo_slug(&self) -> String {
+        format!("{}/{}", self.owner, self.repo)
+    }
+
+    /// Run a `gh` command and return the raw output.
+    fn run_gh(&self, args: &[String]) -> Result<std::process::Output, IssueTrackerError> {
+        Command::new("gh")
+            .args(args)
+            .output()
+            .map_err(|e| IssueTrackerError::Transport(format!("failed to spawn gh: {e}")))
+    }
+
+    /// Unwrap command output into stdout text, mapping non-zero exits to errors.
+    fn check_output(
+        &self,
+        output: std::process::Output,
+        context: &str,
+    ) -> Result<String, IssueTrackerError> {
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            return Err(classify_gh_error(&stderr, context));
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    }
+}
+
+/// Map `gh` stderr to a typed `IssueTrackerError`.
+fn classify_gh_error(stderr: &str, context: &str) -> IssueTrackerError {
+    let lower = stderr.to_lowercase();
+    if lower.contains("authentication")
+        || lower.contains("401")
+        || lower.contains("credentials")
+        || lower.contains("auth")
+    {
+        IssueTrackerError::Auth(format!("{context}: {stderr}"))
+    } else if lower.contains("not found")
+        || lower.contains("404")
+        || lower.contains("no issue")
+        || lower.contains("could not resolve")
+    {
+        IssueTrackerError::NotFound(format!("{context}: {stderr}"))
+    } else if lower.contains("rate limit") || lower.contains("429") {
+        IssueTrackerError::RateLimited(format!("{context}: {stderr}"))
+    } else {
+        IssueTrackerError::Transport(format!("{context}: {stderr}"))
+    }
+}
+
+// Serde types matching `gh --json` output.
+#[derive(Deserialize)]
+struct GhIssue {
+    id: Option<u64>,
+    number: u32,
+    title: String,
+    body: Option<String>,
+    state: String,
+    labels: Vec<GhLabel>,
+    assignees: Vec<GhUser>,
+    url: String,
+}
+
+#[derive(Deserialize)]
+struct GhLabel {
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct GhUser {
+    login: String,
+}
+
+impl From<GhIssue> for Issue {
+    fn from(gh: GhIssue) -> Self {
+        Issue {
+            id: gh.id.unwrap_or(0),
+            number: gh.number,
+            title: gh.title,
+            body: gh.body.unwrap_or_default(),
+            state: if gh.state.eq_ignore_ascii_case("open") {
+                IssueState::Open
+            } else {
+                IssueState::Closed
+            },
+            labels: gh.labels.into_iter().map(|l| l.name).collect(),
+            assignees: gh.assignees.into_iter().map(|a| a.login).collect(),
+            url: gh.url,
+        }
+    }
+}
+
+const JSON_FIELDS: &str = "id,number,title,body,state,labels,assignees,url";
+
+impl IssueTracker for GitHubIssueTracker {
+    fn list_open_issues(&self, filter: &IssueFilter) -> Result<Vec<Issue>, IssueTrackerError> {
+        let slug = self.repo_slug();
+        let mut args = vec![
+            "issue".to_string(),
+            "list".to_string(),
+            "--repo".to_string(),
+            slug,
+            "--state".to_string(),
+            "open".to_string(),
+            "--json".to_string(),
+            JSON_FIELDS.to_string(),
+        ];
+        if !filter.labels.is_empty() {
+            args.push("--label".to_string());
+            args.push(filter.labels.join(","));
+        }
+        if let Some(ref assignee) = filter.assignee {
+            args.push("--assignee".to_string());
+            args.push(assignee.clone());
+        }
+        if let Some(ref q) = filter.search {
+            args.push("--search".to_string());
+            args.push(q.clone());
+        }
+        let output = self.run_gh(&args)?;
+        let stdout = self.check_output(output, "list_open_issues")?;
+        let gh_issues: Vec<GhIssue> = serde_json::from_str(&stdout).map_err(|e| {
+            IssueTrackerError::Transport(format!("failed to parse list output: {e}"))
+        })?;
+        Ok(gh_issues.into_iter().map(Issue::from).collect())
+    }
+
+    fn get_issue(&self, number: u32) -> Result<Issue, IssueTrackerError> {
+        let slug = self.repo_slug();
+        let args = vec![
+            "issue".to_string(),
+            "view".to_string(),
+            number.to_string(),
+            "--repo".to_string(),
+            slug,
+            "--json".to_string(),
+            JSON_FIELDS.to_string(),
+        ];
+        let output = self.run_gh(&args)?;
+        let stdout = self.check_output(output, "get_issue")?;
+        let gh_issue: GhIssue = serde_json::from_str(&stdout).map_err(|e| {
+            IssueTrackerError::Transport(format!("failed to parse issue view output: {e}"))
+        })?;
+        Ok(Issue::from(gh_issue))
+    }
+
+    fn create_issue(&self, draft: IssueDraft) -> Result<Issue, IssueTrackerError> {
+        if draft.title.trim().is_empty() {
+            return Err(IssueTrackerError::Validation(
+                "issue title must not be empty".to_string(),
+            ));
+        }
+        let slug = self.repo_slug();
+        let mut args = vec![
+            "issue".to_string(),
+            "create".to_string(),
+            "--repo".to_string(),
+            slug,
+            "--title".to_string(),
+            draft.title.clone(),
+            "--body".to_string(),
+            draft.body.clone(),
+            "--json".to_string(),
+            JSON_FIELDS.to_string(),
+        ];
+        if !draft.labels.is_empty() {
+            args.push("--label".to_string());
+            args.push(draft.labels.join(","));
+        }
+        if !draft.assignees.is_empty() {
+            args.push("--assignee".to_string());
+            args.push(draft.assignees.join(","));
+        }
+        let output = self.run_gh(&args)?;
+        let stdout = self.check_output(output, "create_issue")?;
+        let gh_issue: GhIssue = serde_json::from_str(&stdout).map_err(|e| {
+            IssueTrackerError::Transport(format!("failed to parse create output: {e}"))
+        })?;
+        Ok(Issue::from(gh_issue))
+    }
+
+    fn update_issue_body(&self, number: u32, body: &str) -> Result<(), IssueTrackerError> {
+        let slug = self.repo_slug();
+        let args = vec![
+            "issue".to_string(),
+            "edit".to_string(),
+            number.to_string(),
+            "--repo".to_string(),
+            slug,
+            "--body".to_string(),
+            body.to_string(),
+        ];
+        let output = self.run_gh(&args)?;
+        self.check_output(output, "update_issue_body")?;
+        Ok(())
+    }
+
+    fn add_comment(&self, number: u32, body: &str) -> Result<(), IssueTrackerError> {
+        let slug = self.repo_slug();
+        let args = vec![
+            "issue".to_string(),
+            "comment".to_string(),
+            number.to_string(),
+            "--repo".to_string(),
+            slug,
+            "--body".to_string(),
+            body.to_string(),
+        ];
+        let output = self.run_gh(&args)?;
+        self.check_output(output, "add_comment")?;
+        Ok(())
+    }
+
+    fn close_issue(&self, number: u32, reason: CloseReason) -> Result<(), IssueTrackerError> {
+        let slug = self.repo_slug();
+        let reason_str = match reason {
+            CloseReason::Completed => "completed",
+            CloseReason::NotPlanned | CloseReason::Duplicate(_) => "not planned",
+        };
+        let args = vec![
+            "issue".to_string(),
+            "close".to_string(),
+            number.to_string(),
+            "--repo".to_string(),
+            slug,
+            "--reason".to_string(),
+            reason_str.to_string(),
+        ];
+        let output = self.run_gh(&args)?;
+        self.check_output(output, "close_issue")?;
+        Ok(())
+    }
+
+    fn reopen_issue(&self, number: u32) -> Result<(), IssueTrackerError> {
+        let slug = self.repo_slug();
+        let args = vec![
+            "issue".to_string(),
+            "reopen".to_string(),
+            number.to_string(),
+            "--repo".to_string(),
+            slug,
+        ];
+        let output = self.run_gh(&args)?;
+        self.check_output(output, "reopen_issue")?;
+        Ok(())
+    }
+
+    fn link_issue_to_pr(
+        &self,
+        issue_number: u32,
+        pr_number: u32,
+    ) -> Result<(), IssueTrackerError> {
+        let body = format!("Linked to pull request #{pr_number}.");
+        self.add_comment(issue_number, &body)
+    }
+}
+
+// ── MockIssueTracker ──────────────────────────────────────────────────────────
+
+/// Test double that records every call made to it.
+///
+/// By default, read methods return empty collections and write methods
+/// succeed.  Override `next_issue` to control what `get_issue` and
+/// `create_issue` return.
+pub struct MockIssueTracker {
+    /// Calls recorded in order: (method_name, args…).
+    pub calls: Mutex<Vec<MockCall>>,
+    /// Optional issue returned by `get_issue` and `create_issue`.
+    pub next_issue: Mutex<Option<Issue>>,
+    /// If set, every method returns this error.
+    pub force_error: Option<IssueTrackerError>,
+}
+
+#[derive(Debug, Clone)]
+pub enum MockCall {
+    ListOpenIssues,
+    GetIssue(u32),
+    CreateIssue { title: String, body: String },
+    UpdateIssueBody { number: u32 },
+    AddComment { number: u32, body: String },
+    CloseIssue(u32),
+    ReopenIssue(u32),
+    LinkIssueToPr { issue_number: u32, pr_number: u32 },
+}
+
+impl MockIssueTracker {
+    pub fn new() -> Self {
+        Self {
+            calls: Mutex::new(Vec::new()),
+            next_issue: Mutex::new(None),
+            force_error: None,
+        }
+    }
+
+    /// Return a reference to the recorded calls.
+    pub fn recorded_calls(&self) -> Vec<MockCall> {
+        self.calls.lock().unwrap().clone()
+    }
+
+    fn check_force_error(&self) -> Option<IssueTrackerError> {
+        match &self.force_error {
+            Some(IssueTrackerError::Auth(m)) => Some(IssueTrackerError::Auth(m.clone())),
+            Some(IssueTrackerError::NotFound(m)) => Some(IssueTrackerError::NotFound(m.clone())),
+            Some(IssueTrackerError::RateLimited(m)) => {
+                Some(IssueTrackerError::RateLimited(m.clone()))
+            }
+            Some(IssueTrackerError::Transport(m)) => {
+                Some(IssueTrackerError::Transport(m.clone()))
+            }
+            Some(IssueTrackerError::Validation(m)) => {
+                Some(IssueTrackerError::Validation(m.clone()))
+            }
+            None => None,
+        }
+    }
+
+    fn default_issue() -> Issue {
+        Issue {
+            id: 1,
+            number: 1,
+            title: "mock issue".to_string(),
+            body: String::new(),
+            state: IssueState::Open,
+            labels: vec![],
+            assignees: vec![],
+            url: "https://github.com/mock/repo/issues/1".to_string(),
+        }
+    }
+}
+
+impl Default for MockIssueTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IssueTracker for MockIssueTracker {
+    fn list_open_issues(&self, _filter: &IssueFilter) -> Result<Vec<Issue>, IssueTrackerError> {
+        self.calls.lock().unwrap().push(MockCall::ListOpenIssues);
+        if let Some(e) = self.check_force_error() {
+            return Err(e);
+        }
+        Ok(vec![])
+    }
+
+    fn get_issue(&self, number: u32) -> Result<Issue, IssueTrackerError> {
+        self.calls.lock().unwrap().push(MockCall::GetIssue(number));
+        if let Some(e) = self.check_force_error() {
+            return Err(e);
+        }
+        let issue = self
+            .next_issue
+            .lock()
+            .unwrap()
+            .clone()
+            .unwrap_or_else(Self::default_issue);
+        Ok(issue)
+    }
+
+    fn create_issue(&self, draft: IssueDraft) -> Result<Issue, IssueTrackerError> {
+        self.calls.lock().unwrap().push(MockCall::CreateIssue {
+            title: draft.title.clone(),
+            body: draft.body.clone(),
+        });
+        if let Some(e) = self.check_force_error() {
+            return Err(e);
+        }
+        let mut issue = self
+            .next_issue
+            .lock()
+            .unwrap()
+            .clone()
+            .unwrap_or_else(Self::default_issue);
+        issue.title = draft.title;
+        issue.body = draft.body;
+        Ok(issue)
+    }
+
+    fn update_issue_body(&self, number: u32, _body: &str) -> Result<(), IssueTrackerError> {
+        self.calls.lock().unwrap().push(MockCall::UpdateIssueBody { number });
+        if let Some(e) = self.check_force_error() {
+            return Err(e);
+        }
+        Ok(())
+    }
+
+    fn add_comment(&self, number: u32, body: &str) -> Result<(), IssueTrackerError> {
+        self.calls.lock().unwrap().push(MockCall::AddComment {
+            number,
+            body: body.to_string(),
+        });
+        if let Some(e) = self.check_force_error() {
+            return Err(e);
+        }
+        Ok(())
+    }
+
+    fn close_issue(&self, number: u32, _reason: CloseReason) -> Result<(), IssueTrackerError> {
+        self.calls.lock().unwrap().push(MockCall::CloseIssue(number));
+        if let Some(e) = self.check_force_error() {
+            return Err(e);
+        }
+        Ok(())
+    }
+
+    fn reopen_issue(&self, number: u32) -> Result<(), IssueTrackerError> {
+        self.calls.lock().unwrap().push(MockCall::ReopenIssue(number));
+        if let Some(e) = self.check_force_error() {
+            return Err(e);
+        }
+        Ok(())
+    }
+
+    fn link_issue_to_pr(
+        &self,
+        issue_number: u32,
+        pr_number: u32,
+    ) -> Result<(), IssueTrackerError> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push(MockCall::LinkIssueToPr { issue_number, pr_number });
+        if let Some(e) = self.check_force_error() {
+            return Err(e);
+        }
+        Ok(())
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── MockIssueTracker tests ────────────────────────────────────────────────
+
+    #[test]
+    fn mock_records_list_call() {
+        let tracker = MockIssueTracker::new();
+        let result = tracker.list_open_issues(&IssueFilter::default()).unwrap();
+        assert!(result.is_empty());
+        let calls = tracker.recorded_calls();
+        assert_eq!(calls.len(), 1);
+        assert!(matches!(calls[0], MockCall::ListOpenIssues));
+    }
+
+    #[test]
+    fn mock_records_get_issue_call() {
+        let tracker = MockIssueTracker::new();
+        let issue = tracker.get_issue(42).unwrap();
+        assert_eq!(issue.id, 1); // default issue
+        let calls = tracker.recorded_calls();
+        assert!(matches!(calls[0], MockCall::GetIssue(42)));
+    }
+
+    #[test]
+    fn mock_returns_configured_next_issue() {
+        let tracker = MockIssueTracker::new();
+        *tracker.next_issue.lock().unwrap() = Some(Issue {
+            id: 99,
+            number: 7,
+            title: "custom".to_string(),
+            body: "body text".to_string(),
+            state: IssueState::Open,
+            labels: vec!["bug".to_string()],
+            assignees: vec![],
+            url: "https://example.com/7".to_string(),
+        });
+        let issue = tracker.get_issue(7).unwrap();
+        assert_eq!(issue.id, 99);
+        assert_eq!(issue.number, 7);
+        assert_eq!(issue.title, "custom");
+        assert_eq!(issue.labels, vec!["bug"]);
+    }
+
+    #[test]
+    fn mock_create_issue_applies_title_and_body() {
+        let tracker = MockIssueTracker::new();
+        let draft = IssueDraft {
+            title: "Fix the thing".to_string(),
+            body: "Here is why".to_string(),
+            ..Default::default()
+        };
+        let issue = tracker.create_issue(draft).unwrap();
+        assert_eq!(issue.title, "Fix the thing");
+        assert_eq!(issue.body, "Here is why");
+        let calls = tracker.recorded_calls();
+        assert!(matches!(&calls[0], MockCall::CreateIssue { title, .. } if title == "Fix the thing"));
+    }
+
+    #[test]
+    fn mock_records_add_comment() {
+        let tracker = MockIssueTracker::new();
+        tracker.add_comment(5, "hello world").unwrap();
+        let calls = tracker.recorded_calls();
+        assert!(
+            matches!(&calls[0], MockCall::AddComment { number: 5, body } if body == "hello world")
+        );
+    }
+
+    #[test]
+    fn mock_records_close_issue() {
+        let tracker = MockIssueTracker::new();
+        tracker.close_issue(3, CloseReason::Completed).unwrap();
+        assert!(matches!(tracker.recorded_calls()[0], MockCall::CloseIssue(3)));
+    }
+
+    #[test]
+    fn mock_records_reopen_issue() {
+        let tracker = MockIssueTracker::new();
+        tracker.reopen_issue(8).unwrap();
+        assert!(matches!(tracker.recorded_calls()[0], MockCall::ReopenIssue(8)));
+    }
+
+    #[test]
+    fn mock_records_link_issue_to_pr() {
+        let tracker = MockIssueTracker::new();
+        tracker.link_issue_to_pr(10, 55).unwrap();
+        let calls = tracker.recorded_calls();
+        assert!(
+            matches!(&calls[0], MockCall::LinkIssueToPr { issue_number: 10, pr_number: 55 })
+        );
+    }
+
+    #[test]
+    fn mock_link_issue_to_pr_also_records_add_comment() {
+        // link_issue_to_pr is implemented as add_comment, so both MockCall
+        // variants should appear: LinkIssueToPr (this trait method) and
+        // AddComment (the internal call it delegates to in a real impl).
+        // With MockIssueTracker, link_issue_to_pr is its own path, so only
+        // one call is recorded.
+        let tracker = MockIssueTracker::new();
+        tracker.link_issue_to_pr(1, 2).unwrap();
+        assert_eq!(tracker.recorded_calls().len(), 1);
+    }
+
+    #[test]
+    fn mock_propagates_force_error() {
+        let mut tracker = MockIssueTracker::new();
+        tracker.force_error =
+            Some(IssueTrackerError::Auth("token expired".to_string()));
+        let err = tracker.list_open_issues(&IssueFilter::default()).unwrap_err();
+        assert!(matches!(err, IssueTrackerError::Auth(_)));
+    }
+
+    #[test]
+    fn mock_update_issue_body_records_number() {
+        let tracker = MockIssueTracker::new();
+        tracker.update_issue_body(12, "new body").unwrap();
+        assert!(matches!(tracker.recorded_calls()[0], MockCall::UpdateIssueBody { number: 12 }));
+    }
+
+    // ── classify_gh_error tests ───────────────────────────────────────────────
+
+    #[test]
+    fn classify_auth_error() {
+        let e = classify_gh_error("HTTP 401 Unauthorized: bad credentials", "test");
+        assert!(matches!(e, IssueTrackerError::Auth(_)));
+    }
+
+    #[test]
+    fn classify_not_found_error() {
+        let e = classify_gh_error("Could not resolve to an Issue with the title 'foo'", "test");
+        assert!(matches!(e, IssueTrackerError::NotFound(_)));
+    }
+
+    #[test]
+    fn classify_rate_limited_error() {
+        let e = classify_gh_error("rate limit exceeded (429)", "test");
+        assert!(matches!(e, IssueTrackerError::RateLimited(_)));
+    }
+
+    #[test]
+    fn classify_transport_for_unknown_error() {
+        let e = classify_gh_error("something went wrong with the network", "test");
+        assert!(matches!(e, IssueTrackerError::Transport(_)));
+    }
+
+    // ── GitHubIssueTracker unit tests (no network) ───────────────────────────
+
+    #[test]
+    fn github_tracker_validate_empty_title() {
+        let tracker = GitHubIssueTracker::new("owner", "repo");
+        let err = tracker
+            .create_issue(IssueDraft { title: "  ".to_string(), ..Default::default() })
+            .unwrap_err();
+        assert!(matches!(err, IssueTrackerError::Validation(_)));
+    }
+
+    #[test]
+    fn gh_issue_deserialize_from_json() {
+        let json = r#"{
+            "id": 12345,
+            "number": 7,
+            "title": "Test issue",
+            "body": "The body",
+            "state": "OPEN",
+            "labels": [{"name": "bug"}, {"name": "help wanted"}],
+            "assignees": [{"login": "alice"}],
+            "url": "https://github.com/owner/repo/issues/7"
+        }"#;
+        let gh: GhIssue = serde_json::from_str(json).unwrap();
+        let issue = Issue::from(gh);
+        assert_eq!(issue.number, 7);
+        assert_eq!(issue.title, "Test issue");
+        assert_eq!(issue.state, IssueState::Open);
+        assert_eq!(issue.labels, vec!["bug", "help wanted"]);
+        assert_eq!(issue.assignees, vec!["alice"]);
+    }
+
+    #[test]
+    fn gh_issue_closed_state() {
+        let json = r#"{
+            "number": 1, "title": "t", "body": null,
+            "state": "closed",
+            "labels": [], "assignees": [],
+            "url": "https://github.com/o/r/issues/1"
+        }"#;
+        let gh: GhIssue = serde_json::from_str(json).unwrap();
+        let issue = Issue::from(gh);
+        assert_eq!(issue.state, IssueState::Closed);
+    }
+
+    #[test]
+    fn issue_draft_default_is_empty() {
+        let d = IssueDraft::default();
+        assert!(d.title.is_empty());
+        assert!(d.body.is_empty());
+        assert!(d.labels.is_empty());
+        assert!(d.assignees.is_empty());
+    }
+
+    #[test]
+    fn issue_filter_default_is_empty() {
+        let f = IssueFilter::default();
+        assert!(f.state.is_none());
+        assert!(f.labels.is_empty());
+        assert!(f.assignee.is_none());
+        assert!(f.search.is_none());
+    }
+}

--- a/src/issue_tracker.rs
+++ b/src/issue_tracker.rs
@@ -361,6 +361,172 @@ impl IssueTracker for GitHubIssueTracker {
     }
 }
 
+// ── LocalPromiseTracker ───────────────────────────────────────────────────────
+
+/// Dev/debug-only tracker that writes to a single markdown file.
+///
+/// Each "issue" is a heading (`## #<number> <title>`) with a body block and
+/// an appended log of timestamped comments.  Intended for offline
+/// experimentation — **not** for production use.
+///
+/// The file is created (including parent directories) on first write if it
+/// does not already exist.
+pub struct LocalPromiseTracker {
+    pub path: std::path::PathBuf,
+    inner: Mutex<LocalStore>,
+}
+
+struct LocalStore {
+    /// In-memory issues indexed by number.
+    issues: std::collections::HashMap<u32, Issue>,
+    /// Monotonically increasing counter for new issue numbers.
+    next_number: u32,
+}
+
+impl LocalPromiseTracker {
+    pub fn new(path: impl Into<std::path::PathBuf>) -> Self {
+        Self {
+            path: path.into(),
+            inner: Mutex::new(LocalStore {
+                issues: std::collections::HashMap::new(),
+                next_number: 1,
+            }),
+        }
+    }
+
+    /// Persist the entire store to the markdown file.
+    fn flush(&self, store: &LocalStore) -> Result<(), IssueTrackerError> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| IssueTrackerError::Transport(format!("create_dir_all: {e}")))?;
+        }
+        let mut out = String::new();
+        out.push_str("<!-- LocalPromiseTracker — dev/debug only -->\n\n");
+        let mut numbers: Vec<u32> = store.issues.keys().copied().collect();
+        numbers.sort_unstable();
+        for n in numbers {
+            let issue = &store.issues[&n];
+            let state_tag = if issue.state == IssueState::Open { "OPEN" } else { "CLOSED" };
+            out.push_str(&format!("## #{n} {title} [{state_tag}]\n\n", title = issue.title));
+            if !issue.body.is_empty() {
+                out.push_str(&issue.body);
+                out.push_str("\n\n");
+            }
+        }
+        std::fs::write(&self.path, out)
+            .map_err(|e| IssueTrackerError::Transport(format!("write promise file: {e}")))?;
+        Ok(())
+    }
+}
+
+impl IssueTracker for LocalPromiseTracker {
+    fn list_open_issues(&self, filter: &IssueFilter) -> Result<Vec<Issue>, IssueTrackerError> {
+        let store = self.inner.lock().unwrap();
+        let issues: Vec<Issue> = store
+            .issues
+            .values()
+            .filter(|i| i.state == IssueState::Open)
+            .filter(|i| {
+                filter.labels.is_empty()
+                    || filter.labels.iter().any(|l| i.labels.contains(l))
+            })
+            .filter(|i| {
+                filter
+                    .assignee
+                    .as_deref()
+                    .map_or(true, |a| i.assignees.contains(&a.to_string()))
+            })
+            .filter(|i| {
+                filter
+                    .search
+                    .as_deref()
+                    .map_or(true, |q| i.title.contains(q) || i.body.contains(q))
+            })
+            .cloned()
+            .collect();
+        Ok(issues)
+    }
+
+    fn get_issue(&self, number: u32) -> Result<Issue, IssueTrackerError> {
+        let store = self.inner.lock().unwrap();
+        store
+            .issues
+            .get(&number)
+            .cloned()
+            .ok_or_else(|| IssueTrackerError::NotFound(format!("issue #{number} not found")))
+    }
+
+    fn create_issue(&self, draft: IssueDraft) -> Result<Issue, IssueTrackerError> {
+        if draft.title.trim().is_empty() {
+            return Err(IssueTrackerError::Validation(
+                "issue title must not be empty".to_string(),
+            ));
+        }
+        let mut store = self.inner.lock().unwrap();
+        let number = store.next_number;
+        store.next_number += 1;
+        let issue = Issue {
+            id: number as u64,
+            number,
+            title: draft.title,
+            body: draft.body,
+            state: IssueState::Open,
+            labels: draft.labels,
+            assignees: draft.assignees,
+            url: format!("local://issues/{number}"),
+        };
+        store.issues.insert(number, issue.clone());
+        self.flush(&store)?;
+        Ok(issue)
+    }
+
+    fn update_issue_body(&self, number: u32, body: &str) -> Result<(), IssueTrackerError> {
+        let mut store = self.inner.lock().unwrap();
+        let issue = store
+            .issues
+            .get_mut(&number)
+            .ok_or_else(|| IssueTrackerError::NotFound(format!("issue #{number} not found")))?;
+        issue.body = body.to_string();
+        self.flush(&store)
+    }
+
+    fn add_comment(&self, number: u32, body: &str) -> Result<(), IssueTrackerError> {
+        let mut store = self.inner.lock().unwrap();
+        let issue = store
+            .issues
+            .get_mut(&number)
+            .ok_or_else(|| IssueTrackerError::NotFound(format!("issue #{number} not found")))?;
+        // Append comment as a timestamped log entry in the body.
+        let entry = format!("\n---\n> {body}\n");
+        issue.body.push_str(&entry);
+        self.flush(&store)
+    }
+
+    fn close_issue(&self, number: u32, _reason: CloseReason) -> Result<(), IssueTrackerError> {
+        let mut store = self.inner.lock().unwrap();
+        let issue = store
+            .issues
+            .get_mut(&number)
+            .ok_or_else(|| IssueTrackerError::NotFound(format!("issue #{number} not found")))?;
+        issue.state = IssueState::Closed;
+        self.flush(&store)
+    }
+
+    fn reopen_issue(&self, number: u32) -> Result<(), IssueTrackerError> {
+        let mut store = self.inner.lock().unwrap();
+        let issue = store
+            .issues
+            .get_mut(&number)
+            .ok_or_else(|| IssueTrackerError::NotFound(format!("issue #{number} not found")))?;
+        issue.state = IssueState::Open;
+        self.flush(&store)
+    }
+
+    fn link_issue_to_pr(&self, issue_number: u32, pr_number: u32) -> Result<(), IssueTrackerError> {
+        self.add_comment(issue_number, &format!("Linked to pull request #{pr_number}."))
+    }
+}
+
 // ── MockIssueTracker ──────────────────────────────────────────────────────────
 
 /// Test double that records every call made to it.
@@ -744,5 +910,137 @@ mod tests {
         assert!(f.labels.is_empty());
         assert!(f.assignee.is_none());
         assert!(f.search.is_none());
+    }
+
+    // ── LocalPromiseTracker tests ─────────────────────────────────────────────
+
+    fn temp_tracker() -> LocalPromiseTracker {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("promise.md");
+        // Leak the TempDir so the file persists for the test.
+        std::mem::forget(dir);
+        LocalPromiseTracker::new(path)
+    }
+
+    #[test]
+    fn local_tracker_create_and_get() {
+        let tracker = temp_tracker();
+        let issue = tracker
+            .create_issue(IssueDraft {
+                title: "My task".to_string(),
+                body: "details".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(issue.number, 1);
+        assert_eq!(issue.title, "My task");
+        assert_eq!(issue.state, IssueState::Open);
+
+        let fetched = tracker.get_issue(1).unwrap();
+        assert_eq!(fetched.title, "My task");
+    }
+
+    #[test]
+    fn local_tracker_not_found() {
+        let tracker = temp_tracker();
+        let err = tracker.get_issue(99).unwrap_err();
+        assert!(matches!(err, IssueTrackerError::NotFound(_)));
+    }
+
+    #[test]
+    fn local_tracker_list_open() {
+        let tracker = temp_tracker();
+        tracker
+            .create_issue(IssueDraft { title: "A".to_string(), ..Default::default() })
+            .unwrap();
+        tracker
+            .create_issue(IssueDraft { title: "B".to_string(), ..Default::default() })
+            .unwrap();
+        tracker.close_issue(1, CloseReason::Completed).unwrap();
+
+        let open = tracker.list_open_issues(&IssueFilter::default()).unwrap();
+        assert_eq!(open.len(), 1);
+        assert_eq!(open[0].title, "B");
+    }
+
+    #[test]
+    fn local_tracker_update_body() {
+        let tracker = temp_tracker();
+        tracker
+            .create_issue(IssueDraft { title: "T".to_string(), ..Default::default() })
+            .unwrap();
+        tracker.update_issue_body(1, "updated body").unwrap();
+        let issue = tracker.get_issue(1).unwrap();
+        assert_eq!(issue.body, "updated body");
+    }
+
+    #[test]
+    fn local_tracker_add_comment_appends_to_body() {
+        let tracker = temp_tracker();
+        tracker
+            .create_issue(IssueDraft { title: "T".to_string(), body: "original".to_string(), ..Default::default() })
+            .unwrap();
+        tracker.add_comment(1, "a comment").unwrap();
+        let issue = tracker.get_issue(1).unwrap();
+        assert!(issue.body.contains("a comment"));
+    }
+
+    #[test]
+    fn local_tracker_close_and_reopen() {
+        let tracker = temp_tracker();
+        tracker
+            .create_issue(IssueDraft { title: "T".to_string(), ..Default::default() })
+            .unwrap();
+        tracker.close_issue(1, CloseReason::Completed).unwrap();
+        assert_eq!(tracker.get_issue(1).unwrap().state, IssueState::Closed);
+        tracker.reopen_issue(1).unwrap();
+        assert_eq!(tracker.get_issue(1).unwrap().state, IssueState::Open);
+    }
+
+    #[test]
+    fn local_tracker_link_pr_adds_comment() {
+        let tracker = temp_tracker();
+        tracker
+            .create_issue(IssueDraft { title: "T".to_string(), ..Default::default() })
+            .unwrap();
+        tracker.link_issue_to_pr(1, 42).unwrap();
+        let issue = tracker.get_issue(1).unwrap();
+        assert!(issue.body.contains("42"));
+    }
+
+    #[test]
+    fn local_tracker_empty_title_rejected() {
+        let tracker = temp_tracker();
+        let err = tracker
+            .create_issue(IssueDraft { title: "".to_string(), ..Default::default() })
+            .unwrap_err();
+        assert!(matches!(err, IssueTrackerError::Validation(_)));
+    }
+
+    #[test]
+    fn local_tracker_creates_parent_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("deep").join("promise.md");
+        let tracker = LocalPromiseTracker::new(&path);
+        tracker
+            .create_issue(IssueDraft { title: "dir test".to_string(), ..Default::default() })
+            .unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn local_tracker_search_filter() {
+        let tracker = temp_tracker();
+        tracker
+            .create_issue(IssueDraft { title: "fix login bug".to_string(), ..Default::default() })
+            .unwrap();
+        tracker
+            .create_issue(IssueDraft { title: "update docs".to_string(), ..Default::default() })
+            .unwrap();
+        let results = tracker
+            .list_open_issues(&IssueFilter { search: Some("login".to_string()), ..Default::default() })
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "fix login bug");
     }
 }

--- a/src/issue_tracker.rs
+++ b/src/issue_tracker.rs
@@ -699,6 +699,44 @@ impl IssueTracker for MockIssueTracker {
     }
 }
 
+// ── SharedMockIssueTracker ────────────────────────────────────────────────────
+
+/// Thin newtype that lets tests hold an `Arc<MockIssueTracker>` while also
+/// giving the engine ownership of a `Box<dyn IssueTracker>`.
+///
+/// Only compiled in `#[cfg(test)]` because it's a test utility, not production
+/// code.
+#[cfg(test)]
+pub struct SharedMockIssueTracker(pub std::sync::Arc<MockIssueTracker>);
+
+#[cfg(test)]
+impl IssueTracker for SharedMockIssueTracker {
+    fn list_open_issues(&self, f: &IssueFilter) -> Result<Vec<Issue>, IssueTrackerError> {
+        self.0.list_open_issues(f)
+    }
+    fn get_issue(&self, n: u32) -> Result<Issue, IssueTrackerError> {
+        self.0.get_issue(n)
+    }
+    fn create_issue(&self, d: IssueDraft) -> Result<Issue, IssueTrackerError> {
+        self.0.create_issue(d)
+    }
+    fn update_issue_body(&self, n: u32, b: &str) -> Result<(), IssueTrackerError> {
+        self.0.update_issue_body(n, b)
+    }
+    fn add_comment(&self, n: u32, b: &str) -> Result<(), IssueTrackerError> {
+        self.0.add_comment(n, b)
+    }
+    fn close_issue(&self, n: u32, r: CloseReason) -> Result<(), IssueTrackerError> {
+        self.0.close_issue(n, r)
+    }
+    fn reopen_issue(&self, n: u32) -> Result<(), IssueTrackerError> {
+        self.0.reopen_issue(n)
+    }
+    fn link_issue_to_pr(&self, issue: u32, pr: u32) -> Result<(), IssueTrackerError> {
+        self.0.link_issue_to_pr(issue, pr)
+    }
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]

--- a/src/issue_tracker.rs
+++ b/src/issue_tracker.rs
@@ -91,8 +91,7 @@ pub trait IssueTracker: Send + Sync {
     fn reopen_issue(&self, number: u32) -> Result<(), IssueTrackerError>;
     /// Record an association between an issue and a pull request by posting a
     /// cross-reference comment on the issue.
-    fn link_issue_to_pr(&self, issue_number: u32, pr_number: u32)
-        -> Result<(), IssueTrackerError>;
+    fn link_issue_to_pr(&self, issue_number: u32, pr_number: u32) -> Result<(), IssueTrackerError>;
     /// Ensure that the given labels exist on the repository, creating any that
     /// are absent.  This is a no-op for backends that do not support label
     /// management (e.g. `LocalPromiseTracker`).
@@ -116,7 +115,10 @@ pub struct GitHubIssueTracker {
 
 impl GitHubIssueTracker {
     pub fn new(owner: impl Into<String>, repo: impl Into<String>) -> Self {
-        Self { owner: owner.into(), repo: repo.into() }
+        Self {
+            owner: owner.into(),
+            repo: repo.into(),
+        }
     }
 
     fn repo_slug(&self) -> String {
@@ -364,11 +366,7 @@ impl IssueTracker for GitHubIssueTracker {
         Ok(())
     }
 
-    fn link_issue_to_pr(
-        &self,
-        issue_number: u32,
-        pr_number: u32,
-    ) -> Result<(), IssueTrackerError> {
+    fn link_issue_to_pr(&self, issue_number: u32, pr_number: u32) -> Result<(), IssueTrackerError> {
         let body = format!("Linked to pull request #{pr_number}.");
         self.add_comment(issue_number, &body)
     }
@@ -442,8 +440,15 @@ impl LocalPromiseTracker {
         numbers.sort_unstable();
         for n in numbers {
             let issue = &store.issues[&n];
-            let state_tag = if issue.state == IssueState::Open { "OPEN" } else { "CLOSED" };
-            out.push_str(&format!("## #{n} {title} [{state_tag}]\n\n", title = issue.title));
+            let state_tag = if issue.state == IssueState::Open {
+                "OPEN"
+            } else {
+                "CLOSED"
+            };
+            out.push_str(&format!(
+                "## #{n} {title} [{state_tag}]\n\n",
+                title = issue.title
+            ));
             if !issue.body.is_empty() {
                 out.push_str(&issue.body);
                 out.push_str("\n\n");
@@ -463,8 +468,7 @@ impl IssueTracker for LocalPromiseTracker {
             .values()
             .filter(|i| i.state == IssueState::Open)
             .filter(|i| {
-                filter.labels.is_empty()
-                    || filter.labels.iter().any(|l| i.labels.contains(l))
+                filter.labels.is_empty() || filter.labels.iter().any(|l| i.labels.contains(l))
             })
             .filter(|i| {
                 filter
@@ -559,7 +563,10 @@ impl IssueTracker for LocalPromiseTracker {
     }
 
     fn link_issue_to_pr(&self, issue_number: u32, pr_number: u32) -> Result<(), IssueTrackerError> {
-        self.add_comment(issue_number, &format!("Linked to pull request #{pr_number}."))
+        self.add_comment(
+            issue_number,
+            &format!("Linked to pull request #{pr_number}."),
+        )
     }
 }
 
@@ -585,12 +592,24 @@ pub struct MockIssueTracker {
 pub enum MockCall {
     ListOpenIssues,
     GetIssue(u32),
-    CreateIssue { title: String, body: String },
-    UpdateIssueBody { number: u32 },
-    AddComment { number: u32, body: String },
+    CreateIssue {
+        title: String,
+        #[allow(dead_code)]
+        body: String,
+    },
+    UpdateIssueBody {
+        number: u32,
+    },
+    AddComment {
+        number: u32,
+        body: String,
+    },
     CloseIssue(u32),
     ReopenIssue(u32),
-    LinkIssueToPr { issue_number: u32, pr_number: u32 },
+    LinkIssueToPr {
+        issue_number: u32,
+        pr_number: u32,
+    },
     EnsureLabels(Vec<String>),
 }
 
@@ -616,9 +635,7 @@ impl MockIssueTracker {
             Some(IssueTrackerError::RateLimited(m)) => {
                 Some(IssueTrackerError::RateLimited(m.clone()))
             }
-            Some(IssueTrackerError::Transport(m)) => {
-                Some(IssueTrackerError::Transport(m.clone()))
-            }
+            Some(IssueTrackerError::Transport(m)) => Some(IssueTrackerError::Transport(m.clone())),
             Some(IssueTrackerError::Validation(m)) => {
                 Some(IssueTrackerError::Validation(m.clone()))
             }
@@ -691,7 +708,10 @@ impl IssueTracker for MockIssueTracker {
     }
 
     fn update_issue_body(&self, number: u32, _body: &str) -> Result<(), IssueTrackerError> {
-        self.calls.lock().unwrap().push(MockCall::UpdateIssueBody { number });
+        self.calls
+            .lock()
+            .unwrap()
+            .push(MockCall::UpdateIssueBody { number });
         if let Some(e) = self.check_force_error() {
             return Err(e);
         }
@@ -710,7 +730,10 @@ impl IssueTracker for MockIssueTracker {
     }
 
     fn close_issue(&self, number: u32, _reason: CloseReason) -> Result<(), IssueTrackerError> {
-        self.calls.lock().unwrap().push(MockCall::CloseIssue(number));
+        self.calls
+            .lock()
+            .unwrap()
+            .push(MockCall::CloseIssue(number));
         if let Some(e) = self.check_force_error() {
             return Err(e);
         }
@@ -718,22 +741,21 @@ impl IssueTracker for MockIssueTracker {
     }
 
     fn reopen_issue(&self, number: u32) -> Result<(), IssueTrackerError> {
-        self.calls.lock().unwrap().push(MockCall::ReopenIssue(number));
+        self.calls
+            .lock()
+            .unwrap()
+            .push(MockCall::ReopenIssue(number));
         if let Some(e) = self.check_force_error() {
             return Err(e);
         }
         Ok(())
     }
 
-    fn link_issue_to_pr(
-        &self,
-        issue_number: u32,
-        pr_number: u32,
-    ) -> Result<(), IssueTrackerError> {
-        self.calls
-            .lock()
-            .unwrap()
-            .push(MockCall::LinkIssueToPr { issue_number, pr_number });
+    fn link_issue_to_pr(&self, issue_number: u32, pr_number: u32) -> Result<(), IssueTrackerError> {
+        self.calls.lock().unwrap().push(MockCall::LinkIssueToPr {
+            issue_number,
+            pr_number,
+        });
         if let Some(e) = self.check_force_error() {
             return Err(e);
         }
@@ -852,7 +874,9 @@ mod tests {
         assert_eq!(issue.title, "Fix the thing");
         assert_eq!(issue.body, "Here is why");
         let calls = tracker.recorded_calls();
-        assert!(matches!(&calls[0], MockCall::CreateIssue { title, .. } if title == "Fix the thing"));
+        assert!(
+            matches!(&calls[0], MockCall::CreateIssue { title, .. } if title == "Fix the thing")
+        );
     }
 
     #[test]
@@ -869,14 +893,20 @@ mod tests {
     fn mock_records_close_issue() {
         let tracker = MockIssueTracker::new();
         tracker.close_issue(3, CloseReason::Completed).unwrap();
-        assert!(matches!(tracker.recorded_calls()[0], MockCall::CloseIssue(3)));
+        assert!(matches!(
+            tracker.recorded_calls()[0],
+            MockCall::CloseIssue(3)
+        ));
     }
 
     #[test]
     fn mock_records_reopen_issue() {
         let tracker = MockIssueTracker::new();
         tracker.reopen_issue(8).unwrap();
-        assert!(matches!(tracker.recorded_calls()[0], MockCall::ReopenIssue(8)));
+        assert!(matches!(
+            tracker.recorded_calls()[0],
+            MockCall::ReopenIssue(8)
+        ));
     }
 
     #[test]
@@ -884,9 +914,13 @@ mod tests {
         let tracker = MockIssueTracker::new();
         tracker.link_issue_to_pr(10, 55).unwrap();
         let calls = tracker.recorded_calls();
-        assert!(
-            matches!(&calls[0], MockCall::LinkIssueToPr { issue_number: 10, pr_number: 55 })
-        );
+        assert!(matches!(
+            &calls[0],
+            MockCall::LinkIssueToPr {
+                issue_number: 10,
+                pr_number: 55
+            }
+        ));
     }
 
     #[test]
@@ -904,9 +938,10 @@ mod tests {
     #[test]
     fn mock_propagates_force_error() {
         let mut tracker = MockIssueTracker::new();
-        tracker.force_error =
-            Some(IssueTrackerError::Auth("token expired".to_string()));
-        let err = tracker.list_open_issues(&IssueFilter::default()).unwrap_err();
+        tracker.force_error = Some(IssueTrackerError::Auth("token expired".to_string()));
+        let err = tracker
+            .list_open_issues(&IssueFilter::default())
+            .unwrap_err();
         assert!(matches!(err, IssueTrackerError::Auth(_)));
     }
 
@@ -914,7 +949,10 @@ mod tests {
     fn mock_update_issue_body_records_number() {
         let tracker = MockIssueTracker::new();
         tracker.update_issue_body(12, "new body").unwrap();
-        assert!(matches!(tracker.recorded_calls()[0], MockCall::UpdateIssueBody { number: 12 }));
+        assert!(matches!(
+            tracker.recorded_calls()[0],
+            MockCall::UpdateIssueBody { number: 12 }
+        ));
     }
 
     // ── classify_gh_error tests ───────────────────────────────────────────────
@@ -949,7 +987,10 @@ mod tests {
     fn github_tracker_validate_empty_title() {
         let tracker = GitHubIssueTracker::new("owner", "repo");
         let err = tracker
-            .create_issue(IssueDraft { title: "  ".to_string(), ..Default::default() })
+            .create_issue(IssueDraft {
+                title: "  ".to_string(),
+                ..Default::default()
+            })
             .unwrap_err();
         assert!(matches!(err, IssueTrackerError::Validation(_)));
     }
@@ -1045,10 +1086,16 @@ mod tests {
     fn local_tracker_list_open() {
         let tracker = temp_tracker();
         tracker
-            .create_issue(IssueDraft { title: "A".to_string(), ..Default::default() })
+            .create_issue(IssueDraft {
+                title: "A".to_string(),
+                ..Default::default()
+            })
             .unwrap();
         tracker
-            .create_issue(IssueDraft { title: "B".to_string(), ..Default::default() })
+            .create_issue(IssueDraft {
+                title: "B".to_string(),
+                ..Default::default()
+            })
             .unwrap();
         tracker.close_issue(1, CloseReason::Completed).unwrap();
 
@@ -1061,7 +1108,10 @@ mod tests {
     fn local_tracker_update_body() {
         let tracker = temp_tracker();
         tracker
-            .create_issue(IssueDraft { title: "T".to_string(), ..Default::default() })
+            .create_issue(IssueDraft {
+                title: "T".to_string(),
+                ..Default::default()
+            })
             .unwrap();
         tracker.update_issue_body(1, "updated body").unwrap();
         let issue = tracker.get_issue(1).unwrap();
@@ -1072,7 +1122,11 @@ mod tests {
     fn local_tracker_add_comment_appends_to_body() {
         let tracker = temp_tracker();
         tracker
-            .create_issue(IssueDraft { title: "T".to_string(), body: "original".to_string(), ..Default::default() })
+            .create_issue(IssueDraft {
+                title: "T".to_string(),
+                body: "original".to_string(),
+                ..Default::default()
+            })
             .unwrap();
         tracker.add_comment(1, "a comment").unwrap();
         let issue = tracker.get_issue(1).unwrap();
@@ -1083,7 +1137,10 @@ mod tests {
     fn local_tracker_close_and_reopen() {
         let tracker = temp_tracker();
         tracker
-            .create_issue(IssueDraft { title: "T".to_string(), ..Default::default() })
+            .create_issue(IssueDraft {
+                title: "T".to_string(),
+                ..Default::default()
+            })
             .unwrap();
         tracker.close_issue(1, CloseReason::Completed).unwrap();
         assert_eq!(tracker.get_issue(1).unwrap().state, IssueState::Closed);
@@ -1095,7 +1152,10 @@ mod tests {
     fn local_tracker_link_pr_adds_comment() {
         let tracker = temp_tracker();
         tracker
-            .create_issue(IssueDraft { title: "T".to_string(), ..Default::default() })
+            .create_issue(IssueDraft {
+                title: "T".to_string(),
+                ..Default::default()
+            })
             .unwrap();
         tracker.link_issue_to_pr(1, 42).unwrap();
         let issue = tracker.get_issue(1).unwrap();
@@ -1106,7 +1166,10 @@ mod tests {
     fn local_tracker_empty_title_rejected() {
         let tracker = temp_tracker();
         let err = tracker
-            .create_issue(IssueDraft { title: "".to_string(), ..Default::default() })
+            .create_issue(IssueDraft {
+                title: "".to_string(),
+                ..Default::default()
+            })
             .unwrap_err();
         assert!(matches!(err, IssueTrackerError::Validation(_)));
     }
@@ -1117,7 +1180,10 @@ mod tests {
         let path = dir.path().join("nested").join("deep").join("promise.md");
         let tracker = LocalPromiseTracker::new(&path);
         tracker
-            .create_issue(IssueDraft { title: "dir test".to_string(), ..Default::default() })
+            .create_issue(IssueDraft {
+                title: "dir test".to_string(),
+                ..Default::default()
+            })
             .unwrap();
         assert!(path.exists());
     }
@@ -1126,13 +1192,22 @@ mod tests {
     fn local_tracker_search_filter() {
         let tracker = temp_tracker();
         tracker
-            .create_issue(IssueDraft { title: "fix login bug".to_string(), ..Default::default() })
+            .create_issue(IssueDraft {
+                title: "fix login bug".to_string(),
+                ..Default::default()
+            })
             .unwrap();
         tracker
-            .create_issue(IssueDraft { title: "update docs".to_string(), ..Default::default() })
+            .create_issue(IssueDraft {
+                title: "update docs".to_string(),
+                ..Default::default()
+            })
             .unwrap();
         let results = tracker
-            .list_open_issues(&IssueFilter { search: Some("login".to_string()), ..Default::default() })
+            .list_open_issues(&IssueFilter {
+                search: Some("login".to_string()),
+                ..Default::default()
+            })
             .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].title, "fix login bug");
@@ -1143,8 +1218,7 @@ mod tests {
     #[test]
     fn mock_records_ensure_labels_call() {
         let tracker = MockIssueTracker::new();
-        let labels =
-            vec!["bug".to_string(), "discovered-during-loop".to_string()];
+        let labels = vec!["bug".to_string(), "discovered-during-loop".to_string()];
         tracker.ensure_labels(&labels).unwrap();
         let calls = tracker.recorded_calls();
         assert_eq!(calls.len(), 1);
@@ -1163,8 +1237,7 @@ mod tests {
     #[test]
     fn mock_ensure_labels_propagates_force_error() {
         let mut tracker = MockIssueTracker::new();
-        tracker.force_error =
-            Some(IssueTrackerError::Transport("network error".to_string()));
+        tracker.force_error = Some(IssueTrackerError::Transport("network error".to_string()));
         let labels = vec!["bug".to_string()];
         let err = tracker.ensure_labels(&labels).unwrap_err();
         assert!(matches!(err, IssueTrackerError::Transport(_)));

--- a/src/issue_tracker.rs
+++ b/src/issue_tracker.rs
@@ -14,6 +14,7 @@ pub enum IssueState {
 
 /// A GitHub issue returned by the tracker.
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct Issue {
     pub id: u64,
     pub number: u32,
@@ -27,6 +28,7 @@ pub struct Issue {
 
 /// Payload for creating a new issue.
 #[derive(Debug, Clone, Default)]
+#[allow(dead_code)]
 pub struct IssueDraft {
     pub title: String,
     pub body: String,
@@ -36,6 +38,7 @@ pub struct IssueDraft {
 
 /// Filter criteria for listing issues.
 #[derive(Debug, Clone, Default)]
+#[allow(dead_code)]
 pub struct IssueFilter {
     pub state: Option<IssueState>,
     pub labels: Vec<String>,
@@ -45,6 +48,7 @@ pub struct IssueFilter {
 
 /// Reason an issue is being closed.
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub enum CloseReason {
     Completed,
     NotPlanned,
@@ -65,6 +69,7 @@ pub enum IssueTrackerError {
     #[error("transport error: {0}")]
     Transport(String),
     #[error("validation error: {0}")]
+    #[allow(dead_code)]
     Validation(String),
 }
 
@@ -75,6 +80,7 @@ pub enum IssueTrackerError {
 /// All mutation operations must go through MCP-compliant paths in production
 /// use.  Implementations are responsible for honouring whatever auth and
 /// policy constraints apply to their backend.
+#[allow(dead_code)]
 pub trait IssueTracker: Send + Sync {
     fn list_open_issues(&self, filter: &IssueFilter) -> Result<Vec<Issue>, IssueTrackerError>;
     fn get_issue(&self, number: u32) -> Result<Issue, IssueTrackerError>;
@@ -399,6 +405,7 @@ impl IssueTracker for GitHubIssueTracker {
 ///
 /// The file is created (including parent directories) on first write if it
 /// does not already exist.
+#[allow(dead_code)]
 pub struct LocalPromiseTracker {
     pub path: std::path::PathBuf,
     inner: Mutex<LocalStore>,
@@ -408,6 +415,7 @@ struct LocalStore {
     /// In-memory issues indexed by number.
     issues: std::collections::HashMap<u32, Issue>,
     /// Monotonically increasing counter for new issue numbers.
+    #[allow(dead_code)]
     next_number: u32,
 }
 
@@ -462,13 +470,13 @@ impl IssueTracker for LocalPromiseTracker {
                 filter
                     .assignee
                     .as_deref()
-                    .map_or(true, |a| i.assignees.contains(&a.to_string()))
+                    .is_none_or(|a| i.assignees.contains(&a.to_string()))
             })
             .filter(|i| {
                 filter
                     .search
                     .as_deref()
-                    .map_or(true, |q| i.title.contains(q) || i.body.contains(q))
+                    .is_none_or(|q| i.title.contains(q) || i.body.contains(q))
             })
             .cloned()
             .collect();
@@ -562,6 +570,7 @@ impl IssueTracker for LocalPromiseTracker {
 /// By default, read methods return empty collections and write methods
 /// succeed.  Override `next_issue` to control what `get_issue` and
 /// `create_issue` return.
+#[cfg(test)]
 pub struct MockIssueTracker {
     /// Calls recorded in order: (method_name, args…).
     pub calls: Mutex<Vec<MockCall>>,
@@ -571,6 +580,7 @@ pub struct MockIssueTracker {
     pub force_error: Option<IssueTrackerError>,
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone)]
 pub enum MockCall {
     ListOpenIssues,
@@ -584,6 +594,7 @@ pub enum MockCall {
     EnsureLabels(Vec<String>),
 }
 
+#[cfg(test)]
 impl MockIssueTracker {
     pub fn new() -> Self {
         Self {
@@ -629,12 +640,14 @@ impl MockIssueTracker {
     }
 }
 
+#[cfg(test)]
 impl Default for MockIssueTracker {
     fn default() -> Self {
         Self::new()
     }
 }
 
+#[cfg(test)]
 impl IssueTracker for MockIssueTracker {
     fn list_open_issues(&self, _filter: &IssueFilter) -> Result<Vec<Issue>, IssueTrackerError> {
         self.calls.lock().unwrap().push(MockCall::ListOpenIssues);

--- a/src/issue_tracker.rs
+++ b/src/issue_tracker.rs
@@ -87,6 +87,13 @@ pub trait IssueTracker: Send + Sync {
     /// cross-reference comment on the issue.
     fn link_issue_to_pr(&self, issue_number: u32, pr_number: u32)
         -> Result<(), IssueTrackerError>;
+    /// Ensure that the given labels exist on the repository, creating any that
+    /// are absent.  This is a no-op for backends that do not support label
+    /// management (e.g. `LocalPromiseTracker`).
+    fn ensure_labels(&self, labels: &[String]) -> Result<(), IssueTrackerError> {
+        let _ = labels;
+        Ok(())
+    }
 }
 
 // ── GitHub CLI implementation ─────────────────────────────────────────────────
@@ -359,6 +366,27 @@ impl IssueTracker for GitHubIssueTracker {
         let body = format!("Linked to pull request #{pr_number}.");
         self.add_comment(issue_number, &body)
     }
+
+    fn ensure_labels(&self, labels: &[String]) -> Result<(), IssueTrackerError> {
+        let slug = self.repo_slug();
+        for label in labels {
+            // `gh label create --force` is idempotent — it creates the label
+            // if absent and updates it if present (no error on conflict).
+            let args = vec![
+                "label".to_string(),
+                "create".to_string(),
+                label.clone(),
+                "--repo".to_string(),
+                slug.clone(),
+                "--force".to_string(),
+            ];
+            let output = self.run_gh(&args)?;
+            // Label create may exit non-zero on an already-existing label with
+            // some older gh versions; treat that as success.
+            let _ = output;
+        }
+        Ok(())
+    }
 }
 
 // ── LocalPromiseTracker ───────────────────────────────────────────────────────
@@ -553,6 +581,7 @@ pub enum MockCall {
     CloseIssue(u32),
     ReopenIssue(u32),
     LinkIssueToPr { issue_number: u32, pr_number: u32 },
+    EnsureLabels(Vec<String>),
 }
 
 impl MockIssueTracker {
@@ -697,6 +726,17 @@ impl IssueTracker for MockIssueTracker {
         }
         Ok(())
     }
+
+    fn ensure_labels(&self, labels: &[String]) -> Result<(), IssueTrackerError> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push(MockCall::EnsureLabels(labels.to_vec()));
+        if let Some(e) = self.check_force_error() {
+            return Err(e);
+        }
+        Ok(())
+    }
 }
 
 // ── SharedMockIssueTracker ────────────────────────────────────────────────────
@@ -734,6 +774,9 @@ impl IssueTracker for SharedMockIssueTracker {
     }
     fn link_issue_to_pr(&self, issue: u32, pr: u32) -> Result<(), IssueTrackerError> {
         self.0.link_issue_to_pr(issue, pr)
+    }
+    fn ensure_labels(&self, labels: &[String]) -> Result<(), IssueTrackerError> {
+        self.0.ensure_labels(labels)
     }
 }
 
@@ -1080,5 +1123,37 @@ mod tests {
             .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].title, "fix login bug");
+    }
+
+    // ── ensure_labels tests ───────────────────────────────────────────────────
+
+    #[test]
+    fn mock_records_ensure_labels_call() {
+        let tracker = MockIssueTracker::new();
+        let labels =
+            vec!["bug".to_string(), "discovered-during-loop".to_string()];
+        tracker.ensure_labels(&labels).unwrap();
+        let calls = tracker.recorded_calls();
+        assert_eq!(calls.len(), 1);
+        assert!(matches!(&calls[0], MockCall::EnsureLabels(l) if l == &labels));
+    }
+
+    #[test]
+    fn local_tracker_ensure_labels_is_noop() {
+        // LocalPromiseTracker uses the default no-op implementation.
+        let tracker = temp_tracker();
+        let labels = vec!["bug".to_string(), "tech-debt".to_string()];
+        // Should succeed without doing anything.
+        tracker.ensure_labels(&labels).unwrap();
+    }
+
+    #[test]
+    fn mock_ensure_labels_propagates_force_error() {
+        let mut tracker = MockIssueTracker::new();
+        tracker.force_error =
+            Some(IssueTrackerError::Transport("network error".to_string()));
+        let labels = vec!["bug".to_string()];
+        let err = tracker.ensure_labels(&labels).unwrap_err();
+        assert!(matches!(err, IssueTrackerError::Transport(_)));
     }
 }

--- a/src/issue_tracker.rs
+++ b/src/issue_tracker.rs
@@ -374,8 +374,12 @@ impl IssueTracker for GitHubIssueTracker {
     fn ensure_labels(&self, labels: &[String]) -> Result<(), IssueTrackerError> {
         let slug = self.repo_slug();
         for label in labels {
-            // `gh label create --force` is idempotent — it creates the label
-            // if absent and updates it if present (no error on conflict).
+            // `gh label create --force` is idempotent on modern gh versions —
+            // it creates the label if absent and updates it if present.  Older
+            // versions exit non-zero when the label already exists; for those,
+            // allow only an "already exists" stderr through.  Every other
+            // non-zero exit (auth, 404, rate-limit, validation, transport) is
+            // surfaced via `classify_gh_error` so the caller can react.
             let args = vec![
                 "label".to_string(),
                 "create".to_string(),
@@ -385,12 +389,42 @@ impl IssueTracker for GitHubIssueTracker {
                 "--force".to_string(),
             ];
             let output = self.run_gh(&args)?;
-            // Label create may exit non-zero on an already-existing label with
-            // some older gh versions; treat that as success.
-            let _ = output;
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let stderr_lower = stderr.to_lowercase();
+                if stderr_lower.contains("already exists") {
+                    // Benign: concurrent creator, or old gh version without
+                    // `--force` semantics.  Treat as success.
+                    continue;
+                }
+                return Err(classify_gh_error(
+                    &stderr,
+                    &format!("ensure_labels({label})"),
+                ));
+            }
         }
         Ok(())
     }
+}
+
+/// Scan an existing promise-markdown file for issue-number headings and return
+/// the numbers found.
+///
+/// Headings are written by `flush()` as `## #<number> <title> [STATE]`.  We
+/// parse just the numeric portion; any line that does not match the format is
+/// ignored.  Missing files return an empty vector.
+fn scan_existing_issue_numbers(path: &std::path::Path) -> Vec<u32> {
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    contents
+        .lines()
+        .filter_map(|line| {
+            let rest = line.strip_prefix("## #")?;
+            let end = rest.find(|c: char| !c.is_ascii_digit())?;
+            rest[..end].parse::<u32>().ok()
+        })
+        .collect()
 }
 
 // ── LocalPromiseTracker ───────────────────────────────────────────────────────
@@ -413,17 +447,30 @@ struct LocalStore {
     /// In-memory issues indexed by number.
     issues: std::collections::HashMap<u32, Issue>,
     /// Monotonically increasing counter for new issue numbers.
-    #[allow(dead_code)]
+    ///
+    /// Initialised on construction to `max(issue_numbers_on_disk) + 1` so that
+    /// issue numbers remain unique across process restarts.  See #75 for the
+    /// collision bug this prevents.
     next_number: u32,
 }
 
 impl LocalPromiseTracker {
     pub fn new(path: impl Into<std::path::PathBuf>) -> Self {
+        let path = path.into();
+        // Seed `next_number` from whatever issue numbers are already present
+        // on disk, so a restart cannot collide with existing issues.  We only
+        // look at the headings — full body round-tripping is intentionally out
+        // of scope for this dev/debug tracker.
+        let next_number = scan_existing_issue_numbers(&path)
+            .into_iter()
+            .max()
+            .map(|n| n + 1)
+            .unwrap_or(1);
         Self {
-            path: path.into(),
+            path,
             inner: Mutex::new(LocalStore {
                 issues: std::collections::HashMap::new(),
-                next_number: 1,
+                next_number,
             }),
         }
     }

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -767,8 +767,31 @@ impl LoopEngine {
                         break;
                     }
                     Err(e) => {
-                        error!(iteration = i, provider = self.adapter.name(), error = %e, "Iteration error");
-                        final_outcome = IterationOutcome::Unknown;
+                        // Fatal, non-transient errors: a bad binary or an
+                        // invalid argument will recur on every iteration.
+                        // Treat them the same as `ProviderSpawn` — set a
+                        // termination reason, post a blocker comment if
+                        // possible, and abort the outer loop.  Without this,
+                        // the loop used to silently iterate `iterations` times
+                        // with each marked `Unknown` and no `termination_reason`
+                        // in the summary (see #63).
+                        let msg = e.to_string();
+                        error!(
+                            iteration = i,
+                            provider = self.adapter.name(),
+                            error = %e,
+                            "Iteration error (fatal)"
+                        );
+                        final_outcome = IterationOutcome::SpawnFailure {
+                            message: msg.clone(),
+                        };
+                        if self.config.issue_tracking.comment_cadence != CommentCadence::OffEngine {
+                            self.post_comment(&format!(
+                                "**Blocker** — iteration {i} aborted: fatal error. `{msg}`"
+                            ));
+                        }
+                        summary.termination_reason = Some(TerminationReason::ProviderError(msg));
+                        abort_loop = true;
                         break;
                     }
                 }

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -136,7 +136,7 @@ pub struct LoopEngine {
 
 impl LoopEngine {
     pub fn new(config: LoopConfig, guard: PolicyGuard) -> Self {
-        let adapter = build_adapter(&config.provider, config.telemetry.stream_output);
+        let adapter = build_adapter(&config.provider, config.telemetry.stream_output, config.workspace_dir.clone());
         let policy_engine = if config.orchestration.enabled {
             let owner = config.orchestration.repo_owner.clone().unwrap_or_default();
             let repo = config.orchestration.repo_name.clone().unwrap_or_default();

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -186,6 +186,15 @@ impl LoopEngine {
         }
     }
 
+    /// Builder that replaces the engine's internal interrupt flag with an externally-supplied
+    /// one.  Use this when multiple engines must share a single SIGINT signal: create one
+    /// `Arc<AtomicBool>`, install **one** `ctrlc` handler that sets it, then pass the same
+    /// `Arc` to every engine so they all stop when the signal fires.
+    pub fn with_shared_interrupt(mut self, flag: Arc<AtomicBool>) -> Self {
+        self.interrupted = flag;
+        self
+    }
+
     /// Constructor that accepts a custom adapter; uses a default (safe) policy guard.
     #[allow(dead_code)]
     pub fn with_adapter(config: LoopConfig, adapter: Box<dyn ProviderAdapter>) -> Self {

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -1,6 +1,6 @@
 use crate::config::{CommentCadence, IssueTrackingMode, LoopConfig, PrMode};
 use crate::issue_tracker::{GitHubIssueTracker, IssueTracker, LocalPromiseTracker};
-use crate::orchestration::{GhCliContextResolver, PolicyEngine};
+use crate::orchestration::{BranchSelection, GhCliContextResolver, PolicyEngine};
 use crate::policy_guard::PolicyGuard;
 use crate::pr_manager::{
     GhPrLifecycle, PrManager, TriageAction, build_pr_manager,
@@ -74,6 +74,19 @@ impl SessionSummary {
 }
 
 /// Construct the appropriate `IssueTracker` from the resolved config.
+/// Compute the delay in milliseconds for a given retry attempt using
+/// exponential backoff: `base_ms * multiplier^attempt` (attempt is 0-indexed).
+///
+/// With `multiplier = 1.0` this degrades to flat backoff.
+fn compute_backoff_ms(base_ms: u64, multiplier: f64, attempt: u32) -> u64 {
+    if multiplier <= 1.0 || attempt == 0 {
+        return base_ms;
+    }
+    let scaled = (base_ms as f64) * multiplier.powi(attempt as i32);
+    // Cap at ~10 minutes to avoid absurdly long sleeps on many retries.
+    scaled.min(600_000.0) as u64
+}
+
 fn build_tracker(config: &LoopConfig) -> Box<dyn IssueTracker> {
     match config.issue_tracking.mode {
         IssueTrackingMode::Github => {
@@ -127,7 +140,11 @@ impl LoopEngine {
         let policy_engine = if config.orchestration.enabled {
             let owner = config.orchestration.repo_owner.clone().unwrap_or_default();
             let repo = config.orchestration.repo_name.clone().unwrap_or_default();
-            Some(PolicyEngine::new(Box::new(GhCliContextResolver { owner, repo })))
+            let rules = config.orchestration.policies.clone();
+            Some(PolicyEngine::with_rules(
+                Box::new(GhCliContextResolver { owner, repo }),
+                rules,
+            ))
         } else {
             None
         };
@@ -438,7 +455,7 @@ impl LoopEngine {
             // If orchestration is enabled, select a workflow branch and use its prompt.
             let (raw_prompt, workflow_branch) = if let Some(ref engine) = self.policy_engine {
                 match engine.select_branch() {
-                    Ok((branch, _ctx)) => {
+                    Ok(BranchSelection { branch, prompt_override, .. }) => {
                         let branch_name = branch.to_string();
                         info!(
                             iteration = i,
@@ -446,7 +463,8 @@ impl LoopEngine {
                             workflow_branch = %branch_name,
                             "Iteration start"
                         );
-                        let p = branch.default_prompt().to_string();
+                        let p = prompt_override
+                            .unwrap_or_else(|| branch.default_prompt().to_string());
                         (p, Some(branch_name))
                     }
                     Err(e) => {
@@ -531,37 +549,43 @@ impl LoopEngine {
                                 );
                             }
                             break;
-                        } else if attempt < self.config.max_retries {
-                            summary.retries += 1;
-                            warn!(
-                                iteration = i,
-                                attempt = attempt + 1,
-                                max_retries = self.config.max_retries,
-                                provider = self.adapter.name(),
-                                exit_code = result.exit_code,
-                                backoff_ms = self.config.retry_backoff_ms,
-                                "Iteration failed, retrying"
-                            );
-                            std::thread::sleep(std::time::Duration::from_millis(
-                                self.config.retry_backoff_ms,
-                            ));
-                            attempt += 1;
                         } else {
-                            final_outcome = IterationOutcome::from_exit_code(result.exit_code);
-                            let first_err =
-                                IterationRecord::stderr_first_line(&result.stderr);
-                            warn!(
-                                iteration = i,
-                                provider = self.adapter.name(),
-                                exit_code = result.exit_code,
-                                duration_ms,
-                                stderr = %result.stderr.trim(),
-                                "Iteration failed (non-zero exit)"
-                            );
-                            if let Some(ref excerpt) = first_err {
-                                warn!(iteration = i, stderr_first_line = %excerpt, "");
+                            let outcome = IterationOutcome::from_exit_code(result.exit_code);
+                            if attempt < self.config.max_retries && outcome.is_retryable() {
+                                summary.retries += 1;
+                                let delay_ms = compute_backoff_ms(
+                                    self.config.retry_backoff_ms,
+                                    self.config.retry_backoff_multiplier,
+                                    attempt,
+                                );
+                                warn!(
+                                    iteration = i,
+                                    attempt = attempt + 1,
+                                    max_retries = self.config.max_retries,
+                                    provider = self.adapter.name(),
+                                    exit_code = result.exit_code,
+                                    backoff_ms = delay_ms,
+                                    "Iteration failed (retryable), retrying"
+                                );
+                                std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+                                attempt += 1;
+                            } else {
+                                final_outcome = outcome;
+                                let first_err =
+                                    IterationRecord::stderr_first_line(&result.stderr);
+                                warn!(
+                                    iteration = i,
+                                    provider = self.adapter.name(),
+                                    exit_code = result.exit_code,
+                                    duration_ms,
+                                    stderr = %result.stderr.trim(),
+                                    "Iteration failed (non-zero exit)"
+                                );
+                                if let Some(ref excerpt) = first_err {
+                                    warn!(iteration = i, stderr_first_line = %excerpt, "");
+                                }
+                                break;
                             }
-                            break;
                         }
                     }
                     Err(crate::error::LooperError::ProviderSpawn { binary, source }) => {
@@ -883,6 +907,30 @@ mod tests {
     use crate::config::{LoopConfig, Provider};
     use crate::provider::tests::FakeAdapter;
 
+    // ── compute_backoff_ms ────────────────────────────────────────────────────
+
+    #[test]
+    fn flat_backoff_returns_base_for_all_attempts() {
+        assert_eq!(compute_backoff_ms(500, 1.0, 0), 500);
+        assert_eq!(compute_backoff_ms(500, 1.0, 1), 500);
+        assert_eq!(compute_backoff_ms(500, 1.0, 5), 500);
+    }
+
+    #[test]
+    fn exponential_backoff_doubles_each_attempt() {
+        assert_eq!(compute_backoff_ms(100, 2.0, 0), 100); // 100 * 2^0 = 100
+        assert_eq!(compute_backoff_ms(100, 2.0, 1), 200); // 100 * 2^1 = 200
+        assert_eq!(compute_backoff_ms(100, 2.0, 2), 400); // 100 * 2^2 = 400
+        assert_eq!(compute_backoff_ms(100, 2.0, 3), 800); // 100 * 2^3 = 800
+    }
+
+    #[test]
+    fn exponential_backoff_is_capped_at_ten_minutes() {
+        // With base 1000ms and multiplier 2, attempt 30 would be > 1 billion ms.
+        let capped = compute_backoff_ms(1000, 2.0, 30);
+        assert_eq!(capped, 600_000);
+    }
+
     fn config_with_iterations(n: i64) -> LoopConfig {
         LoopConfig {
             iterations: n,
@@ -1169,6 +1217,7 @@ mod tests {
                 enabled: true,
                 repo_owner: Some("owner".to_string()),
                 repo_name: Some("repo".to_string()),
+                ..OrchestrationConfig::default()
             },
             ..Default::default()
         };
@@ -1204,6 +1253,7 @@ mod tests {
                 enabled: true,
                 repo_owner: Some("owner".to_string()),
                 repo_name: Some("repo".to_string()),
+                ..OrchestrationConfig::default()
             },
             ..Default::default()
         };

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -1,12 +1,16 @@
-use crate::config::{CommentCadence, IssueTrackingMode, LoopConfig};
+use crate::config::{CommentCadence, IssueTrackingMode, LoopConfig, PrMode};
 use crate::issue_tracker::{GitHubIssueTracker, IssueTracker, LocalPromiseTracker};
 use crate::orchestration::{GhCliContextResolver, PolicyEngine};
 use crate::policy_guard::PolicyGuard;
+use crate::pr_manager::{
+    GhPrLifecycle, PrManager, TriageAction, build_pr_manager,
+};
 use crate::pr_strategy::{PrStrategy, build_strategy};
 use crate::provider::{build_adapter, ProviderAdapter};
 use crate::telemetry::{
     IterationOutcome, IterationRecord, RunArtifacts, RunManifest, unix_now,
 };
+use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
@@ -110,6 +114,9 @@ pub struct LoopEngine {
     tracker: Box<dyn IssueTracker>,
     /// PR strategy: consulted once per iteration before the provider is invoked.
     pr_strategy: Box<dyn PrStrategy>,
+    /// PR manager for single-PR mode: scans iteration output for shippable
+    /// signals and opens/updates PRs accordingly.
+    pr_manager: Option<PrManager<GhPrLifecycle>>,
     /// Shared flag set to `true` when SIGINT is received.
     interrupted: Arc<AtomicBool>,
 }
@@ -126,8 +133,13 @@ impl LoopEngine {
         };
         let tracker = build_tracker(&config);
         let pr_strategy = build_strategy(config.pr_management.clone());
+        let pr_manager = if config.pr_management.mode == PrMode::SinglePr {
+            Some(build_pr_manager(config.pr_management.clone()))
+        } else {
+            None
+        };
         let interrupted = Arc::new(AtomicBool::new(false));
-        Self { config, adapter, policy_engine, guard, tracker, pr_strategy, interrupted }
+        Self { config, adapter, policy_engine, guard, tracker, pr_strategy, pr_manager, interrupted }
     }
 
     /// Constructor that accepts a custom adapter; uses a default (safe) policy guard.
@@ -137,7 +149,16 @@ impl LoopEngine {
         let guard = PolicyGuard::new(crate::policy_guard::UnsafeOverrides::default());
         let tracker = build_tracker(&config);
         let pr_strategy = build_strategy(config.pr_management.clone());
-        Self { config, adapter, policy_engine: None, guard, tracker, pr_strategy, interrupted }
+        Self {
+            config,
+            adapter,
+            policy_engine: None,
+            guard,
+            tracker,
+            pr_strategy,
+            pr_manager: None,
+            interrupted,
+        }
     }
 
     /// Constructor that accepts a custom adapter and issue tracker (useful for testing).
@@ -150,7 +171,16 @@ impl LoopEngine {
         let interrupted = Arc::new(AtomicBool::new(false));
         let guard = PolicyGuard::new(crate::policy_guard::UnsafeOverrides::default());
         let pr_strategy = build_strategy(config.pr_management.clone());
-        Self { config, adapter, policy_engine: None, guard, tracker, pr_strategy, interrupted }
+        Self {
+            config,
+            adapter,
+            policy_engine: None,
+            guard,
+            tracker,
+            pr_strategy,
+            pr_manager: None,
+            interrupted,
+        }
     }
 
     /// Constructor that accepts a custom adapter and policy engine (useful for testing).
@@ -164,7 +194,16 @@ impl LoopEngine {
         let guard = PolicyGuard::new(crate::policy_guard::UnsafeOverrides::default());
         let tracker = build_tracker(&config);
         let pr_strategy = build_strategy(config.pr_management.clone());
-        Self { config, adapter, policy_engine: Some(policy_engine), guard, tracker, pr_strategy, interrupted }
+        Self {
+            config,
+            adapter,
+            policy_engine: Some(policy_engine),
+            guard,
+            tracker,
+            pr_strategy,
+            pr_manager: None,
+            interrupted,
+        }
     }
 
     /// Install a Ctrl+C handler that sets the interrupted flag.
@@ -341,6 +380,61 @@ impl LoopEngine {
                 "PR strategy plan"
             );
 
+            // For multi-PR mode: handle Merge action directly (no agent needed)
+            // and skip agent invocation for BlockedOnHumanReview.
+            if let Some(ref action) = pr_plan.triage_action {
+                match action {
+                    TriageAction::Merge { pr } => {
+                        info!(
+                            iteration = i,
+                            pr = pr.number,
+                            url = %pr.url,
+                            "multi-pr: merging ready PR"
+                        );
+                        let merge_result = Command::new("gh")
+                            .args(["pr", "merge", &pr.number.to_string(), "--merge"])
+                            .output();
+                        match merge_result {
+                            Ok(out) if out.status.success() => {
+                                info!(iteration = i, pr = pr.number, "multi-pr: PR merged");
+                            }
+                            Ok(out) => {
+                                let stderr = String::from_utf8_lossy(&out.stderr);
+                                warn!(iteration = i, pr = pr.number, stderr = %stderr, "multi-pr: merge failed");
+                            }
+                            Err(e) => {
+                                warn!(iteration = i, pr = pr.number, error = %e, "multi-pr: failed to spawn gh for merge");
+                            }
+                        }
+                        // Record as a success iteration (merge happened, no agent needed).
+                        iteration_records.push(IterationRecord {
+                            iteration: i,
+                            provider: self.adapter.name().to_string(),
+                            prompt_source: "triage-merge".to_string(),
+                            workflow_branch: None,
+                            outcome: IterationOutcome::Success,
+                            duration_ms: iter_start.elapsed().as_millis(),
+                            retries: 0,
+                            stderr_excerpt: None,
+                            transcript_path: None,
+                            started_at: iter_started_at,
+                        });
+                        summary.iterations_run += 1;
+                        summary.successes += 1;
+                        continue;
+                    }
+                    TriageAction::BlockedOnHumanReview { pr } => {
+                        info!(
+                            iteration = i,
+                            pr = pr.number,
+                            "multi-pr: PR ready but blocked on human review; falling through to issue work"
+                        );
+                        // Fall through — no prompt override set, so normal issue-work prompt is used.
+                    }
+                    _ => {}
+                }
+            }
+
             // If orchestration is enabled, select a workflow branch and use its prompt.
             let (raw_prompt, workflow_branch) = if let Some(ref engine) = self.policy_engine {
                 match engine.select_branch() {
@@ -386,6 +480,13 @@ impl LoopEngine {
                     "Iteration start"
                 );
                 (prompt.clone(), None)
+            };
+
+            // Apply prompt override from the PR triage plan (multi-PR mode only).
+            let raw_prompt = if let Some(ref override_prompt) = pr_plan.prompt_override {
+                override_prompt.clone()
+            } else {
+                raw_prompt
             };
 
             // Augment prompt with MCP-use preamble (no-op when allow_direct_github is set).
@@ -497,6 +598,63 @@ impl LoopEngine {
                 retries = attempt,
                 "Iteration complete"
             );
+
+            // Single-PR: after each successful iteration, scan output for the
+            // shippable signal and open/update the PR if detected.
+            if final_outcome.is_success() {
+                if let Some(ref manager) = self.pr_manager {
+                    let branch = self
+                        .config
+                        .pr_management
+                        .branch_prefix
+                        .trim_end_matches('/')
+                        .to_string();
+                    let issue_number = self
+                        .config
+                        .issue_tracking
+                        .comment_issue_number
+                        .map(|n| n as u64)
+                        .unwrap_or(0);
+                    match manager.handle_milestone(
+                        &branch,
+                        issue_number,
+                        "loop iteration",
+                        &final_stdout,
+                    ) {
+                        Ok(crate::pr_manager::PrAction::Opened(pr)) => {
+                            info!(
+                                iteration = i,
+                                pr = pr.number,
+                                url = %pr.url,
+                                "single-pr: opened PR for shippable work"
+                            );
+                            // Post cross-reference comment on linked issue.
+                            if issue_number > 0 {
+                                let msg = format!(
+                                    "**PR opened** — [#{pr_num}]({url}) opened from this iteration.",
+                                    pr_num = pr.number,
+                                    url = pr.url
+                                );
+                                self.post_comment(&msg);
+                            }
+                        }
+                        Ok(crate::pr_manager::PrAction::Updated { pr, .. }) => {
+                            info!(iteration = i, pr = pr.number, "single-pr: commented on existing PR");
+                        }
+                        Ok(crate::pr_manager::PrAction::BlockedOnHumanReview(pr)) => {
+                            info!(
+                                iteration = i,
+                                pr = pr.number,
+                                "single-pr: PR already open; blocked on human review"
+                            );
+                        }
+                        Ok(crate::pr_manager::PrAction::NoSignal) => {}
+                        Err(e) => {
+                            warn!(iteration = i, error = %e, "single-pr: PrManager error");
+                        }
+                    }
+                }
+            }
 
             // Post iteration comment based on cadence.
             let cadence = &self.config.issue_tracking.comment_cadence;

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -6,7 +6,9 @@ use crate::policy_guard::PolicyGuard;
 use crate::pr_manager::{build_pr_manager, GhPrLifecycle, PrManager, TriageAction};
 use crate::pr_strategy::{build_strategy, PrStrategy};
 use crate::provider::{build_adapter, ProviderAdapter};
-use crate::telemetry::{unix_now, IterationOutcome, IterationRecord, RunArtifacts, RunManifest};
+use crate::telemetry::{
+    resolve_operator, unix_now, IterationOutcome, IterationRecord, RunArtifacts, RunManifest,
+};
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -1007,6 +1009,12 @@ impl LoopEngine {
             iterations_requested: self.config.iterations,
             termination_reason: summary.termination_reason.as_ref().map(|r| r.to_string()),
             skipped_decisions: summary.skipped_decisions,
+            run_by: resolve_operator(),
+            workspace_dir: self
+                .config
+                .workspace_dir
+                .as_ref()
+                .map(|p| p.display().to_string()),
             iterations: iteration_records,
         };
         artifacts.write_manifest(&manifest);

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -504,6 +504,24 @@ impl LoopEngine {
                         match merge_result {
                             Ok(out) if out.status.success() => {
                                 info!(iteration = i, pr = pr.number, "multi-pr: PR merged");
+                                // Attempt post-merge branch cleanup when the PR has a known
+                                // head branch.  Failures are non-fatal (PR already merged).
+                                if !pr.head_ref.is_empty() {
+                                    let bm = BranchManager::new(self.config.pr_management.clone());
+                                    match bm.cleanup_branch(&pr.head_ref) {
+                                        Ok(()) => info!(
+                                            iteration = i,
+                                            branch = %pr.head_ref,
+                                            "multi-pr: cleaned up feature branch after merge"
+                                        ),
+                                        Err(e) => warn!(
+                                            iteration = i,
+                                            branch = %pr.head_ref,
+                                            error = %e,
+                                            "multi-pr: post-merge branch cleanup failed (non-fatal)"
+                                        ),
+                                    }
+                                }
                             }
                             Ok(out) => {
                                 let stderr = String::from_utf8_lossy(&out.stderr);
@@ -1909,6 +1927,7 @@ mod tests {
                     number: 42,
                     title: "feat: something".to_string(),
                     url: "https://github.com/owner/repo/pull/42".to_string(),
+                    head_ref: "loop/42-feat-something".to_string(),
                 };
                 IterationPlan {
                     description: "blocked on human review".to_string(),
@@ -2006,5 +2025,103 @@ mod tests {
             summary.termination_reason,
             Some(TerminationReason::StoppedOnFailure)
         );
+    }
+
+    // ── Multi-PR merge path ───────────────────────────────────────────────────
+
+    /// Verify that `TriageAction::Merge` is handled without panicking and the
+    /// iteration is always recorded as a success (regardless of whether `gh pr
+    /// merge` succeeds in the test environment — no real GitHub connection is
+    /// available).  Post-merge branch cleanup is attempted but the failure is
+    /// non-fatal; the summary must still show one success.
+    #[test]
+    fn merge_triage_action_is_handled_gracefully() {
+        use crate::config::{PrManagementConfig, PrMode};
+        use crate::pr_manager::{PrInfo, TriageAction};
+        use crate::pr_strategy::{IterationPlan, PrStrategy};
+
+        struct MergeStrategy;
+        impl PrStrategy for MergeStrategy {
+            fn plan_iteration(&self, _iteration: u64) -> IterationPlan {
+                let pr = PrInfo {
+                    number: 77,
+                    title: "feat: merge me".to_string(),
+                    url: "https://github.com/owner/repo/pull/77".to_string(),
+                    head_ref: "loop/77-feat-merge-me".to_string(),
+                };
+                IterationPlan {
+                    description: "merge ready PR".to_string(),
+                    mode: PrMode::MultiPr,
+                    prompt_override: None,
+                    triage_action: Some(TriageAction::Merge { pr }),
+                }
+            }
+        }
+
+        let config = LoopConfig {
+            iterations: 1,
+            provider: Provider::Claude,
+            prompt_inline: Some("test prompt".to_string()),
+            pr_management: PrManagementConfig {
+                mode: PrMode::MultiPr,
+                ..PrManagementConfig::default()
+            },
+            ..Default::default()
+        };
+        let engine = LoopEngine::with_adapter_and_pr_strategy(
+            config,
+            Box::new(FakeAdapter::success("fake")),
+            Box::new(MergeStrategy),
+        );
+        // `gh pr merge` will fail (no real GitHub), but the engine must not
+        // panic and must record the iteration as a success.
+        let summary = engine.run();
+        assert_eq!(summary.iterations_run, 1);
+        assert_eq!(summary.successes, 1);
+    }
+
+    /// When `head_ref` is empty the cleanup branch is skipped entirely.
+    #[test]
+    fn merge_triage_with_empty_head_ref_skips_cleanup() {
+        use crate::config::{PrManagementConfig, PrMode};
+        use crate::pr_manager::{PrInfo, TriageAction};
+        use crate::pr_strategy::{IterationPlan, PrStrategy};
+
+        struct MergeNoRefStrategy;
+        impl PrStrategy for MergeNoRefStrategy {
+            fn plan_iteration(&self, _iteration: u64) -> IterationPlan {
+                let pr = PrInfo {
+                    number: 88,
+                    title: "no ref".to_string(),
+                    url: "https://github.com/owner/repo/pull/88".to_string(),
+                    head_ref: String::new(), // empty — cleanup must be skipped
+                };
+                IterationPlan {
+                    description: "merge ready PR (no head ref)".to_string(),
+                    mode: PrMode::MultiPr,
+                    prompt_override: None,
+                    triage_action: Some(TriageAction::Merge { pr }),
+                }
+            }
+        }
+
+        let config = LoopConfig {
+            iterations: 1,
+            provider: Provider::Claude,
+            prompt_inline: Some("test prompt".to_string()),
+            pr_management: PrManagementConfig {
+                mode: PrMode::MultiPr,
+                ..PrManagementConfig::default()
+            },
+            ..Default::default()
+        };
+        let engine = LoopEngine::with_adapter_and_pr_strategy(
+            config,
+            Box::new(FakeAdapter::success("fake")),
+            Box::new(MergeNoRefStrategy),
+        );
+        let summary = engine.run();
+        assert_eq!(summary.iterations_run, 1);
+        assert_eq!(summary.successes, 1);
     }
 }

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -1,4 +1,5 @@
-use crate::config::LoopConfig;
+use crate::config::{IssueTrackingMode, LoopConfig};
+use crate::issue_tracker::{GitHubIssueTracker, IssueTracker, LocalPromiseTracker};
 use crate::orchestration::{GhCliContextResolver, PolicyEngine};
 use crate::policy_guard::PolicyGuard;
 use crate::provider::{build_adapter, ProviderAdapter};
@@ -64,6 +65,35 @@ impl SessionSummary {
     }
 }
 
+/// Construct the appropriate `IssueTracker` from the resolved config.
+fn build_tracker(config: &LoopConfig) -> Box<dyn IssueTracker> {
+    match config.issue_tracking.mode {
+        IssueTrackingMode::Github => {
+            let owner = config
+                .issue_tracking
+                .repo_owner
+                .clone()
+                .or_else(|| config.orchestration.repo_owner.clone())
+                .unwrap_or_default();
+            let repo = config
+                .issue_tracking
+                .repo_name
+                .clone()
+                .or_else(|| config.orchestration.repo_name.clone())
+                .unwrap_or_default();
+            Box::new(GitHubIssueTracker::new(owner, repo))
+        }
+        IssueTrackingMode::Local => {
+            let path = config
+                .issue_tracking
+                .local_promise_path
+                .clone()
+                .unwrap_or_else(|| std::path::PathBuf::from(".code-looper/promise.md"));
+            Box::new(LocalPromiseTracker::new(path))
+        }
+    }
+}
+
 /// Drives the main iteration loop.
 pub struct LoopEngine {
     config: LoopConfig,
@@ -72,6 +102,10 @@ pub struct LoopEngine {
     policy_engine: Option<PolicyEngine>,
     /// Policy guard used to augment prompts with MCP-use requirements.
     guard: PolicyGuard,
+    /// Issue tracker for this run.  Not yet actively called by the engine;
+    /// active use (start/milestone/end comments) lands in a follow-up issue.
+    #[allow(dead_code)]
+    tracker: Box<dyn IssueTracker>,
     /// Shared flag set to `true` when SIGINT is received.
     interrupted: Arc<AtomicBool>,
 }
@@ -86,8 +120,9 @@ impl LoopEngine {
         } else {
             None
         };
+        let tracker = build_tracker(&config);
         let interrupted = Arc::new(AtomicBool::new(false));
-        Self { config, adapter, policy_engine, guard, interrupted }
+        Self { config, adapter, policy_engine, guard, tracker, interrupted }
     }
 
     /// Constructor that accepts a custom adapter; uses a default (safe) policy guard.
@@ -95,7 +130,8 @@ impl LoopEngine {
     pub fn with_adapter(config: LoopConfig, adapter: Box<dyn ProviderAdapter>) -> Self {
         let interrupted = Arc::new(AtomicBool::new(false));
         let guard = PolicyGuard::new(crate::policy_guard::UnsafeOverrides::default());
-        Self { config, adapter, policy_engine: None, guard, interrupted }
+        let tracker = build_tracker(&config);
+        Self { config, adapter, policy_engine: None, guard, tracker, interrupted }
     }
 
     /// Constructor that accepts a custom adapter and policy engine (useful for testing).
@@ -107,7 +143,8 @@ impl LoopEngine {
     ) -> Self {
         let interrupted = Arc::new(AtomicBool::new(false));
         let guard = PolicyGuard::new(crate::policy_guard::UnsafeOverrides::default());
-        Self { config, adapter, policy_engine: Some(policy_engine), guard, interrupted }
+        let tracker = build_tracker(&config);
+        Self { config, adapter, policy_engine: Some(policy_engine), guard, tracker, interrupted }
     }
 
     /// Install a Ctrl+C handler that sets the interrupted flag.
@@ -160,6 +197,38 @@ impl LoopEngine {
 
         let mut summary = SessionSummary::default();
         let session_start = Instant::now();
+
+        // Log issue tracking mode; warn loudly when running in local/dev mode.
+        match self.config.issue_tracking.mode {
+            IssueTrackingMode::Local => {
+                warn!(
+                    issue_tracking_mode = "local",
+                    "Issue tracking is in LOCAL mode — run state is not durably tracked. \
+                     Set issue_tracking.mode=\"github\" for production use."
+                );
+            }
+            IssueTrackingMode::Github => {
+                let owner = self
+                    .config
+                    .issue_tracking
+                    .repo_owner
+                    .as_deref()
+                    .or(self.config.orchestration.repo_owner.as_deref())
+                    .unwrap_or("(unknown)");
+                let repo = self
+                    .config
+                    .issue_tracking
+                    .repo_name
+                    .as_deref()
+                    .or(self.config.orchestration.repo_name.as_deref())
+                    .unwrap_or("(unknown)");
+                info!(
+                    issue_tracking_mode = "github",
+                    repo = %format!("{owner}/{repo}"),
+                    "Issue tracking active"
+                );
+            }
+        }
 
         info!(
             provider = self.adapter.name(),

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -1,3 +1,4 @@
+use crate::branch::BranchManager;
 use crate::config::{CommentCadence, IssueTrackingMode, LoopConfig, PrMode};
 use crate::issue_tracker::{GitHubIssueTracker, IssueTracker, LocalPromiseTracker};
 use crate::orchestration::{BranchSelection, GhCliContextResolver, PolicyEngine};
@@ -130,6 +131,9 @@ pub struct LoopEngine {
     /// PR manager for single-PR mode: scans iteration output for shippable
     /// signals and opens/updates PRs accordingly.
     pr_manager: Option<PrManager<GhPrLifecycle>>,
+    /// Branch manager for single-PR mode: ensures the feature branch exists
+    /// before iterations run and pushes commits when a shippable signal fires.
+    branch_manager: Option<BranchManager>,
     /// Shared flag set to `true` when SIGINT is received.
     interrupted: Arc<AtomicBool>,
 }
@@ -155,8 +159,13 @@ impl LoopEngine {
         } else {
             None
         };
+        let branch_manager = if config.pr_management.mode == PrMode::SinglePr {
+            Some(BranchManager::new(config.pr_management.clone()))
+        } else {
+            None
+        };
         let interrupted = Arc::new(AtomicBool::new(false));
-        Self { config, adapter, policy_engine, guard, tracker, pr_strategy, pr_manager, interrupted }
+        Self { config, adapter, policy_engine, guard, tracker, pr_strategy, pr_manager, branch_manager, interrupted }
     }
 
     /// Constructor that accepts a custom adapter; uses a default (safe) policy guard.
@@ -174,6 +183,7 @@ impl LoopEngine {
             tracker,
             pr_strategy,
             pr_manager: None,
+            branch_manager: None,
             interrupted,
         }
     }
@@ -196,6 +206,7 @@ impl LoopEngine {
             tracker,
             pr_strategy,
             pr_manager: None,
+            branch_manager: None,
             interrupted,
         }
     }
@@ -219,6 +230,7 @@ impl LoopEngine {
             tracker,
             pr_strategy,
             pr_manager: None,
+            branch_manager: None,
             interrupted,
         }
     }
@@ -375,6 +387,34 @@ impl LoopEngine {
                 provider = self.adapter.name(),
             ));
         }
+
+        // Single-PR: ensure the feature branch exists before iterations start.
+        // The derived branch name is kept for use in the shippable-signal handler.
+        let single_pr_branch: String = if let Some(ref bm) = self.branch_manager {
+            let issue_number = self
+                .config
+                .issue_tracking
+                .comment_issue_number
+                .map(|n| n as u64)
+                .unwrap_or(0);
+            match bm.ensure_branch(issue_number, "") {
+                Ok(branch) => {
+                    info!(branch = %branch, "single-pr: checked out feature branch");
+                    branch
+                }
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        "single-pr: could not ensure feature branch; will use current branch"
+                    );
+                    // Fall back to whatever branch the working directory is on.
+                    crate::branch::current_branch()
+                        .unwrap_or_else(|_| bm.branch_name(issue_number, ""))
+                }
+            }
+        } else {
+            String::new()
+        };
 
         // Tracks the body of the most recently posted failure comment for deduplication.
         let mut last_failure_comment: Option<String> = None;
@@ -627,18 +667,37 @@ impl LoopEngine {
             // shippable signal and open/update the PR if detected.
             if final_outcome.is_success() {
                 if let Some(ref manager) = self.pr_manager {
-                    let branch = self
-                        .config
-                        .pr_management
-                        .branch_prefix
-                        .trim_end_matches('/')
-                        .to_string();
+                    // Use the branch name established at loop startup (from
+                    // BranchManager::ensure_branch).  Fall back to current_branch()
+                    // so we never pass the bare prefix string to `gh pr create`.
+                    let branch = if !single_pr_branch.is_empty() {
+                        single_pr_branch.clone()
+                    } else {
+                        crate::branch::current_branch().unwrap_or_else(|_| {
+                            self.config
+                                .pr_management
+                                .branch_prefix
+                                .trim_end_matches('/')
+                                .to_string()
+                        })
+                    };
                     let issue_number = self
                         .config
                         .issue_tracking
                         .comment_issue_number
                         .map(|n| n as u64)
                         .unwrap_or(0);
+                    // Push the feature branch to origin so `gh pr create` can find it.
+                    if let Some(ref bm) = self.branch_manager {
+                        if let Err(e) = bm.push_branch(&branch) {
+                            warn!(
+                                iteration = i,
+                                branch = %branch,
+                                error = %e,
+                                "single-pr: push_branch failed; PR creation may fail"
+                            );
+                        }
+                    }
                     match manager.handle_milestone(
                         &branch,
                         issue_number,
@@ -1586,6 +1645,71 @@ mod tests {
         assert!(
             comment_bodies.iter().any(|b| b.contains("Blocker")),
             "expected a blocker comment; got: {comment_bodies:?}"
+        );
+    }
+
+    // ── Single-PR branch-name wiring ─────────────────────────────────────────
+
+    /// Verify that in single-PR mode, `branch_manager` is constructed and the
+    /// derived branch name is not the bare trimmed prefix ("loop") but a
+    /// well-formed feature-branch name.
+    #[test]
+    fn single_pr_branch_name_is_not_bare_prefix() {
+        use crate::config::{PrManagementConfig, PrMode};
+        let config = LoopConfig {
+            iterations: 1,
+            provider: Provider::Claude,
+            prompt_inline: Some("test".to_string()),
+            pr_management: PrManagementConfig {
+                mode: PrMode::SinglePr,
+                branch_prefix: "loop/".to_string(),
+                ..PrManagementConfig::default()
+            },
+            ..Default::default()
+        };
+        // Build a production engine; we check the branch_manager field directly.
+        // We can't run the loop (it would spawn 'claude'), so we just verify
+        // construction succeeds and branch_manager is present.
+        let guard = crate::policy_guard::PolicyGuard::new(
+            crate::policy_guard::UnsafeOverrides::default(),
+        );
+        let engine = LoopEngine::new(config, guard);
+        assert!(
+            engine.branch_manager.is_some(),
+            "branch_manager must be Some in single-PR mode"
+        );
+        // The derived branch name for issue 0 with empty title starts with "loop/0".
+        let bm = engine.branch_manager.as_ref().unwrap();
+        let name = bm.branch_name(0, "");
+        assert!(
+            name.starts_with("loop/0"),
+            "branch name '{name}' must start with 'loop/0', not the bare prefix"
+        );
+        assert_ne!(name, "loop", "branch name must not be the bare trimmed prefix");
+    }
+
+    /// Verify that in no-pr mode, `branch_manager` is None (we don't manage
+    /// branches when PR creation is disabled).
+    #[test]
+    fn no_pr_mode_has_no_branch_manager() {
+        use crate::config::{PrManagementConfig, PrMode};
+        let config = LoopConfig {
+            iterations: 1,
+            provider: Provider::Claude,
+            prompt_inline: Some("test".to_string()),
+            pr_management: PrManagementConfig {
+                mode: PrMode::NoPr,
+                ..PrManagementConfig::default()
+            },
+            ..Default::default()
+        };
+        let guard = crate::policy_guard::PolicyGuard::new(
+            crate::policy_guard::UnsafeOverrides::default(),
+        );
+        let engine = LoopEngine::new(config, guard);
+        assert!(
+            engine.branch_manager.is_none(),
+            "branch_manager must be None in no-pr mode"
         );
     }
 }

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -48,6 +48,9 @@ pub struct SessionSummary {
     pub successes: u64,
     pub failures: u64,
     pub retries: u64,
+    /// Number of planned orchestration actions that were intentionally skipped
+    /// (e.g. PR blocked on human review, no actionable PR found).
+    pub skipped_decisions: u64,
     pub termination_reason: Option<TerminationReason>,
 }
 
@@ -58,17 +61,19 @@ impl SessionSummary {
             successes = self.successes,
             failures = self.failures,
             retries = self.retries,
+            skipped_decisions = self.skipped_decisions,
             termination_reason = %self.termination_reason.as_ref().map(|r| r.to_string()).unwrap_or_default(),
             "Session summary"
         );
         println!();
         println!("─── Session Summary ────────────────────────────");
-        println!("  Iterations run : {}", self.iterations_run);
-        println!("  Successes      : {}", self.successes);
-        println!("  Failures       : {}", self.failures);
-        println!("  Retries        : {}", self.retries);
+        println!("  Iterations run   : {}", self.iterations_run);
+        println!("  Successes        : {}", self.successes);
+        println!("  Failures         : {}", self.failures);
+        println!("  Retries          : {}", self.retries);
+        println!("  Skipped decisions: {}", self.skipped_decisions);
         if let Some(reason) = &self.termination_reason {
-            println!("  Termination    : {reason}");
+            println!("  Termination      : {reason}");
         }
         println!("────────────────────────────────────────────────");
     }
@@ -226,6 +231,29 @@ impl LoopEngine {
             config,
             adapter,
             policy_engine: Some(policy_engine),
+            guard,
+            tracker,
+            pr_strategy,
+            pr_manager: None,
+            branch_manager: None,
+            interrupted,
+        }
+    }
+
+    /// Constructor that accepts a custom adapter and PR strategy (useful for testing).
+    #[cfg(test)]
+    pub fn with_adapter_and_pr_strategy(
+        config: LoopConfig,
+        adapter: Box<dyn ProviderAdapter>,
+        pr_strategy: Box<dyn PrStrategy>,
+    ) -> Self {
+        let interrupted = Arc::new(AtomicBool::new(false));
+        let guard = PolicyGuard::new(crate::policy_guard::UnsafeOverrides::default());
+        let tracker = build_tracker(&config);
+        Self {
+            config,
+            adapter,
+            policy_engine: None,
             guard,
             tracker,
             pr_strategy,
@@ -486,6 +514,7 @@ impl LoopEngine {
                             pr = pr.number,
                             "multi-pr: PR ready but blocked on human review; falling through to issue work"
                         );
+                        summary.skipped_decisions += 1;
                         // Fall through — no prompt override set, so normal issue-work prompt is used.
                     }
                     _ => {}
@@ -730,6 +759,7 @@ impl LoopEngine {
                                 pr = pr.number,
                                 "single-pr: PR already open; blocked on human review"
                             );
+                            summary.skipped_decisions += 1;
                         }
                         Ok(crate::pr_manager::PrAction::NoSignal) => {}
                         Err(e) => {
@@ -918,6 +948,7 @@ impl LoopEngine {
                 .termination_reason
                 .as_ref()
                 .map(|r| r.to_string()),
+            skipped_decisions: summary.skipped_decisions,
             iterations: iteration_records,
         };
         artifacts.write_manifest(&manifest);
@@ -1711,5 +1742,53 @@ mod tests {
             engine.branch_manager.is_none(),
             "branch_manager must be None in no-pr mode"
         );
+    }
+
+    // ── skipped_decisions counter ────────────────────────────────────────────
+
+    #[test]
+    fn blocked_on_human_review_increments_skipped_decisions() {
+        use crate::config::{PrManagementConfig, PrMode};
+        use crate::pr_manager::{PrInfo, TriageAction};
+        use crate::pr_strategy::{IterationPlan, PrStrategy};
+
+        /// Fake strategy that always returns BlockedOnHumanReview.
+        struct BlockedStrategy;
+        impl PrStrategy for BlockedStrategy {
+            fn plan_iteration(&self, _iteration: u64) -> IterationPlan {
+                let pr = PrInfo {
+                    number: 42,
+                    title: "feat: something".to_string(),
+                    url: "https://github.com/owner/repo/pull/42".to_string(),
+                };
+                IterationPlan {
+                    description: "blocked on human review".to_string(),
+                    mode: PrMode::MultiPr,
+                    prompt_override: None,
+                    triage_action: Some(TriageAction::BlockedOnHumanReview { pr }),
+                }
+            }
+        }
+
+        let config = LoopConfig {
+            iterations: 2,
+            provider: Provider::Claude,
+            prompt_inline: Some("test prompt".to_string()),
+            pr_management: PrManagementConfig {
+                mode: PrMode::MultiPr,
+                ..PrManagementConfig::default()
+            },
+            ..Default::default()
+        };
+        let engine = LoopEngine::with_adapter_and_pr_strategy(
+            config,
+            Box::new(FakeAdapter::success("fake")),
+            Box::new(BlockedStrategy),
+        );
+        let summary = engine.run();
+        assert_eq!(summary.iterations_run, 2);
+        assert_eq!(summary.successes, 2);
+        assert_eq!(summary.skipped_decisions, 2,
+            "each BlockedOnHumanReview should increment skipped_decisions by 1");
     }
 }

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -665,7 +665,22 @@ impl LoopEngine {
                             break;
                         } else {
                             let outcome = IterationOutcome::from_exit_code(result.exit_code);
-                            if attempt < self.config.max_retries && outcome.is_retryable() {
+                            let is_permanent = result
+                                .exit_code
+                                .map(|c| self.config.non_retryable_exit_codes.contains(&c))
+                                .unwrap_or(false);
+                            if is_permanent {
+                                warn!(
+                                    iteration = i,
+                                    provider = self.adapter.name(),
+                                    exit_code = result.exit_code,
+                                    "Iteration failed with a non-retryable exit code; skipping retries"
+                                );
+                            }
+                            if !is_permanent
+                                && attempt < self.config.max_retries
+                                && outcome.is_retryable()
+                            {
                                 summary.retries += 1;
                                 let delay_ms = compute_backoff_ms(
                                     self.config.retry_backoff_ms,
@@ -1368,6 +1383,75 @@ mod tests {
         let summary = engine.run();
         assert_eq!(summary.retries, 0);
         assert_eq!(summary.failures, 2);
+    }
+
+    #[test]
+    fn non_retryable_exit_code_skips_retries() {
+        use crate::provider::tests::FakeAdapter;
+
+        // max_retries = 3, but exit code 2 is in non_retryable_exit_codes.
+        // The engine should record 0 retries and 1 failure.
+        let config = LoopConfig {
+            iterations: 1,
+            provider: Provider::Claude,
+            prompt_inline: Some("test".to_string()),
+            max_retries: 3,
+            retry_backoff_ms: 0,
+            non_retryable_exit_codes: vec![2],
+            ..Default::default()
+        };
+        let adapter = FakeAdapter::with_exit_code("fake", 2);
+        let engine = LoopEngine::with_adapter(config, Box::new(adapter));
+        let summary = engine.run();
+        assert_eq!(summary.iterations_run, 1);
+        assert_eq!(summary.failures, 1);
+        assert_eq!(
+            summary.retries, 0,
+            "non-retryable code should not be retried"
+        );
+    }
+
+    #[test]
+    fn retryable_exit_code_not_in_list_still_retries() {
+        use crate::provider::tests::FakeAdapter;
+
+        // Exit code 1 is not in non_retryable_exit_codes (only 2 is).
+        // With max_retries = 2 it should retry twice before giving up.
+        let config = LoopConfig {
+            iterations: 1,
+            provider: Provider::Claude,
+            prompt_inline: Some("test".to_string()),
+            max_retries: 2,
+            retry_backoff_ms: 0,
+            non_retryable_exit_codes: vec![2],
+            ..Default::default()
+        };
+        let adapter = FakeAdapter::with_exit_code("fake", 1);
+        let engine = LoopEngine::with_adapter(config, Box::new(adapter));
+        let summary = engine.run();
+        assert_eq!(summary.failures, 1);
+        assert_eq!(summary.retries, 2, "exit code 1 should still be retried");
+    }
+
+    #[test]
+    fn non_retryable_exit_codes_empty_retries_normally() {
+        use crate::provider::tests::FakeAdapter;
+
+        // When non_retryable_exit_codes is empty (default), all non-zero exits retry.
+        let config = LoopConfig {
+            iterations: 1,
+            provider: Provider::Claude,
+            prompt_inline: Some("test".to_string()),
+            max_retries: 1,
+            retry_backoff_ms: 0,
+            non_retryable_exit_codes: vec![],
+            ..Default::default()
+        };
+        let adapter = FakeAdapter::with_exit_code("fake", 99);
+        let engine = LoopEngine::with_adapter(config, Box::new(adapter));
+        let summary = engine.run();
+        assert_eq!(summary.failures, 1);
+        assert_eq!(summary.retries, 1);
     }
 
     #[test]

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -148,6 +148,7 @@ impl LoopEngine {
             config.telemetry.stream_output,
             config.workspace_dir.clone(),
             config.iteration_timeout_secs,
+            config.provider_extra_args.clone(),
         );
         let policy_engine = if config.orchestration.enabled {
             let owner = config.orchestration.repo_owner.clone().unwrap_or_default();

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -281,6 +281,15 @@ impl LoopEngine {
                     repo = %format!("{owner}/{repo}"),
                     "Issue tracking active"
                 );
+                // Ensure standard labels exist on the repository.
+                let labels = self.config.issue_tracking.standard_labels.clone();
+                if !labels.is_empty() {
+                    if let Err(e) = self.tracker.ensure_labels(&labels) {
+                        warn!(error = %e, "Failed to ensure standard labels on repository");
+                    } else {
+                        info!(labels = ?labels, "Standard labels ensured on repository");
+                    }
+                }
             }
         }
 
@@ -588,6 +597,57 @@ impl LoopEngine {
         );
 
         summary.print();
+
+        // End-of-run owned-issue lifecycle verification.
+        // When a linked issue is configured and we're in GitHub mode, check
+        // whether the issue is still open.  If the run succeeded and all work
+        // appears done, warn (or close, when auto_close_owned_issues=true).
+        if self.config.issue_tracking.mode == IssueTrackingMode::Github {
+            if let Some(issue_number) = self.config.issue_tracking.comment_issue_number {
+                match self.tracker.get_issue(issue_number) {
+                    Ok(issue) if issue.state == crate::issue_tracker::IssueState::Open => {
+                        if self.config.issue_tracking.auto_close_owned_issues {
+                            info!(
+                                issue = issue_number,
+                                "auto_close_owned_issues: closing issue at end of run"
+                            );
+                            let close_comment = format!(
+                                "Loop run `{run_id}` completed — closing issue automatically \
+                                 (`auto_close_owned_issues=true`).",
+                                run_id = artifacts.run_id
+                            );
+                            let _ = self.tracker.add_comment(issue_number, &close_comment);
+                            if let Err(e) = self.tracker.close_issue(
+                                issue_number,
+                                crate::issue_tracker::CloseReason::Completed,
+                            ) {
+                                warn!(
+                                    issue = issue_number,
+                                    error = %e,
+                                    "auto_close_owned_issues: failed to close issue"
+                                );
+                            }
+                        } else {
+                            warn!(
+                                issue = issue_number,
+                                "Owned issue is still open at end of run. \
+                                 Set auto_close_owned_issues=true to close automatically."
+                            );
+                        }
+                    }
+                    Ok(_) => {
+                        info!(issue = issue_number, "Owned issue is closed — lifecycle complete");
+                    }
+                    Err(e) => {
+                        warn!(
+                            issue = issue_number,
+                            error = %e,
+                            "Could not verify owned issue state at end of run"
+                        );
+                    }
+                }
+            }
+        }
 
         // Post run-end comment.
         if self.config.issue_tracking.comment_cadence != CommentCadence::OffEngine {
@@ -1021,7 +1081,7 @@ mod tests {
                 repo_name: Some("repo".to_string()),
                 comment_issue_number: Some(issue),
                 comment_cadence: cadence,
-                local_promise_path: None,
+                ..Default::default()
             },
             ..Default::default()
         }
@@ -1148,6 +1208,142 @@ mod tests {
         );
     }
 
+    // ── Label-ensure and ownership verification tests ────────────────────────
+
+    #[test]
+    fn github_mode_calls_ensure_labels_at_startup() {
+        let tracker = Arc::new(MockIssueTracker::new());
+        let config = LoopConfig {
+            iterations: 1,
+            provider: Provider::Claude,
+            prompt_inline: Some("test".to_string()),
+            issue_tracking: IssueTrackingConfig {
+                mode: IssueTrackingMode::Github,
+                repo_owner: Some("o".to_string()),
+                repo_name: Some("r".to_string()),
+                comment_issue_number: None,
+                comment_cadence: CommentCadence::OffEngine,
+                standard_labels: vec!["bug".to_string(), "tech-debt".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let engine = LoopEngine::with_adapter_and_tracker(
+            config,
+            Box::new(FakeAdapter::success("fake")),
+            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(&tracker))),
+        );
+        engine.run();
+        let calls = tracker.recorded_calls();
+        assert!(
+            calls.iter().any(|c| matches!(c, MockCall::EnsureLabels(l) if l.contains(&"bug".to_string()))),
+            "expected EnsureLabels call; got: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn local_mode_does_not_call_ensure_labels() {
+        let tracker = Arc::new(MockIssueTracker::new());
+        let config = LoopConfig {
+            iterations: 1,
+            provider: Provider::Claude,
+            prompt_inline: Some("test".to_string()),
+            issue_tracking: IssueTrackingConfig {
+                mode: IssueTrackingMode::Local,
+                comment_cadence: CommentCadence::OffEngine,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let engine = LoopEngine::with_adapter_and_tracker(
+            config,
+            Box::new(FakeAdapter::success("fake")),
+            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(&tracker))),
+        );
+        engine.run();
+        let calls = tracker.recorded_calls();
+        assert!(
+            !calls.iter().any(|c| matches!(c, MockCall::EnsureLabels(_))),
+            "local mode should not call ensure_labels; got: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn auto_close_owned_issues_closes_open_issue_at_end_of_run() {
+        let tracker = Arc::new(MockIssueTracker::new());
+        // Default mock returns an open issue for get_issue.
+        let config = LoopConfig {
+            iterations: 1,
+            provider: Provider::Claude,
+            prompt_inline: Some("test".to_string()),
+            issue_tracking: IssueTrackingConfig {
+                mode: IssueTrackingMode::Github,
+                repo_owner: Some("o".to_string()),
+                repo_name: Some("r".to_string()),
+                comment_issue_number: Some(42),
+                comment_cadence: CommentCadence::OffEngine,
+                auto_close_owned_issues: true,
+                standard_labels: vec![],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let engine = LoopEngine::with_adapter_and_tracker(
+            config,
+            Box::new(FakeAdapter::success("fake")),
+            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(&tracker))),
+        );
+        engine.run();
+        let calls = tracker.recorded_calls();
+        assert!(
+            calls.iter().any(|c| matches!(c, MockCall::CloseIssue(42))),
+            "auto_close_owned_issues should close issue 42; calls: {calls:?}"
+        );
+    }
+
+    #[test]
+    fn owned_issue_already_closed_does_not_close_again() {
+        let tracker = Arc::new(MockIssueTracker::new());
+        // Override next_issue to return a closed issue.
+        *tracker.next_issue.lock().unwrap() = Some(crate::issue_tracker::Issue {
+            id: 1,
+            number: 42,
+            title: "already done".to_string(),
+            body: "".to_string(),
+            state: crate::issue_tracker::IssueState::Closed,
+            labels: vec![],
+            assignees: vec![],
+            url: "https://example.com/42".to_string(),
+        });
+        let config = LoopConfig {
+            iterations: 1,
+            provider: Provider::Claude,
+            prompt_inline: Some("test".to_string()),
+            issue_tracking: IssueTrackingConfig {
+                mode: IssueTrackingMode::Github,
+                repo_owner: Some("o".to_string()),
+                repo_name: Some("r".to_string()),
+                comment_issue_number: Some(42),
+                comment_cadence: CommentCadence::OffEngine,
+                auto_close_owned_issues: true,
+                standard_labels: vec![],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let engine = LoopEngine::with_adapter_and_tracker(
+            config,
+            Box::new(FakeAdapter::success("fake")),
+            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(&tracker))),
+        );
+        engine.run();
+        let calls = tracker.recorded_calls();
+        assert!(
+            !calls.iter().any(|c| matches!(c, MockCall::CloseIssue(_))),
+            "already-closed issue should not be closed again; calls: {calls:?}"
+        );
+    }
+
     #[test]
     fn stop_on_failure_posts_blocker_comment() {
         let tracker = Arc::new(MockIssueTracker::new());
@@ -1162,7 +1358,7 @@ mod tests {
                 repo_name: Some("r".to_string()),
                 comment_issue_number: Some(3),
                 comment_cadence: CommentCadence::Milestones,
-                local_promise_path: None,
+                ..Default::default()
             },
             ..Default::default()
         };

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -3,14 +3,10 @@ use crate::config::{CommentCadence, IssueTrackingMode, LoopConfig, PrMode};
 use crate::issue_tracker::{GitHubIssueTracker, IssueTracker, LocalPromiseTracker};
 use crate::orchestration::{BranchSelection, GhCliContextResolver, PolicyEngine};
 use crate::policy_guard::PolicyGuard;
-use crate::pr_manager::{
-    GhPrLifecycle, PrManager, TriageAction, build_pr_manager,
-};
-use crate::pr_strategy::{PrStrategy, build_strategy};
+use crate::pr_manager::{build_pr_manager, GhPrLifecycle, PrManager, TriageAction};
+use crate::pr_strategy::{build_strategy, PrStrategy};
 use crate::provider::{build_adapter, ProviderAdapter};
-use crate::telemetry::{
-    IterationOutcome, IterationRecord, RunArtifacts, RunManifest, unix_now,
-};
+use crate::telemetry::{unix_now, IterationOutcome, IterationRecord, RunArtifacts, RunManifest};
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -145,7 +141,12 @@ pub struct LoopEngine {
 
 impl LoopEngine {
     pub fn new(config: LoopConfig, guard: PolicyGuard) -> Self {
-        let adapter = build_adapter(&config.provider, config.telemetry.stream_output, config.workspace_dir.clone(), config.iteration_timeout_secs);
+        let adapter = build_adapter(
+            &config.provider,
+            config.telemetry.stream_output,
+            config.workspace_dir.clone(),
+            config.iteration_timeout_secs,
+        );
         let policy_engine = if config.orchestration.enabled {
             let owner = config.orchestration.repo_owner.clone().unwrap_or_default();
             let repo = config.orchestration.repo_name.clone().unwrap_or_default();
@@ -170,7 +171,17 @@ impl LoopEngine {
             None
         };
         let interrupted = Arc::new(AtomicBool::new(false));
-        Self { config, adapter, policy_engine, guard, tracker, pr_strategy, pr_manager, branch_manager, interrupted }
+        Self {
+            config,
+            adapter,
+            policy_engine,
+            guard,
+            tracker,
+            pr_strategy,
+            pr_manager,
+            branch_manager,
+            interrupted,
+        }
     }
 
     /// Constructor that accepts a custom adapter; uses a default (safe) policy guard.
@@ -524,7 +535,11 @@ impl LoopEngine {
             // If orchestration is enabled, select a workflow branch and use its prompt.
             let (raw_prompt, workflow_branch) = if let Some(ref engine) = self.policy_engine {
                 match engine.select_branch() {
-                    Ok(BranchSelection { branch, prompt_override, .. }) => {
+                    Ok(BranchSelection {
+                        branch,
+                        prompt_override,
+                        ..
+                    }) => {
                         let branch_name = branch.to_string();
                         info!(
                             iteration = i,
@@ -532,8 +547,8 @@ impl LoopEngine {
                             workflow_branch = %branch_name,
                             "Iteration start"
                         );
-                        let p = prompt_override
-                            .unwrap_or_else(|| branch.default_prompt().to_string());
+                        let p =
+                            prompt_override.unwrap_or_else(|| branch.default_prompt().to_string());
                         (p, Some(branch_name))
                     }
                     Err(e) => {
@@ -640,8 +655,7 @@ impl LoopEngine {
                                 attempt += 1;
                             } else {
                                 final_outcome = outcome;
-                                let first_err =
-                                    IterationRecord::stderr_first_line(&result.stderr);
+                                let first_err = IterationRecord::stderr_first_line(&result.stderr);
                                 warn!(
                                     iteration = i,
                                     provider = self.adapter.name(),
@@ -657,7 +671,10 @@ impl LoopEngine {
                             }
                         }
                     }
-                    Err(crate::error::LooperError::ProviderTimeout { binary: _, timeout_secs }) => {
+                    Err(crate::error::LooperError::ProviderTimeout {
+                        binary: _,
+                        timeout_secs,
+                    }) => {
                         let outcome = IterationOutcome::Timeout;
                         if attempt < self.config.max_retries {
                             summary.retries += 1;
@@ -691,8 +708,9 @@ impl LoopEngine {
                     Err(crate::error::LooperError::ProviderSpawn { binary, source }) => {
                         let msg = format!("failed to spawn '{binary}': {source}");
                         error!(iteration = i, provider = self.adapter.name(), "{msg}");
-                        final_outcome =
-                            IterationOutcome::SpawnFailure { message: msg.clone() };
+                        final_outcome = IterationOutcome::SpawnFailure {
+                            message: msg.clone(),
+                        };
                         if self.config.issue_tracking.comment_cadence != CommentCadence::OffEngine {
                             self.post_comment(&format!(
                                 "**Blocker** — iteration {i} aborted: provider spawn failure. \
@@ -782,7 +800,11 @@ impl LoopEngine {
                             }
                         }
                         Ok(crate::pr_manager::PrAction::Updated { pr, .. }) => {
-                            info!(iteration = i, pr = pr.number, "single-pr: commented on existing PR");
+                            info!(
+                                iteration = i,
+                                pr = pr.number,
+                                "single-pr: commented on existing PR"
+                            );
                         }
                         Ok(crate::pr_manager::PrAction::BlockedOnHumanReview(pr)) => {
                             info!(
@@ -814,11 +836,12 @@ impl LoopEngine {
                 } else {
                     String::new()
                 };
-                let err_note = if let Some(ref exc) = IterationRecord::stderr_first_line(&final_stderr) {
-                    format!("\n> `{exc}`")
-                } else {
-                    String::new()
-                };
+                let err_note =
+                    if let Some(ref exc) = IterationRecord::stderr_first_line(&final_stderr) {
+                        format!("\n> `{exc}`")
+                    } else {
+                        String::new()
+                    };
                 let comment_body = format!(
                     "**Iteration {i}** — outcome: `{outcome}`, duration: {ms}ms{retry}{err}",
                     outcome = final_outcome.label(),
@@ -841,7 +864,8 @@ impl LoopEngine {
             }
 
             // Post blocker comment when aborting due to stop_on_failure.
-            let stop_on_fail = !final_outcome.is_success() && self.config.stop_on_failure && !abort_loop;
+            let stop_on_fail =
+                !final_outcome.is_success() && self.config.stop_on_failure && !abort_loop;
             if stop_on_fail && cadence != &CommentCadence::OffEngine {
                 self.post_comment(&format!(
                     "**Blocker** — iteration {i} failed and `stop_on_failure` is set; \
@@ -875,7 +899,10 @@ impl LoopEngine {
             }
 
             if !final_outcome.is_success() && self.config.stop_on_failure {
-                info!(iteration = i, "stop_on_failure is set; halting loop after failed iteration");
+                info!(
+                    iteration = i,
+                    "stop_on_failure is set; halting loop after failed iteration"
+                );
                 summary.termination_reason = Some(TerminationReason::StoppedOnFailure);
                 break;
             }
@@ -938,7 +965,10 @@ impl LoopEngine {
                         }
                     }
                     Ok(_) => {
-                        info!(issue = issue_number, "Owned issue is closed — lifecycle complete");
+                        info!(
+                            issue = issue_number,
+                            "Owned issue is closed — lifecycle complete"
+                        );
                     }
                     Err(e) => {
                         warn!(
@@ -975,10 +1005,7 @@ impl LoopEngine {
             ended_at: Some(run_ended_at),
             provider: self.adapter.name().to_string(),
             iterations_requested: self.config.iterations,
-            termination_reason: summary
-                .termination_reason
-                .as_ref()
-                .map(|r| r.to_string()),
+            termination_reason: summary.termination_reason.as_ref().map(|r| r.to_string()),
             skipped_decisions: summary.skipped_decisions,
             iterations: iteration_records,
         };
@@ -1143,7 +1170,10 @@ mod tests {
             TerminationReason::ProviderError("bad".to_string()).to_string(),
             "provider error: bad"
         );
-        assert_eq!(TerminationReason::StoppedOnFailure.to_string(), "stopped on failure");
+        assert_eq!(
+            TerminationReason::StoppedOnFailure.to_string(),
+            "stopped on failure"
+        );
     }
 
     #[test]
@@ -1160,7 +1190,10 @@ mod tests {
         let summary = engine.run();
         assert_eq!(summary.iterations_run, 1);
         assert_eq!(summary.failures, 1);
-        assert_eq!(summary.termination_reason, Some(TerminationReason::StoppedOnFailure));
+        assert_eq!(
+            summary.termination_reason,
+            Some(TerminationReason::StoppedOnFailure)
+        );
     }
 
     #[test]
@@ -1177,7 +1210,10 @@ mod tests {
         let summary = engine.run();
         assert_eq!(summary.iterations_run, 3);
         assert_eq!(summary.failures, 3);
-        assert_eq!(summary.termination_reason, Some(TerminationReason::Completed));
+        assert_eq!(
+            summary.termination_reason,
+            Some(TerminationReason::Completed)
+        );
     }
 
     #[test]
@@ -1189,7 +1225,9 @@ mod tests {
         // Adapter that always returns exit code 1.
         struct AlwaysFailAdapter;
         impl ProviderAdapter for AlwaysFailAdapter {
-            fn name(&self) -> &str { "always-fail" }
+            fn name(&self) -> &str {
+                "always-fail"
+            }
             fn execute(&self, _prompt: &str) -> Result<ExecutionResult, LooperError> {
                 Ok(ExecutionResult {
                     exit_code: Some(1),
@@ -1228,7 +1266,9 @@ mod tests {
             calls: Arc<AtomicU32>,
         }
         impl ProviderAdapter for FlipFlopAdapter {
-            fn name(&self) -> &str { "flip-flop" }
+            fn name(&self) -> &str {
+                "flip-flop"
+            }
             fn execute(&self, _prompt: &str) -> Result<ExecutionResult, LooperError> {
                 let n = self.calls.fetch_add(1, AtomOrd::SeqCst);
                 Ok(ExecutionResult {
@@ -1272,7 +1312,10 @@ mod tests {
         let engine = LoopEngine::with_adapter(config, Box::new(adapter));
         let summary = engine.run();
         // The hook runs after run() returns the summary — just confirm loop completed.
-        assert_eq!(summary.termination_reason, Some(TerminationReason::Completed));
+        assert_eq!(
+            summary.termination_reason,
+            Some(TerminationReason::Completed)
+        );
     }
 
     #[test]
@@ -1343,7 +1386,10 @@ mod tests {
             ..Default::default()
         };
         let resolver = StubContextResolver {
-            context: RepoContext { open_pr_count: 0, open_issue_count: 1 },
+            context: RepoContext {
+                open_pr_count: 0,
+                open_issue_count: 1,
+            },
         };
         let policy_engine = PolicyEngine::new(Box::new(resolver));
         let adapter = FakeAdapter::success("fake");
@@ -1351,7 +1397,10 @@ mod tests {
         let summary = engine.run();
         assert_eq!(summary.iterations_run, 2);
         assert_eq!(summary.successes, 2);
-        assert_eq!(summary.termination_reason, Some(TerminationReason::Completed));
+        assert_eq!(
+            summary.termination_reason,
+            Some(TerminationReason::Completed)
+        );
     }
 
     #[test]
@@ -1423,7 +1472,9 @@ mod tests {
         let engine = LoopEngine::with_adapter_and_tracker(
             config,
             Box::new(FakeAdapter::success("fake")),
-            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(&tracker))),
+            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(
+                &tracker,
+            ))),
         );
         engine.run();
         let calls = tracker.recorded_calls();
@@ -1432,14 +1483,24 @@ mod tests {
             .iter()
             .filter(|c| matches!(c, MockCall::AddComment { .. }))
             .collect();
-        assert_eq!(add_comment_calls.len(), 2, "expected start + end comments, got {add_comment_calls:?}");
+        assert_eq!(
+            add_comment_calls.len(),
+            2,
+            "expected start + end comments, got {add_comment_calls:?}"
+        );
         if let MockCall::AddComment { number, body } = &add_comment_calls[0] {
             assert_eq!(*number, 42);
-            assert!(body.contains("Loop run started"), "start comment body: {body}");
+            assert!(
+                body.contains("Loop run started"),
+                "start comment body: {body}"
+            );
         }
         if let MockCall::AddComment { number, body } = &add_comment_calls[1] {
             assert_eq!(*number, 42);
-            assert!(body.contains("Loop run finished"), "end comment body: {body}");
+            assert!(
+                body.contains("Loop run finished"),
+                "end comment body: {body}"
+            );
         }
     }
 
@@ -1450,23 +1511,33 @@ mod tests {
         let engine = LoopEngine::with_adapter_and_tracker(
             config,
             Box::new(FakeAdapter::failure("fake")),
-            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(&tracker))),
+            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(
+                &tracker,
+            ))),
         );
         engine.run();
         let calls = tracker.recorded_calls();
         let comment_bodies: Vec<_> = calls
             .iter()
             .filter_map(|c| {
-                if let MockCall::AddComment { body, .. } = c { Some(body.as_str()) } else { None }
+                if let MockCall::AddComment { body, .. } = c {
+                    Some(body.as_str())
+                } else {
+                    None
+                }
             })
             .collect();
         // start + 2 failure iteration comments (deduplicated if identical) + end
         assert!(
-            comment_bodies.iter().any(|b| b.contains("Loop run started")),
+            comment_bodies
+                .iter()
+                .any(|b| b.contains("Loop run started")),
             "missing start comment; got: {comment_bodies:?}"
         );
         assert!(
-            comment_bodies.iter().any(|b| b.contains("Loop run finished")),
+            comment_bodies
+                .iter()
+                .any(|b| b.contains("Loop run finished")),
             "missing end comment"
         );
         assert!(
@@ -1482,7 +1553,9 @@ mod tests {
         let engine = LoopEngine::with_adapter_and_tracker(
             config,
             Box::new(FakeAdapter::success("fake")),
-            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(&tracker))),
+            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(
+                &tracker,
+            ))),
         );
         engine.run();
         let calls = tracker.recorded_calls();
@@ -1491,7 +1564,10 @@ mod tests {
             .filter(|c| matches!(c, MockCall::AddComment { .. }))
             .count();
         // 1 start + 2 iteration comments + 1 end = 4
-        assert_eq!(add_comment_count, 4, "expected 4 comments for 2 iterations, got {add_comment_count}");
+        assert_eq!(
+            add_comment_count, 4,
+            "expected 4 comments for 2 iterations, got {add_comment_count}"
+        );
     }
 
     #[test]
@@ -1501,11 +1577,15 @@ mod tests {
         let engine = LoopEngine::with_adapter_and_tracker(
             config,
             Box::new(FakeAdapter::success("fake")),
-            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(&tracker))),
+            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(
+                &tracker,
+            ))),
         );
         engine.run();
         let calls = tracker.recorded_calls();
-        let has_comment = calls.iter().any(|c| matches!(c, MockCall::AddComment { .. }));
+        let has_comment = calls
+            .iter()
+            .any(|c| matches!(c, MockCall::AddComment { .. }));
         assert!(!has_comment, "off-engine cadence should post no comments");
     }
 
@@ -1527,12 +1607,16 @@ mod tests {
         let engine = LoopEngine::with_adapter_and_tracker(
             config,
             Box::new(FakeAdapter::success("fake")),
-            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(&tracker))),
+            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(
+                &tracker,
+            ))),
         );
         engine.run();
         let calls = tracker.recorded_calls();
         assert!(
-            !calls.iter().any(|c| matches!(c, MockCall::AddComment { .. })),
+            !calls
+                .iter()
+                .any(|c| matches!(c, MockCall::AddComment { .. })),
             "local mode should never post comments"
         );
     }
@@ -1560,12 +1644,16 @@ mod tests {
         let engine = LoopEngine::with_adapter_and_tracker(
             config,
             Box::new(FakeAdapter::success("fake")),
-            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(&tracker))),
+            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(
+                &tracker,
+            ))),
         );
         engine.run();
         let calls = tracker.recorded_calls();
         assert!(
-            calls.iter().any(|c| matches!(c, MockCall::EnsureLabels(l) if l.contains(&"bug".to_string()))),
+            calls
+                .iter()
+                .any(|c| matches!(c, MockCall::EnsureLabels(l) if l.contains(&"bug".to_string()))),
             "expected EnsureLabels call; got: {calls:?}"
         );
     }
@@ -1587,7 +1675,9 @@ mod tests {
         let engine = LoopEngine::with_adapter_and_tracker(
             config,
             Box::new(FakeAdapter::success("fake")),
-            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(&tracker))),
+            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(
+                &tracker,
+            ))),
         );
         engine.run();
         let calls = tracker.recorded_calls();
@@ -1620,7 +1710,9 @@ mod tests {
         let engine = LoopEngine::with_adapter_and_tracker(
             config,
             Box::new(FakeAdapter::success("fake")),
-            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(&tracker))),
+            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(
+                &tracker,
+            ))),
         );
         engine.run();
         let calls = tracker.recorded_calls();
@@ -1663,7 +1755,9 @@ mod tests {
         let engine = LoopEngine::with_adapter_and_tracker(
             config,
             Box::new(FakeAdapter::success("fake")),
-            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(&tracker))),
+            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(
+                &tracker,
+            ))),
         );
         engine.run();
         let calls = tracker.recorded_calls();
@@ -1694,14 +1788,20 @@ mod tests {
         let engine = LoopEngine::with_adapter_and_tracker(
             config,
             Box::new(FakeAdapter::failure("fake")),
-            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(&tracker))),
+            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(
+                &tracker,
+            ))),
         );
         engine.run();
         let calls = tracker.recorded_calls();
         let comment_bodies: Vec<_> = calls
             .iter()
             .filter_map(|c| {
-                if let MockCall::AddComment { body, .. } = c { Some(body.as_str()) } else { None }
+                if let MockCall::AddComment { body, .. } = c {
+                    Some(body.as_str())
+                } else {
+                    None
+                }
             })
             .collect();
         assert!(
@@ -1732,9 +1832,8 @@ mod tests {
         // Build a production engine; we check the branch_manager field directly.
         // We can't run the loop (it would spawn 'claude'), so we just verify
         // construction succeeds and branch_manager is present.
-        let guard = crate::policy_guard::PolicyGuard::new(
-            crate::policy_guard::UnsafeOverrides::default(),
-        );
+        let guard =
+            crate::policy_guard::PolicyGuard::new(crate::policy_guard::UnsafeOverrides::default());
         let engine = LoopEngine::new(config, guard);
         assert!(
             engine.branch_manager.is_some(),
@@ -1747,7 +1846,10 @@ mod tests {
             name.starts_with("loop/0"),
             "branch name '{name}' must start with 'loop/0', not the bare prefix"
         );
-        assert_ne!(name, "loop", "branch name must not be the bare trimmed prefix");
+        assert_ne!(
+            name, "loop",
+            "branch name must not be the bare trimmed prefix"
+        );
     }
 
     /// Verify that in no-pr mode, `branch_manager` is None (we don't manage
@@ -1765,9 +1867,8 @@ mod tests {
             },
             ..Default::default()
         };
-        let guard = crate::policy_guard::PolicyGuard::new(
-            crate::policy_guard::UnsafeOverrides::default(),
-        );
+        let guard =
+            crate::policy_guard::PolicyGuard::new(crate::policy_guard::UnsafeOverrides::default());
         let engine = LoopEngine::new(config, guard);
         assert!(
             engine.branch_manager.is_none(),
@@ -1819,8 +1920,10 @@ mod tests {
         let summary = engine.run();
         assert_eq!(summary.iterations_run, 2);
         assert_eq!(summary.successes, 2);
-        assert_eq!(summary.skipped_decisions, 2,
-            "each BlockedOnHumanReview should increment skipped_decisions by 1");
+        assert_eq!(
+            summary.skipped_decisions, 2,
+            "each BlockedOnHumanReview should increment skipped_decisions by 1"
+        );
     }
 
     // ── Timeout handling ──────────────────────────────────────────────────────
@@ -1838,9 +1941,15 @@ mod tests {
         let engine = LoopEngine::with_adapter(config, Box::new(TimeoutAdapter));
         let summary = engine.run();
         assert_eq!(summary.iterations_run, 3);
-        assert_eq!(summary.failures, 3, "timed-out iterations should count as failures");
+        assert_eq!(
+            summary.failures, 3,
+            "timed-out iterations should count as failures"
+        );
         assert_eq!(summary.successes, 0);
-        assert_eq!(summary.termination_reason, Some(TerminationReason::Completed));
+        assert_eq!(
+            summary.termination_reason,
+            Some(TerminationReason::Completed)
+        );
     }
 
     #[test]
@@ -1876,6 +1985,9 @@ mod tests {
         let engine = LoopEngine::with_adapter(config, Box::new(TimeoutAdapter));
         let summary = engine.run();
         assert_eq!(summary.iterations_run, 1, "should stop after first timeout");
-        assert_eq!(summary.termination_reason, Some(TerminationReason::StoppedOnFailure));
+        assert_eq!(
+            summary.termination_reason,
+            Some(TerminationReason::StoppedOnFailure)
+        );
     }
 }

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -2,6 +2,7 @@ use crate::config::{IssueTrackingMode, LoopConfig};
 use crate::issue_tracker::{GitHubIssueTracker, IssueTracker, LocalPromiseTracker};
 use crate::orchestration::{GhCliContextResolver, PolicyEngine};
 use crate::policy_guard::PolicyGuard;
+use crate::pr_strategy::{PrStrategy, build_strategy};
 use crate::provider::{build_adapter, ProviderAdapter};
 use crate::telemetry::{
     IterationOutcome, IterationRecord, RunArtifacts, RunManifest, unix_now,
@@ -109,6 +110,8 @@ pub struct LoopEngine {
     /// active use (start/milestone/end comments) lands in a follow-up issue.
     #[allow(dead_code)]
     tracker: Box<dyn IssueTracker>,
+    /// PR strategy: consulted once per iteration before the provider is invoked.
+    pr_strategy: Box<dyn PrStrategy>,
     /// Shared flag set to `true` when SIGINT is received.
     interrupted: Arc<AtomicBool>,
 }
@@ -124,8 +127,9 @@ impl LoopEngine {
             None
         };
         let tracker = build_tracker(&config);
+        let pr_strategy = build_strategy(config.pr_management.clone());
         let interrupted = Arc::new(AtomicBool::new(false));
-        Self { config, adapter, policy_engine, guard, tracker, interrupted }
+        Self { config, adapter, policy_engine, guard, tracker, pr_strategy, interrupted }
     }
 
     /// Constructor that accepts a custom adapter; uses a default (safe) policy guard.
@@ -134,7 +138,8 @@ impl LoopEngine {
         let interrupted = Arc::new(AtomicBool::new(false));
         let guard = PolicyGuard::new(crate::policy_guard::UnsafeOverrides::default());
         let tracker = build_tracker(&config);
-        Self { config, adapter, policy_engine: None, guard, tracker, interrupted }
+        let pr_strategy = build_strategy(config.pr_management.clone());
+        Self { config, adapter, policy_engine: None, guard, tracker, pr_strategy, interrupted }
     }
 
     /// Constructor that accepts a custom adapter and policy engine (useful for testing).
@@ -147,7 +152,8 @@ impl LoopEngine {
         let interrupted = Arc::new(AtomicBool::new(false));
         let guard = PolicyGuard::new(crate::policy_guard::UnsafeOverrides::default());
         let tracker = build_tracker(&config);
-        Self { config, adapter, policy_engine: Some(policy_engine), guard, tracker, interrupted }
+        let pr_strategy = build_strategy(config.pr_management.clone());
+        Self { config, adapter, policy_engine: Some(policy_engine), guard, tracker, pr_strategy, interrupted }
     }
 
     /// Install a Ctrl+C handler that sets the interrupted flag.
@@ -271,6 +277,15 @@ impl LoopEngine {
 
             let iter_started_at = unix_now();
             let iter_start = Instant::now();
+
+            // Consult the PR strategy before the provider is invoked.
+            let pr_plan = self.pr_strategy.plan_iteration(i);
+            info!(
+                iteration = i,
+                pr_mode = %pr_plan.mode,
+                pr_plan = %pr_plan.description,
+                "PR strategy plan"
+            );
 
             // If orchestration is enabled, select a workflow branch and use its prompt.
             let (raw_prompt, workflow_branch) = if let Some(ref engine) = self.policy_engine {

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -3,6 +3,9 @@ use crate::issue_tracker::{GitHubIssueTracker, IssueTracker, LocalPromiseTracker
 use crate::orchestration::{GhCliContextResolver, PolicyEngine};
 use crate::policy_guard::PolicyGuard;
 use crate::provider::{build_adapter, ProviderAdapter};
+use crate::telemetry::{
+    IterationOutcome, IterationRecord, RunArtifacts, RunManifest, unix_now,
+};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
@@ -112,7 +115,7 @@ pub struct LoopEngine {
 
 impl LoopEngine {
     pub fn new(config: LoopConfig, guard: PolicyGuard) -> Self {
-        let adapter = build_adapter(&config.provider);
+        let adapter = build_adapter(&config.provider, config.telemetry.stream_output);
         let policy_engine = if config.orchestration.enabled {
             let owner = config.orchestration.repo_owner.clone().unwrap_or_default();
             let repo = config.orchestration.repo_name.clone().unwrap_or_default();
@@ -195,8 +198,26 @@ impl LoopEngine {
             self.config.iterations as u64
         };
 
+        let prompt_source = if self.config.prompt_file.is_some() {
+            "file"
+        } else if self.config.prompt_inline.is_some() {
+            "inline"
+        } else {
+            "none"
+        };
+
         let mut summary = SessionSummary::default();
+        let run_started_at = unix_now();
         let session_start = Instant::now();
+
+        // Set up run artifact directory.
+        let artifacts = RunArtifacts::create(
+            &self.config.telemetry.artifacts_dir,
+            // Only persist artifacts when not in no_summary mode.  The
+            // directory is always created when telemetry is on by default.
+            !self.config.telemetry.no_summary,
+        );
+        let mut iteration_records: Vec<IterationRecord> = Vec::new();
 
         // Log issue tracking mode; warn loudly when running in local/dev mode.
         match self.config.issue_tracking.mode {
@@ -232,18 +253,13 @@ impl LoopEngine {
 
         info!(
             provider = self.adapter.name(),
+            run_id = %artifacts.run_id,
             iterations = if infinite {
                 "infinite".to_string()
             } else {
                 max.to_string()
             },
-            prompt_source = if self.config.prompt_file.is_some() {
-                "file"
-            } else if self.config.prompt_inline.is_some() {
-                "inline"
-            } else {
-                "none"
-            },
+            prompt_source,
             "Loop starting"
         );
 
@@ -253,22 +269,40 @@ impl LoopEngine {
                 break;
             }
 
+            let iter_started_at = unix_now();
             let iter_start = Instant::now();
 
             // If orchestration is enabled, select a workflow branch and use its prompt.
-            let raw_prompt = if let Some(ref engine) = self.policy_engine {
+            let (raw_prompt, workflow_branch) = if let Some(ref engine) = self.policy_engine {
                 match engine.select_branch() {
                     Ok((branch, _ctx)) => {
+                        let branch_name = branch.to_string();
                         info!(
                             iteration = i,
                             provider = self.adapter.name(),
-                            workflow_branch = %branch,
+                            workflow_branch = %branch_name,
                             "Iteration start"
                         );
-                        branch.default_prompt().to_string()
+                        let p = branch.default_prompt().to_string();
+                        (p, Some(branch_name))
                     }
                     Err(e) => {
                         error!(iteration = i, "Policy engine failed: {e}");
+                        let outcome = IterationOutcome::PolicyGuardBlock {
+                            message: e.to_string(),
+                        };
+                        iteration_records.push(IterationRecord {
+                            iteration: i,
+                            provider: self.adapter.name().to_string(),
+                            prompt_source: prompt_source.to_string(),
+                            workflow_branch: None,
+                            outcome: outcome.clone(),
+                            duration_ms: iter_start.elapsed().as_millis(),
+                            retries: 0,
+                            stderr_excerpt: Some(e.to_string()),
+                            transcript_path: None,
+                            started_at: iter_started_at,
+                        });
                         summary.iterations_run += 1;
                         summary.failures += 1;
                         summary.termination_reason =
@@ -282,7 +316,7 @@ impl LoopEngine {
                     provider = self.adapter.name(),
                     "Iteration start"
                 );
-                prompt.clone()
+                (prompt.clone(), None)
             };
 
             // Augment prompt with MCP-use preamble (no-op when allow_direct_github is set).
@@ -290,15 +324,23 @@ impl LoopEngine {
 
             // Execute with retry/backoff.
             let mut attempt = 0u32;
-            let mut iteration_succeeded = false;
+            #[allow(unused_assignments)]
+            let mut final_outcome = IterationOutcome::Unknown;
+            let mut final_stdout = String::new();
+            let mut final_stderr = String::new();
+            let mut final_duration_ms = 0u128;
             let mut abort_loop = false;
 
             loop {
                 match self.adapter.execute(&effective_prompt) {
                     Ok(result) => {
                         let duration_ms = result.duration.as_millis();
+                        final_duration_ms = duration_ms;
+                        final_stdout = result.stdout.clone();
+                        final_stderr = result.stderr.clone();
 
                         if result.succeeded() {
+                            final_outcome = IterationOutcome::Success;
                             if attempt > 0 {
                                 info!(
                                     iteration = i,
@@ -318,7 +360,6 @@ impl LoopEngine {
                                     "Iteration succeeded"
                                 );
                             }
-                            iteration_succeeded = true;
                             break;
                         } else if attempt < self.config.max_retries {
                             summary.retries += 1;
@@ -336,6 +377,9 @@ impl LoopEngine {
                             ));
                             attempt += 1;
                         } else {
+                            final_outcome = IterationOutcome::from_exit_code(result.exit_code);
+                            let first_err =
+                                IterationRecord::stderr_first_line(&result.stderr);
                             warn!(
                                 iteration = i,
                                 provider = self.adapter.name(),
@@ -344,25 +388,56 @@ impl LoopEngine {
                                 stderr = %result.stderr.trim(),
                                 "Iteration failed (non-zero exit)"
                             );
+                            if let Some(ref excerpt) = first_err {
+                                warn!(iteration = i, stderr_first_line = %excerpt, "");
+                            }
                             break;
                         }
                     }
                     Err(crate::error::LooperError::ProviderSpawn { binary, source }) => {
                         let msg = format!("failed to spawn '{binary}': {source}");
                         error!(iteration = i, provider = self.adapter.name(), "{msg}");
+                        final_outcome =
+                            IterationOutcome::SpawnFailure { message: msg.clone() };
                         summary.termination_reason = Some(TerminationReason::ProviderError(msg));
                         abort_loop = true;
                         break;
                     }
                     Err(e) => {
                         error!(iteration = i, provider = self.adapter.name(), error = %e, "Iteration error");
+                        final_outcome = IterationOutcome::Unknown;
                         break;
                     }
                 }
             }
 
+            // Persist iteration transcript and build the record.
+            let transcript_path = artifacts.write_transcript(i, &final_stdout, &final_stderr);
+            let stderr_excerpt = IterationRecord::stderr_first_line(&final_stderr);
+
+            info!(
+                iteration = i,
+                outcome = final_outcome.label(),
+                duration_ms = final_duration_ms,
+                retries = attempt,
+                "Iteration complete"
+            );
+
+            iteration_records.push(IterationRecord {
+                iteration: i,
+                provider: self.adapter.name().to_string(),
+                prompt_source: prompt_source.to_string(),
+                workflow_branch: workflow_branch.clone(),
+                outcome: final_outcome.clone(),
+                duration_ms: final_duration_ms,
+                retries: attempt,
+                stderr_excerpt,
+                transcript_path,
+                started_at: iter_started_at,
+            });
+
             summary.iterations_run += 1;
-            if iteration_succeeded {
+            if final_outcome.is_success() {
                 summary.successes += 1;
             } else {
                 summary.failures += 1;
@@ -372,13 +447,11 @@ impl LoopEngine {
                 break;
             }
 
-            if !iteration_succeeded && self.config.stop_on_failure {
+            if !final_outcome.is_success() && self.config.stop_on_failure {
                 info!(iteration = i, "stop_on_failure is set; halting loop after failed iteration");
                 summary.termination_reason = Some(TerminationReason::StoppedOnFailure);
                 break;
             }
-
-            let _ = iter_start; // elapsed captured inside result.duration
         }
 
         if summary.termination_reason.is_none() {
@@ -390,6 +463,8 @@ impl LoopEngine {
         }
 
         let total_ms = session_start.elapsed().as_millis();
+        let run_ended_at = unix_now();
+
         info!(
             total_duration_ms = total_ms,
             termination_reason = %summary.termination_reason.as_ref().unwrap(),
@@ -397,6 +472,32 @@ impl LoopEngine {
         );
 
         summary.print();
+
+        // Write run manifest and summary.
+        let manifest = RunManifest {
+            run_id: artifacts.run_id.clone(),
+            started_at: run_started_at,
+            ended_at: Some(run_ended_at),
+            provider: self.adapter.name().to_string(),
+            iterations_requested: self.config.iterations,
+            termination_reason: summary
+                .termination_reason
+                .as_ref()
+                .map(|r| r.to_string()),
+            iterations: iteration_records,
+        };
+        artifacts.write_manifest(&manifest);
+        if let Some(summary_path) =
+            artifacts.write_summary(&manifest, self.config.telemetry.no_summary)
+        {
+            info!(path = %summary_path.display(), "Run summary written");
+        }
+
+        // Prune old run directories.
+        RunArtifacts::prune_old_runs(
+            &self.config.telemetry.artifacts_dir,
+            self.config.telemetry.keep_runs,
+        );
 
         // Run completion hook if configured.
         if let Some(cmd) = &self.config.on_complete {

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -145,7 +145,7 @@ pub struct LoopEngine {
 
 impl LoopEngine {
     pub fn new(config: LoopConfig, guard: PolicyGuard) -> Self {
-        let adapter = build_adapter(&config.provider, config.telemetry.stream_output, config.workspace_dir.clone());
+        let adapter = build_adapter(&config.provider, config.telemetry.stream_output, config.workspace_dir.clone(), config.iteration_timeout_secs);
         let policy_engine = if config.orchestration.enabled {
             let owner = config.orchestration.repo_owner.clone().unwrap_or_default();
             let repo = config.orchestration.repo_name.clone().unwrap_or_default();
@@ -655,6 +655,37 @@ impl LoopEngine {
                                 }
                                 break;
                             }
+                        }
+                    }
+                    Err(crate::error::LooperError::ProviderTimeout { binary: _, timeout_secs }) => {
+                        let outcome = IterationOutcome::Timeout;
+                        if attempt < self.config.max_retries {
+                            summary.retries += 1;
+                            let delay_ms = compute_backoff_ms(
+                                self.config.retry_backoff_ms,
+                                self.config.retry_backoff_multiplier,
+                                attempt,
+                            );
+                            warn!(
+                                iteration = i,
+                                attempt = attempt + 1,
+                                max_retries = self.config.max_retries,
+                                provider = self.adapter.name(),
+                                timeout_secs,
+                                backoff_ms = delay_ms,
+                                "Iteration timed out (retryable), retrying"
+                            );
+                            std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+                            attempt += 1;
+                        } else {
+                            warn!(
+                                iteration = i,
+                                provider = self.adapter.name(),
+                                timeout_secs,
+                                "Iteration timed out"
+                            );
+                            final_outcome = outcome;
+                            break;
                         }
                     }
                     Err(crate::error::LooperError::ProviderSpawn { binary, source }) => {
@@ -1790,5 +1821,61 @@ mod tests {
         assert_eq!(summary.successes, 2);
         assert_eq!(summary.skipped_decisions, 2,
             "each BlockedOnHumanReview should increment skipped_decisions by 1");
+    }
+
+    // ── Timeout handling ──────────────────────────────────────────────────────
+
+    #[test]
+    fn timeout_iteration_is_counted_as_failure() {
+        use crate::provider::tests::TimeoutAdapter;
+
+        let config = LoopConfig {
+            iterations: 3,
+            provider: Provider::Claude,
+            prompt_inline: Some("test".to_string()),
+            ..Default::default()
+        };
+        let engine = LoopEngine::with_adapter(config, Box::new(TimeoutAdapter));
+        let summary = engine.run();
+        assert_eq!(summary.iterations_run, 3);
+        assert_eq!(summary.failures, 3, "timed-out iterations should count as failures");
+        assert_eq!(summary.successes, 0);
+        assert_eq!(summary.termination_reason, Some(TerminationReason::Completed));
+    }
+
+    #[test]
+    fn timeout_is_retried_when_max_retries_set() {
+        use crate::provider::tests::TimeoutAdapter;
+
+        let config = LoopConfig {
+            iterations: 1,
+            provider: Provider::Claude,
+            prompt_inline: Some("test".to_string()),
+            max_retries: 2,
+            retry_backoff_ms: 0,
+            ..Default::default()
+        };
+        let engine = LoopEngine::with_adapter(config, Box::new(TimeoutAdapter));
+        let summary = engine.run();
+        assert_eq!(summary.iterations_run, 1);
+        assert_eq!(summary.retries, 2, "should retry twice on timeout");
+        assert_eq!(summary.failures, 1);
+    }
+
+    #[test]
+    fn stop_on_failure_halts_on_timeout() {
+        use crate::provider::tests::TimeoutAdapter;
+
+        let config = LoopConfig {
+            iterations: 5,
+            provider: Provider::Claude,
+            prompt_inline: Some("test".to_string()),
+            stop_on_failure: true,
+            ..Default::default()
+        };
+        let engine = LoopEngine::with_adapter(config, Box::new(TimeoutAdapter));
+        let summary = engine.run();
+        assert_eq!(summary.iterations_run, 1, "should stop after first timeout");
+        assert_eq!(summary.termination_reason, Some(TerminationReason::StoppedOnFailure));
     }
 }

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -7,7 +7,8 @@ use crate::pr_manager::{build_pr_manager, GhPrLifecycle, PrManager, TriageAction
 use crate::pr_strategy::{build_strategy, PrStrategy};
 use crate::provider::{build_adapter, ProviderAdapter};
 use crate::telemetry::{
-    resolve_operator, unix_now, IterationOutcome, IterationRecord, RunArtifacts, RunManifest,
+    resolve_operator, unix_now, IterationOutcome, IterationRecord, RetryPolicy, RunArtifacts,
+    RunManifest,
 };
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -505,23 +506,38 @@ impl LoopEngine {
                         match merge_result {
                             Ok(out) if out.status.success() => {
                                 info!(iteration = i, pr = pr.number, "multi-pr: PR merged");
-                                // Attempt post-merge branch cleanup when the PR has a known
-                                // head branch.  Failures are non-fatal (PR already merged).
-                                if !pr.head_ref.is_empty() {
+                                // Attempt post-merge **remote-only** branch
+                                // cleanup when the PR has a known head
+                                // branch.  The engine never checks out the
+                                // PR's local branch in multi-PR mode, so
+                                // `cleanup_branch` (which tries to delete a
+                                // local branch) would operate on whatever
+                                // the engine's CWD happens to be on — see
+                                // #65.  `cleanup_merged_remote_branch` only
+                                // touches the remote.  Failures are
+                                // non-fatal (PR is already merged).
+                                if let Some(head_ref) = pr.head_ref.as_deref() {
                                     let bm = BranchManager::new(self.config.pr_management.clone());
-                                    match bm.cleanup_branch(&pr.head_ref) {
+                                    match bm.cleanup_merged_remote_branch(head_ref) {
                                         Ok(()) => info!(
                                             iteration = i,
-                                            branch = %pr.head_ref,
-                                            "multi-pr: cleaned up feature branch after merge"
+                                            branch = %head_ref,
+                                            "multi-pr: cleaned up remote feature branch after merge"
                                         ),
                                         Err(e) => warn!(
                                             iteration = i,
-                                            branch = %pr.head_ref,
+                                            branch = %head_ref,
                                             error = %e,
-                                            "multi-pr: post-merge branch cleanup failed (non-fatal)"
+                                            "multi-pr: post-merge remote cleanup failed (non-fatal)"
                                         ),
                                     }
+                                } else {
+                                    warn!(
+                                        iteration = i,
+                                        pr = pr.number,
+                                        "multi-pr: merged PR has no head_ref; \
+                                         skipping remote branch cleanup"
+                                    );
                                 }
                             }
                             Ok(out) => {
@@ -665,22 +681,26 @@ impl LoopEngine {
                             break;
                         } else {
                             let outcome = IterationOutcome::from_exit_code(result.exit_code);
-                            let is_permanent = result
-                                .exit_code
-                                .map(|c| self.config.non_retryable_exit_codes.contains(&c))
-                                .unwrap_or(false);
-                            if is_permanent {
+                            let policy = RetryPolicy::new(&self.config.non_retryable_exit_codes);
+                            let policy_allows = policy.should_retry(&outcome);
+                            // Log the "permanent" case specifically so
+                            // operators can see *why* retries were skipped
+                            // when max_retries > 0.
+                            if !policy_allows
+                                && matches!(outcome, IterationOutcome::NonZeroExit { .. })
+                                && result.exit_code.is_some_and(|c| {
+                                    self.config.non_retryable_exit_codes.contains(&c)
+                                })
+                            {
                                 warn!(
                                     iteration = i,
                                     provider = self.adapter.name(),
                                     exit_code = result.exit_code,
-                                    "Iteration failed with a non-retryable exit code; skipping retries"
+                                    "Iteration failed with a non-retryable exit code; \
+                                     skipping retries"
                                 );
                             }
-                            if !is_permanent
-                                && attempt < self.config.max_retries
-                                && outcome.is_retryable()
-                            {
+                            if policy_allows && attempt < self.config.max_retries {
                                 summary.retries += 1;
                                 let delay_ms = compute_backoff_ms(
                                     self.config.retry_backoff_ms,
@@ -884,7 +904,22 @@ impl LoopEngine {
                         }
                         Ok(crate::pr_manager::PrAction::NoSignal) => {}
                         Err(e) => {
-                            warn!(iteration = i, error = %e, "single-pr: PrManager error");
+                            // Mirror the blocker-comment pattern used by the
+                            // ProviderSpawn arm above: a PR create/update
+                            // failure after a shippable signal means no PR
+                            // exists, the operator needs to know, and the
+                            // linked issue needs an audit trail (see #69).
+                            let msg = format!("single-pr: PrManager error on iteration {i}: {e}");
+                            warn!(iteration = i, error = %e, "{msg}");
+                            if self.config.issue_tracking.comment_cadence
+                                != CommentCadence::OffEngine
+                            {
+                                self.post_comment(&format!(
+                                    "**Blocker** — shippable signal fired on iteration \
+                                     {i} but PR create/update failed: `{e}`. \
+                                     No pull request was opened for this iteration."
+                                ));
+                            }
                         }
                     }
                 }
@@ -1013,7 +1048,21 @@ impl LoopEngine {
                                  (`auto_close_owned_issues=true`).",
                                 run_id = artifacts.run_id
                             );
-                            let _ = self.tracker.add_comment(issue_number, &close_comment);
+                            // If the explanatory comment fails to post, warn
+                            // but still proceed with the close — the close
+                            // result is the load-bearing audit event, and the
+                            // very next call checks its Err.  What we used to
+                            // do (`let _ = ...`) silently discarded the comment
+                            // error (see #69); now an operator reading the
+                            // logs at least sees why no comment appeared.
+                            if let Err(e) = self.tracker.add_comment(issue_number, &close_comment) {
+                                warn!(
+                                    issue = issue_number,
+                                    error = %e,
+                                    "auto_close_owned_issues: failed to post closing \
+                                     comment; closing issue anyway"
+                                );
+                            }
                             if let Err(e) = self.tracker.close_issue(
                                 issue_number,
                                 crate::issue_tracker::CloseReason::Completed,
@@ -1475,6 +1524,37 @@ mod tests {
         let summary = engine.run();
         assert_eq!(summary.failures, 1);
         assert_eq!(summary.retries, 1);
+    }
+
+    /// Regression test for #70: without a way to distinguish "retried then
+    /// recovered" from "retried forever", the existing retry tests all
+    /// used permanently-failing adapters.  `FakeAdapter::sequence(vec![1,
+    /// 0])` models a transient failure that succeeds on retry.
+    #[test]
+    fn retry_recovery_with_sequenced_exit_codes() {
+        use crate::provider::tests::FakeAdapter;
+
+        let config = LoopConfig {
+            iterations: 1,
+            provider: Provider::Claude,
+            prompt_inline: Some("test".to_string()),
+            max_retries: 2,
+            retry_backoff_ms: 0,
+            ..Default::default()
+        };
+        // First call: exit 1 (transient) → retried. Second call: exit 0 → success.
+        let adapter = FakeAdapter::sequence("fake", vec![1, 0]);
+        let engine = LoopEngine::with_adapter(config, Box::new(adapter));
+        let summary = engine.run();
+        assert_eq!(
+            summary.successes, 1,
+            "iteration should end in success after one retry"
+        );
+        assert_eq!(summary.failures, 0);
+        assert_eq!(
+            summary.retries, 1,
+            "exactly one retry should have been recorded"
+        );
     }
 
     #[test]
@@ -2035,7 +2115,7 @@ mod tests {
                     number: 42,
                     title: "feat: something".to_string(),
                     url: "https://github.com/owner/repo/pull/42".to_string(),
-                    head_ref: "loop/42-feat-something".to_string(),
+                    head_ref: Some("loop/42-feat-something".to_string()),
                 };
                 IterationPlan {
                     description: "blocked on human review".to_string(),
@@ -2155,7 +2235,7 @@ mod tests {
                     number: 77,
                     title: "feat: merge me".to_string(),
                     url: "https://github.com/owner/repo/pull/77".to_string(),
-                    head_ref: "loop/77-feat-merge-me".to_string(),
+                    head_ref: Some("loop/77-feat-merge-me".to_string()),
                 };
                 IterationPlan {
                     description: "merge ready PR".to_string(),
@@ -2202,7 +2282,7 @@ mod tests {
                     number: 88,
                     title: "no ref".to_string(),
                     url: "https://github.com/owner/repo/pull/88".to_string(),
-                    head_ref: String::new(), // empty — cleanup must be skipped
+                    head_ref: None, // empty — cleanup must be skipped
                 };
                 IterationPlan {
                     description: "merge ready PR (no head ref)".to_string(),

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -1,4 +1,4 @@
-use crate::config::{IssueTrackingMode, LoopConfig};
+use crate::config::{CommentCadence, IssueTrackingMode, LoopConfig};
 use crate::issue_tracker::{GitHubIssueTracker, IssueTracker, LocalPromiseTracker};
 use crate::orchestration::{GhCliContextResolver, PolicyEngine};
 use crate::policy_guard::PolicyGuard;
@@ -106,9 +106,7 @@ pub struct LoopEngine {
     policy_engine: Option<PolicyEngine>,
     /// Policy guard used to augment prompts with MCP-use requirements.
     guard: PolicyGuard,
-    /// Issue tracker for this run.  Not yet actively called by the engine;
-    /// active use (start/milestone/end comments) lands in a follow-up issue.
-    #[allow(dead_code)]
+    /// Issue tracker for this run.
     tracker: Box<dyn IssueTracker>,
     /// PR strategy: consulted once per iteration before the provider is invoked.
     pr_strategy: Box<dyn PrStrategy>,
@@ -138,6 +136,19 @@ impl LoopEngine {
         let interrupted = Arc::new(AtomicBool::new(false));
         let guard = PolicyGuard::new(crate::policy_guard::UnsafeOverrides::default());
         let tracker = build_tracker(&config);
+        let pr_strategy = build_strategy(config.pr_management.clone());
+        Self { config, adapter, policy_engine: None, guard, tracker, pr_strategy, interrupted }
+    }
+
+    /// Constructor that accepts a custom adapter and issue tracker (useful for testing).
+    #[cfg(test)]
+    pub fn with_adapter_and_tracker(
+        config: LoopConfig,
+        adapter: Box<dyn ProviderAdapter>,
+        tracker: Box<dyn IssueTracker>,
+    ) -> Self {
+        let interrupted = Arc::new(AtomicBool::new(false));
+        let guard = PolicyGuard::new(crate::policy_guard::UnsafeOverrides::default());
         let pr_strategy = build_strategy(config.pr_management.clone());
         Self { config, adapter, policy_engine: None, guard, tracker, pr_strategy, interrupted }
     }
@@ -182,6 +193,22 @@ impl LoopEngine {
         }
         // No prompt configured — use empty string; provider decides behaviour.
         Ok(String::new())
+    }
+
+    /// Post a comment to the configured issue, logging a warning on failure.
+    ///
+    /// No-ops when `comment_issue_number` is `None` or when in local mode.
+    fn post_comment(&self, body: &str) {
+        let issue_number = match self.config.issue_tracking.comment_issue_number {
+            Some(n) => n,
+            None => return,
+        };
+        if self.config.issue_tracking.mode != IssueTrackingMode::Github {
+            return;
+        }
+        if let Err(e) = self.tracker.add_comment(issue_number, body) {
+            warn!(issue = issue_number, error = %e, "Failed to post comment to issue");
+        }
     }
 
     /// Run the loop and return a session summary.
@@ -268,6 +295,24 @@ impl LoopEngine {
             prompt_source,
             "Loop starting"
         );
+
+        // Post run-start comment when a linked issue is configured.
+        if self.config.issue_tracking.comment_cadence != CommentCadence::OffEngine {
+            let iter_display = if infinite {
+                "infinite".to_string()
+            } else {
+                max.to_string()
+            };
+            self.post_comment(&format!(
+                "**Loop run started** — run-id: `{run_id}`, provider: `{provider}`, \
+                 iterations: `{iter_display}`, prompt-source: `{prompt_source}`",
+                run_id = artifacts.run_id,
+                provider = self.adapter.name(),
+            ));
+        }
+
+        // Tracks the body of the most recently posted failure comment for deduplication.
+        let mut last_failure_comment: Option<String> = None;
 
         for i in 1..=max {
             if self.interrupted.load(Ordering::SeqCst) {
@@ -414,6 +459,12 @@ impl LoopEngine {
                         error!(iteration = i, provider = self.adapter.name(), "{msg}");
                         final_outcome =
                             IterationOutcome::SpawnFailure { message: msg.clone() };
+                        if self.config.issue_tracking.comment_cadence != CommentCadence::OffEngine {
+                            self.post_comment(&format!(
+                                "**Blocker** — iteration {i} aborted: provider spawn failure. \
+                                 `{msg}`"
+                            ));
+                        }
                         summary.termination_reason = Some(TerminationReason::ProviderError(msg));
                         abort_loop = true;
                         break;
@@ -437,6 +488,56 @@ impl LoopEngine {
                 retries = attempt,
                 "Iteration complete"
             );
+
+            // Post iteration comment based on cadence.
+            let cadence = &self.config.issue_tracking.comment_cadence;
+            let is_failure = !final_outcome.is_success();
+            let should_comment = match cadence {
+                CommentCadence::OffEngine => false,
+                CommentCadence::EveryIteration => true,
+                CommentCadence::Milestones => is_failure || abort_loop,
+            };
+            if should_comment {
+                let retry_note = if attempt > 0 {
+                    format!(", retries: {attempt}")
+                } else {
+                    String::new()
+                };
+                let err_note = if let Some(ref exc) = IterationRecord::stderr_first_line(&final_stderr) {
+                    format!("\n> `{exc}`")
+                } else {
+                    String::new()
+                };
+                let comment_body = format!(
+                    "**Iteration {i}** — outcome: `{outcome}`, duration: {ms}ms{retry}{err}",
+                    outcome = final_outcome.label(),
+                    ms = final_duration_ms,
+                    retry = retry_note,
+                    err = err_note,
+                );
+                // Deduplicate consecutive identical failure comments.
+                let is_duplicate = last_failure_comment.as_deref() == Some(&comment_body);
+                if !is_duplicate {
+                    self.post_comment(&comment_body);
+                    if is_failure {
+                        last_failure_comment = Some(comment_body);
+                    } else {
+                        last_failure_comment = None;
+                    }
+                }
+            } else if !is_failure {
+                last_failure_comment = None;
+            }
+
+            // Post blocker comment when aborting due to stop_on_failure.
+            let stop_on_fail = !final_outcome.is_success() && self.config.stop_on_failure && !abort_loop;
+            if stop_on_fail && cadence != &CommentCadence::OffEngine {
+                self.post_comment(&format!(
+                    "**Blocker** — iteration {i} failed and `stop_on_failure` is set; \
+                     halting loop. Outcome: `{outcome}`",
+                    outcome = final_outcome.label(),
+                ));
+            }
 
             iteration_records.push(IterationRecord {
                 iteration: i,
@@ -487,6 +588,23 @@ impl LoopEngine {
         );
 
         summary.print();
+
+        // Post run-end comment.
+        if self.config.issue_tracking.comment_cadence != CommentCadence::OffEngine {
+            let reason = summary
+                .termination_reason
+                .as_ref()
+                .map(|r| r.to_string())
+                .unwrap_or_default();
+            self.post_comment(&format!(
+                "**Loop run finished** — iterations: {iters}, successes: {ok}, \
+                 failures: {fail}, retries: {retries}, termination: `{reason}`",
+                iters = summary.iterations_run,
+                ok = summary.successes,
+                fail = summary.failures,
+                retries = summary.retries,
+            ));
+        }
 
         // Write run manifest and summary.
         let manifest = RunManifest {
@@ -884,5 +1002,186 @@ mod tests {
             summary.termination_reason,
             Some(TerminationReason::ProviderError(_))
         ));
+    }
+
+    // ── Engine-driven issue comment tests ────────────────────────────────────
+
+    use crate::config::{CommentCadence, IssueTrackingConfig, IssueTrackingMode};
+    use crate::issue_tracker::{MockCall, MockIssueTracker};
+    use std::sync::Arc;
+
+    fn github_tracker_config(issue: u32, cadence: CommentCadence) -> LoopConfig {
+        LoopConfig {
+            iterations: 2,
+            provider: Provider::Claude,
+            prompt_inline: Some("test".to_string()),
+            issue_tracking: IssueTrackingConfig {
+                mode: IssueTrackingMode::Github,
+                repo_owner: Some("owner".to_string()),
+                repo_name: Some("repo".to_string()),
+                comment_issue_number: Some(issue),
+                comment_cadence: cadence,
+                local_promise_path: None,
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn milestones_cadence_posts_start_and_end_on_success() {
+        let tracker = Arc::new(MockIssueTracker::new());
+        let config = github_tracker_config(42, CommentCadence::Milestones);
+        let engine = LoopEngine::with_adapter_and_tracker(
+            config,
+            Box::new(FakeAdapter::success("fake")),
+            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(&tracker))),
+        );
+        engine.run();
+        let calls = tracker.recorded_calls();
+        // With milestones cadence and all successes: start comment + end comment only.
+        let add_comment_calls: Vec<_> = calls
+            .iter()
+            .filter(|c| matches!(c, MockCall::AddComment { .. }))
+            .collect();
+        assert_eq!(add_comment_calls.len(), 2, "expected start + end comments, got {add_comment_calls:?}");
+        if let MockCall::AddComment { number, body } = &add_comment_calls[0] {
+            assert_eq!(*number, 42);
+            assert!(body.contains("Loop run started"), "start comment body: {body}");
+        }
+        if let MockCall::AddComment { number, body } = &add_comment_calls[1] {
+            assert_eq!(*number, 42);
+            assert!(body.contains("Loop run finished"), "end comment body: {body}");
+        }
+    }
+
+    #[test]
+    fn milestones_cadence_posts_failure_comment() {
+        let tracker = Arc::new(MockIssueTracker::new());
+        let config = github_tracker_config(7, CommentCadence::Milestones);
+        let engine = LoopEngine::with_adapter_and_tracker(
+            config,
+            Box::new(FakeAdapter::failure("fake")),
+            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(&tracker))),
+        );
+        engine.run();
+        let calls = tracker.recorded_calls();
+        let comment_bodies: Vec<_> = calls
+            .iter()
+            .filter_map(|c| {
+                if let MockCall::AddComment { body, .. } = c { Some(body.as_str()) } else { None }
+            })
+            .collect();
+        // start + 2 failure iteration comments (deduplicated if identical) + end
+        assert!(
+            comment_bodies.iter().any(|b| b.contains("Loop run started")),
+            "missing start comment; got: {comment_bodies:?}"
+        );
+        assert!(
+            comment_bodies.iter().any(|b| b.contains("Loop run finished")),
+            "missing end comment"
+        );
+        assert!(
+            comment_bodies.iter().any(|b| b.contains("Iteration")),
+            "missing iteration comment"
+        );
+    }
+
+    #[test]
+    fn every_iteration_cadence_posts_comment_per_iteration() {
+        let tracker = Arc::new(MockIssueTracker::new());
+        let config = github_tracker_config(1, CommentCadence::EveryIteration);
+        let engine = LoopEngine::with_adapter_and_tracker(
+            config,
+            Box::new(FakeAdapter::success("fake")),
+            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(&tracker))),
+        );
+        engine.run();
+        let calls = tracker.recorded_calls();
+        let add_comment_count = calls
+            .iter()
+            .filter(|c| matches!(c, MockCall::AddComment { .. }))
+            .count();
+        // 1 start + 2 iteration comments + 1 end = 4
+        assert_eq!(add_comment_count, 4, "expected 4 comments for 2 iterations, got {add_comment_count}");
+    }
+
+    #[test]
+    fn off_engine_cadence_posts_no_comments() {
+        let tracker = Arc::new(MockIssueTracker::new());
+        let config = github_tracker_config(99, CommentCadence::OffEngine);
+        let engine = LoopEngine::with_adapter_and_tracker(
+            config,
+            Box::new(FakeAdapter::success("fake")),
+            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(&tracker))),
+        );
+        engine.run();
+        let calls = tracker.recorded_calls();
+        let has_comment = calls.iter().any(|c| matches!(c, MockCall::AddComment { .. }));
+        assert!(!has_comment, "off-engine cadence should post no comments");
+    }
+
+    #[test]
+    fn local_mode_posts_no_comments() {
+        let tracker = Arc::new(MockIssueTracker::new());
+        let config = LoopConfig {
+            iterations: 1,
+            provider: Provider::Claude,
+            prompt_inline: Some("test".to_string()),
+            issue_tracking: IssueTrackingConfig {
+                mode: IssueTrackingMode::Local, // local mode — no comments
+                comment_issue_number: Some(5),
+                comment_cadence: CommentCadence::EveryIteration,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let engine = LoopEngine::with_adapter_and_tracker(
+            config,
+            Box::new(FakeAdapter::success("fake")),
+            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(&tracker))),
+        );
+        engine.run();
+        let calls = tracker.recorded_calls();
+        assert!(
+            !calls.iter().any(|c| matches!(c, MockCall::AddComment { .. })),
+            "local mode should never post comments"
+        );
+    }
+
+    #[test]
+    fn stop_on_failure_posts_blocker_comment() {
+        let tracker = Arc::new(MockIssueTracker::new());
+        let config = LoopConfig {
+            iterations: 5,
+            provider: Provider::Claude,
+            prompt_inline: Some("test".to_string()),
+            stop_on_failure: true,
+            issue_tracking: IssueTrackingConfig {
+                mode: IssueTrackingMode::Github,
+                repo_owner: Some("o".to_string()),
+                repo_name: Some("r".to_string()),
+                comment_issue_number: Some(3),
+                comment_cadence: CommentCadence::Milestones,
+                local_promise_path: None,
+            },
+            ..Default::default()
+        };
+        let engine = LoopEngine::with_adapter_and_tracker(
+            config,
+            Box::new(FakeAdapter::failure("fake")),
+            Box::new(crate::issue_tracker::SharedMockIssueTracker(Arc::clone(&tracker))),
+        );
+        engine.run();
+        let calls = tracker.recorded_calls();
+        let comment_bodies: Vec<_> = calls
+            .iter()
+            .filter_map(|c| {
+                if let MockCall::AddComment { body, .. } = c { Some(body.as_str()) } else { None }
+            })
+            .collect();
+        assert!(
+            comment_bodies.iter().any(|b| b.contains("Blocker")),
+            "expected a blocker comment; got: {comment_bodies:?}"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ fn main() -> anyhow::Result<()> {
             let bind_addr = bind_addr.clone();
             // Build config from file / CLI overrides, then hand off to service mode.
             let base = if let Some(ref path) = cli_args.config {
-                config::LoopConfig::from_toml_file(path)
+                config::LoopConfig::from_file(path)
                     .with_context(|| format!("failed to load config from {}", path.display()))?
             } else {
                 config::LoopConfig::default()
@@ -88,7 +88,7 @@ fn main() -> anyhow::Result<()> {
 
     // Determine base config: file-loaded or default.
     let base = if let Some(ref path) = cli_args.config {
-        config::LoopConfig::from_toml_file(path)
+        config::LoopConfig::from_file(path)
             .with_context(|| format!("failed to load config from {}", path.display()))?
     } else {
         config::LoopConfig::default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod issue_tracker;
 mod loop_engine;
 mod orchestration;
 mod policy_guard;
+mod pr_strategy;
 mod provider;
 mod telemetry;
 mod workspace;

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,7 @@ fn main() -> anyhow::Result<()> {
         Some(cli::Commands::Serve {
             port,
             ref bind_addr,
+            unsafe_bind,
         }) => {
             let bind_addr = bind_addr.clone();
             // Build config from file / CLI overrides, then hand off to service mode.
@@ -78,8 +79,13 @@ fn main() -> anyhow::Result<()> {
                 )
                 .init();
 
-            info!(port = port, bind_addr = %bind_addr, "Starting service mode");
-            let svc = service::ServiceMode::new(resolved, bind_addr, port);
+            info!(
+                port = port,
+                bind_addr = %bind_addr,
+                unsafe_bind = unsafe_bind,
+                "Starting service mode"
+            );
+            let svc = service::ServiceMode::new(resolved, bind_addr, port, unsafe_bind);
             return svc.run();
         }
 
@@ -129,7 +135,7 @@ fn main() -> anyhow::Result<()> {
     let guard = policy_guard::PolicyGuard::new(policy_guard::UnsafeOverrides {
         allow_direct_github: resolved.allow_direct_github,
     });
-    let violations = guard.validate_orchestration(resolved.orchestration.enabled);
+    let violations = guard.check_startup(resolved.orchestration.enabled);
     if !violations.is_empty() {
         for v in &violations {
             eprintln!("{v}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod branch;
 mod cli;
 mod config;
 mod error;
+mod security;
 mod issue_tracker;
 mod loop_engine;
 mod orchestration;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod error;
 mod security;
 mod issue_tracker;
 mod loop_engine;
+mod multi_repo;
 mod orchestration;
 mod policy_guard;
 mod pr_manager;
@@ -99,6 +100,21 @@ fn main() -> anyhow::Result<()> {
             eprintln!("{v}");
         }
         anyhow::bail!("Policy guard validation failed");
+    }
+
+    // ── Multi-repo mode ──────────────────────────────────────────────────────
+    // When `multi_repo` entries are present, run the loop for each target in
+    // sequence and print a combined summary.  The single-repo path is skipped.
+    if !resolved.multi_repo.is_empty() {
+        info!(
+            provider = %resolved.provider,
+            repos = resolved.multi_repo.len(),
+            "Code Looper initializing in multi-repo mode"
+        );
+        let targets = resolved.multi_repo.clone();
+        let results = multi_repo::run_multi_repo(&resolved, &targets);
+        multi_repo::print_multi_repo_summary(&results);
+        return Ok(());
     }
 
     info!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod bootstrap;
 mod branch;
 mod cli;
 mod config;
@@ -18,6 +19,34 @@ use tracing::info;
 
 fn main() -> anyhow::Result<()> {
     let cli_args = cli::Cli::parse();
+
+    // Dispatch to the bootstrap subcommand when requested.
+    if let Some(cli::Commands::Bootstrap { workspace_dir, dry_run }) = cli_args.command {
+        let ws_dir = workspace::resolve_workspace_dir(workspace_dir.as_deref());
+        let prefix = if dry_run { "[dry-run]" } else { "[bootstrap]" };
+        let actions = bootstrap::run_bootstrap(&ws_dir, dry_run)
+            .context("bootstrap failed")?;
+        for action in &actions {
+            // Replace the "[bootstrap]" prefix with "[dry-run]" when applicable.
+            let msg = action.to_string();
+            let display = if dry_run {
+                msg.replacen("[bootstrap]", prefix, 1)
+            } else {
+                msg
+            };
+            println!("{display}");
+        }
+        let all_satisfied = actions.iter().all(|a| {
+            matches!(a, bootstrap::BootstrapAction::AlreadySatisfied(_))
+        });
+        if all_satisfied {
+            println!("{prefix} workspace prerequisites already satisfied — nothing to do.");
+        } else if !dry_run {
+            println!("[bootstrap] Done — workspace prerequisites satisfied. Run \"code-looper --help\" to get started.");
+        }
+        return Ok(());
+    }
+
 
     // Determine base config: file-loaded or default.
     let base = if let Some(ref path) = cli_args.config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod issue_tracker;
 mod loop_engine;
 mod orchestration;
 mod policy_guard;
+mod pr_manager;
 mod pr_strategy;
 mod provider;
 mod telemetry;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod config;
 mod error;
+mod issue_tracker;
 mod loop_engine;
 mod orchestration;
 mod policy_guard;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod loop_engine;
 mod orchestration;
 mod policy_guard;
 mod provider;
+mod telemetry;
 mod workspace;
 
 use anyhow::Context;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod branch;
 mod cli;
 mod config;
 mod error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod policy_guard;
 mod pr_manager;
 mod pr_strategy;
 mod provider;
+mod service;
 mod telemetry;
 mod workspace;
 
@@ -22,31 +23,56 @@ use tracing::info;
 fn main() -> anyhow::Result<()> {
     let cli_args = cli::Cli::parse();
 
-    // Dispatch to the bootstrap subcommand when requested.
-    if let Some(cli::Commands::Bootstrap { workspace_dir, dry_run }) = cli_args.command {
-        let ws_dir = workspace::resolve_workspace_dir(workspace_dir.as_deref());
-        let prefix = if dry_run { "[dry-run]" } else { "[bootstrap]" };
-        let actions = bootstrap::run_bootstrap(&ws_dir, dry_run)
-            .context("bootstrap failed")?;
-        for action in &actions {
-            // Replace the "[bootstrap]" prefix with "[dry-run]" when applicable.
-            let msg = action.to_string();
-            let display = if dry_run {
-                msg.replacen("[bootstrap]", prefix, 1)
+    // Dispatch subcommands before config resolution so they can run without a
+    // full loop configuration.
+    match cli_args.command {
+        Some(cli::Commands::Bootstrap { workspace_dir, dry_run }) => {
+            let ws_dir = workspace::resolve_workspace_dir(workspace_dir.as_deref());
+            let prefix = if dry_run { "[dry-run]" } else { "[bootstrap]" };
+            let actions = bootstrap::run_bootstrap(&ws_dir, dry_run)
+                .context("bootstrap failed")?;
+            for action in &actions {
+                let msg = action.to_string();
+                let display = if dry_run { msg.replacen("[bootstrap]", prefix, 1) } else { msg };
+                println!("{display}");
+            }
+            let all_satisfied =
+                actions.iter().all(|a| matches!(a, bootstrap::BootstrapAction::AlreadySatisfied(_)));
+            if all_satisfied {
+                println!("{prefix} workspace prerequisites already satisfied — nothing to do.");
+            } else if !dry_run {
+                println!(
+                    "[bootstrap] Done — workspace prerequisites satisfied. \
+                     Run \"code-looper --help\" to get started."
+                );
+            }
+            return Ok(());
+        }
+
+        Some(cli::Commands::Serve { port, ref bind_addr }) => {
+            let bind_addr = bind_addr.clone();
+            // Build config from file / CLI overrides, then hand off to service mode.
+            let base = if let Some(ref path) = cli_args.config {
+                config::LoopConfig::from_toml_file(path)
+                    .with_context(|| format!("failed to load config from {}", path.display()))?
             } else {
-                msg
+                config::LoopConfig::default()
             };
-            println!("{display}");
+            let resolved = cli_args.apply_overrides(base);
+
+            tracing_subscriber::fmt()
+                .with_env_filter(
+                    tracing_subscriber::EnvFilter::try_from_default_env()
+                        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(&resolved.log_level)),
+                )
+                .init();
+
+            info!(port = port, bind_addr = %bind_addr, "Starting service mode");
+            let svc = service::ServiceMode::new(resolved, bind_addr, port);
+            return svc.run();
         }
-        let all_satisfied = actions.iter().all(|a| {
-            matches!(a, bootstrap::BootstrapAction::AlreadySatisfied(_))
-        });
-        if all_satisfied {
-            println!("{prefix} workspace prerequisites already satisfied — nothing to do.");
-        } else if !dry_run {
-            println!("[bootstrap] Done — workspace prerequisites satisfied. Run \"code-looper --help\" to get started.");
-        }
-        return Ok(());
+
+        None => {}
     }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ mod branch;
 mod cli;
 mod config;
 mod error;
-mod security;
 mod issue_tracker;
 mod loop_engine;
 mod multi_repo;
@@ -12,6 +11,7 @@ mod policy_guard;
 mod pr_manager;
 mod pr_strategy;
 mod provider;
+mod security;
 mod service;
 mod telemetry;
 mod workspace;
@@ -26,18 +26,25 @@ fn main() -> anyhow::Result<()> {
     // Dispatch subcommands before config resolution so they can run without a
     // full loop configuration.
     match cli_args.command {
-        Some(cli::Commands::Bootstrap { workspace_dir, dry_run }) => {
+        Some(cli::Commands::Bootstrap {
+            workspace_dir,
+            dry_run,
+        }) => {
             let ws_dir = workspace::resolve_workspace_dir(workspace_dir.as_deref());
             let prefix = if dry_run { "[dry-run]" } else { "[bootstrap]" };
-            let actions = bootstrap::run_bootstrap(&ws_dir, dry_run)
-                .context("bootstrap failed")?;
+            let actions = bootstrap::run_bootstrap(&ws_dir, dry_run).context("bootstrap failed")?;
             for action in &actions {
                 let msg = action.to_string();
-                let display = if dry_run { msg.replacen("[bootstrap]", prefix, 1) } else { msg };
+                let display = if dry_run {
+                    msg.replacen("[bootstrap]", prefix, 1)
+                } else {
+                    msg
+                };
                 println!("{display}");
             }
-            let all_satisfied =
-                actions.iter().all(|a| matches!(a, bootstrap::BootstrapAction::AlreadySatisfied(_)));
+            let all_satisfied = actions
+                .iter()
+                .all(|a| matches!(a, bootstrap::BootstrapAction::AlreadySatisfied(_)));
             if all_satisfied {
                 println!("{prefix} workspace prerequisites already satisfied — nothing to do.");
             } else if !dry_run {
@@ -49,7 +56,10 @@ fn main() -> anyhow::Result<()> {
             return Ok(());
         }
 
-        Some(cli::Commands::Serve { port, ref bind_addr }) => {
+        Some(cli::Commands::Serve {
+            port,
+            ref bind_addr,
+        }) => {
             let bind_addr = bind_addr.clone();
             // Build config from file / CLI overrides, then hand off to service mode.
             let base = if let Some(ref path) = cli_args.config {
@@ -62,8 +72,9 @@ fn main() -> anyhow::Result<()> {
 
             tracing_subscriber::fmt()
                 .with_env_filter(
-                    tracing_subscriber::EnvFilter::try_from_default_env()
-                        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(&resolved.log_level)),
+                    tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                        tracing_subscriber::EnvFilter::new(&resolved.log_level)
+                    }),
                 )
                 .init();
 
@@ -74,7 +85,6 @@ fn main() -> anyhow::Result<()> {
 
         None => {}
     }
-
 
     // Determine base config: file-loaded or default.
     let base = if let Some(ref path) = cli_args.config {
@@ -100,8 +110,7 @@ fn main() -> anyhow::Result<()> {
 
     // Run workspace prerequisite checks unless explicitly skipped.
     if !resolved.skip_prereq_check {
-        let ws_dir =
-            workspace::resolve_workspace_dir(resolved.workspace_dir.as_deref());
+        let ws_dir = workspace::resolve_workspace_dir(resolved.workspace_dir.as_deref());
         let checker = workspace::PrerequisiteChecker::new(&ws_dir);
         let check_result = checker.run();
         if !check_result.is_ok() {

--- a/src/multi_repo.rs
+++ b/src/multi_repo.rs
@@ -128,7 +128,11 @@ mod tests {
             prompt_inline: Some("base prompt".to_string()),
             ..LoopConfig::default()
         };
-        let targets = vec![make_target("/tmp/repo-a", Some("repo-a"), Some("custom prompt"))];
+        let targets = [make_target(
+            "/tmp/repo-a",
+            Some("repo-a"),
+            Some("custom prompt"),
+        )];
 
         // Verify that run_multi_repo builds the correct derived config by
         // checking that the loop engine receives the override prompt.
@@ -160,16 +164,10 @@ mod tests {
             ..LoopConfig::default()
         };
 
-        let summary_a = LoopEngine::with_adapter(
-            config_a,
-            Box::new(FakeAdapter::success("fake")),
-        )
-        .run();
-        let summary_b = LoopEngine::with_adapter(
-            config_b,
-            Box::new(FakeAdapter::success("fake")),
-        )
-        .run();
+        let summary_a =
+            LoopEngine::with_adapter(config_a, Box::new(FakeAdapter::success("fake"))).run();
+        let summary_b =
+            LoopEngine::with_adapter(config_b, Box::new(FakeAdapter::success("fake"))).run();
 
         assert_eq!(summary_a.successes, 1);
         assert_eq!(summary_b.successes, 2);

--- a/src/multi_repo.rs
+++ b/src/multi_repo.rs
@@ -1,0 +1,181 @@
+use crate::config::{LoopConfig, RepoTarget};
+use crate::loop_engine::{LoopEngine, SessionSummary};
+use crate::policy_guard::{PolicyGuard, UnsafeOverrides};
+use tracing::info;
+
+/// Result for a single repo target in a multi-repo run.
+pub struct RepoRunResult {
+    /// Display name of the repository (from `RepoTarget::display_name`).
+    pub name: String,
+    /// Filesystem path used for this run (for log context).
+    pub path: std::path::PathBuf,
+    /// Session summary returned by the loop engine.
+    pub summary: SessionSummary,
+}
+
+/// Run the loop for each repo target in sequence.
+///
+/// For every target a fresh `LoopConfig` is derived from `base_config` with:
+/// - `workspace_dir` set to `target.path`
+/// - `prompt_inline` replaced by `target.prompt_override` when present
+/// - `prompt_file` cleared when `prompt_override` is set
+///
+/// Returns one `RepoRunResult` per target in the same order as `targets`.
+pub fn run_multi_repo(base_config: &LoopConfig, targets: &[RepoTarget]) -> Vec<RepoRunResult> {
+    let mut results = Vec::with_capacity(targets.len());
+
+    for target in targets {
+        let name = target.display_name();
+        info!(repo = %name, path = %target.path.display(), "Starting multi-repo run");
+
+        let mut repo_config = base_config.clone();
+        repo_config.workspace_dir = Some(target.path.clone());
+
+        if let Some(ref prompt) = target.prompt_override {
+            repo_config.prompt_inline = Some(prompt.clone());
+            repo_config.prompt_file = None;
+        }
+
+        let overrides = UnsafeOverrides {
+            allow_direct_github: base_config.allow_direct_github,
+        };
+        let guard = PolicyGuard::new(overrides);
+        let engine = LoopEngine::new(repo_config, guard);
+        let summary = engine.run();
+
+        results.push(RepoRunResult {
+            name,
+            path: target.path.clone(),
+            summary,
+        });
+    }
+
+    results
+}
+
+/// Print a human-readable summary of all repo run results.
+pub fn print_multi_repo_summary(results: &[RepoRunResult]) {
+    println!();
+    println!("━━━ Multi-repo run summary ━━━");
+    let mut total_success = 0u64;
+    let mut total_failed = 0u64;
+    let mut total_retries = 0u64;
+
+    for r in results {
+        let s = &r.summary;
+        total_success += s.successes;
+        total_failed += s.failures;
+        total_retries += s.retries;
+
+        let status = if s.failures == 0 { "ok" } else { "FAILED" };
+        println!(
+            "  [{status}] {name}  (success={s}, fail={f}, retries={r})",
+            status = status,
+            name = r.name,
+            s = s.successes,
+            f = s.failures,
+            r = s.retries,
+        );
+        if let Some(ref reason) = s.termination_reason {
+            println!("         termination: {reason}");
+        }
+    }
+
+    println!("─────────────────────────────");
+    println!(
+        "  Total repos={repos}  success={s}  failed={f}  retries={r}",
+        repos = results.len(),
+        s = total_success,
+        f = total_failed,
+        r = total_retries,
+    );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::LoopConfig;
+    use crate::loop_engine::LoopEngine;
+    use crate::provider::tests::FakeAdapter;
+
+    fn make_target(path: &str, name: Option<&str>, prompt_override: Option<&str>) -> RepoTarget {
+        RepoTarget {
+            path: path.into(),
+            name: name.map(String::from),
+            prompt_override: prompt_override.map(String::from),
+        }
+    }
+
+    #[test]
+    fn display_name_uses_explicit_name() {
+        let t = make_target("/repos/my-project", Some("custom-label"), None);
+        assert_eq!(t.display_name(), "custom-label");
+    }
+
+    #[test]
+    fn display_name_falls_back_to_dir_name() {
+        let t = make_target("/repos/my-project", None, None);
+        assert_eq!(t.display_name(), "my-project");
+    }
+
+    #[test]
+    fn prompt_override_replaces_inline_prompt() {
+        let base = LoopConfig {
+            iterations: 1,
+            prompt_inline: Some("base prompt".to_string()),
+            ..LoopConfig::default()
+        };
+        let targets = vec![make_target("/tmp/repo-a", Some("repo-a"), Some("custom prompt"))];
+
+        // Verify that run_multi_repo builds the correct derived config by
+        // checking that the loop engine receives the override prompt.
+        // We use a FakeAdapter so no real process is spawned.
+        let mut derived = base.clone();
+        derived.workspace_dir = Some(targets[0].path.clone());
+        if let Some(ref p) = targets[0].prompt_override {
+            derived.prompt_inline = Some(p.clone());
+            derived.prompt_file = None;
+        }
+        assert_eq!(derived.prompt_inline.as_deref(), Some("custom prompt"));
+        assert!(derived.prompt_file.is_none());
+    }
+
+    #[test]
+    fn multi_repo_runs_each_target_with_fake_adapter() {
+        // Build two minimal configs and run them directly through LoopEngine
+        // with FakeAdapter to validate that results are collected per-repo.
+        let config_a = LoopConfig {
+            iterations: 1,
+            prompt_inline: Some("task".to_string()),
+            workspace_dir: Some("/tmp/repo-a".into()),
+            ..LoopConfig::default()
+        };
+        let config_b = LoopConfig {
+            iterations: 2,
+            prompt_inline: Some("task".to_string()),
+            workspace_dir: Some("/tmp/repo-b".into()),
+            ..LoopConfig::default()
+        };
+
+        let summary_a = LoopEngine::with_adapter(
+            config_a,
+            Box::new(FakeAdapter::success("fake")),
+        )
+        .run();
+        let summary_b = LoopEngine::with_adapter(
+            config_b,
+            Box::new(FakeAdapter::success("fake")),
+        )
+        .run();
+
+        assert_eq!(summary_a.successes, 1);
+        assert_eq!(summary_b.successes, 2);
+    }
+
+    #[test]
+    fn print_multi_repo_summary_does_not_panic_on_empty() {
+        print_multi_repo_summary(&[]);
+    }
+}

--- a/src/multi_repo.rs
+++ b/src/multi_repo.rs
@@ -1,7 +1,9 @@
 use crate::config::{LoopConfig, RepoTarget};
 use crate::loop_engine::{LoopEngine, SessionSummary};
 use crate::policy_guard::{PolicyGuard, UnsafeOverrides};
-use tracing::info;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use tracing::{info, warn};
 
 /// Result for a single repo target in a multi-repo run.
 #[allow(dead_code)]
@@ -21,11 +23,27 @@ pub struct RepoRunResult {
 /// - `prompt_inline` replaced by `target.prompt_override` when present
 /// - `prompt_file` cleared when `prompt_override` is set
 ///
-/// Returns one `RepoRunResult` per target in the same order as `targets`.
+/// A single SIGINT / Ctrl+C handler is installed for the whole multi-repo
+/// session.  When the signal fires the current repo's iteration runs to
+/// completion, then the outer loop stops before starting the next repo.
+///
+/// Returns one `RepoRunResult` per target in the same order as `targets`
+/// (fewer entries when interrupted early).
 pub fn run_multi_repo(base_config: &LoopConfig, targets: &[RepoTarget]) -> Vec<RepoRunResult> {
+    let interrupted = Arc::new(AtomicBool::new(false));
+    install_signal_handler(Arc::clone(&interrupted));
+
     let mut results = Vec::with_capacity(targets.len());
 
     for target in targets {
+        if interrupted.load(Ordering::SeqCst) {
+            info!(
+                repo = %target.display_name(),
+                "Multi-repo run interrupted — skipping remaining targets"
+            );
+            break;
+        }
+
         let name = target.display_name();
         info!(repo = %name, path = %target.path.display(), "Starting multi-repo run");
 
@@ -41,7 +59,8 @@ pub fn run_multi_repo(base_config: &LoopConfig, targets: &[RepoTarget]) -> Vec<R
             allow_direct_github: base_config.allow_direct_github,
         };
         let guard = PolicyGuard::new(overrides);
-        let engine = LoopEngine::new(repo_config, guard);
+        let engine =
+            LoopEngine::new(repo_config, guard).with_shared_interrupt(Arc::clone(&interrupted));
         let summary = engine.run();
 
         results.push(RepoRunResult {
@@ -52,6 +71,18 @@ pub fn run_multi_repo(base_config: &LoopConfig, targets: &[RepoTarget]) -> Vec<R
     }
 
     results
+}
+
+/// Install a process-level SIGINT / Ctrl+C handler that sets `flag` to `true`.
+///
+/// Logs a warning if the handler cannot be installed (e.g. already registered
+/// by a caller further up the stack), but does not panic.
+fn install_signal_handler(flag: Arc<AtomicBool>) {
+    ctrlc::set_handler(move || {
+        flag.store(true, Ordering::SeqCst);
+        eprintln!("\nInterrupt received — finishing current repo and stopping…");
+    })
+    .unwrap_or_else(|e| warn!("Failed to install Ctrl+C handler for multi-repo run: {e}"));
 }
 
 /// Print a human-readable summary of all repo run results.
@@ -98,7 +129,7 @@ pub fn print_multi_repo_summary(results: &[RepoRunResult]) {
 mod tests {
     use super::*;
     use crate::config::LoopConfig;
-    use crate::loop_engine::LoopEngine;
+    use crate::loop_engine::{LoopEngine, TerminationReason};
     use crate::provider::tests::FakeAdapter;
 
     fn make_target(path: &str, name: Option<&str>, prompt_override: Option<&str>) -> RepoTarget {
@@ -176,5 +207,71 @@ mod tests {
     #[test]
     fn print_multi_repo_summary_does_not_panic_on_empty() {
         print_multi_repo_summary(&[]);
+    }
+
+    // ── Shared interrupt flag tests ───────────────────────────────────────────
+
+    #[test]
+    fn with_shared_interrupt_pre_set_stops_immediately() {
+        // When the shared flag is already true, the engine should report 0
+        // successful iterations (the loop exits before the first iteration).
+        let flag = Arc::new(AtomicBool::new(true));
+        let config = LoopConfig {
+            iterations: 5,
+            prompt_inline: Some("task".to_string()),
+            ..LoopConfig::default()
+        };
+        let summary = LoopEngine::with_adapter(config, Box::new(FakeAdapter::success("out")))
+            .with_shared_interrupt(Arc::clone(&flag))
+            .run();
+
+        assert_eq!(
+            summary.iterations_run, 0,
+            "pre-set interrupt should skip all iterations"
+        );
+        assert_eq!(
+            summary.termination_reason,
+            Some(TerminationReason::Interrupted),
+            "termination reason should be Interrupted"
+        );
+    }
+
+    #[test]
+    fn interrupted_flag_prevents_next_repo_from_starting() {
+        // Simulate what run_multi_repo does: a pre-set interrupted flag means
+        // the second repo never starts.
+        let interrupted = Arc::new(AtomicBool::new(false));
+
+        // First repo runs normally.
+        let config_a = LoopConfig {
+            iterations: 1,
+            prompt_inline: Some("task".to_string()),
+            workspace_dir: Some("/tmp/repo-a".into()),
+            ..LoopConfig::default()
+        };
+        let summary_a = LoopEngine::with_adapter(config_a, Box::new(FakeAdapter::success("out")))
+            .with_shared_interrupt(Arc::clone(&interrupted))
+            .run();
+        assert_eq!(summary_a.successes, 1);
+
+        // Simulate interrupt arriving between repos.
+        interrupted.store(true, Ordering::SeqCst);
+
+        // Second repo should be skipped (the outer loop would break here).
+        let config_b = LoopConfig {
+            iterations: 3,
+            prompt_inline: Some("task".to_string()),
+            workspace_dir: Some("/tmp/repo-b".into()),
+            ..LoopConfig::default()
+        };
+        let summary_b = LoopEngine::with_adapter(config_b, Box::new(FakeAdapter::success("out")))
+            .with_shared_interrupt(Arc::clone(&interrupted))
+            .run();
+
+        // The engine itself should see the flag and exit immediately.
+        assert_eq!(
+            summary_b.iterations_run, 0,
+            "interrupted engine should run 0 iterations"
+        );
     }
 }

--- a/src/multi_repo.rs
+++ b/src/multi_repo.rs
@@ -4,6 +4,7 @@ use crate::policy_guard::{PolicyGuard, UnsafeOverrides};
 use tracing::info;
 
 /// Result for a single repo target in a multi-repo run.
+#[allow(dead_code)]
 pub struct RepoRunResult {
     /// Display name of the repository (from `RepoTarget::display_name`).
     pub name: String,

--- a/src/orchestration.rs
+++ b/src/orchestration.rs
@@ -210,11 +210,18 @@ fn count_gh_items(owner: &str, repo: &str, kind: &str) -> Result<u32, LooperErro
         )));
     }
 
-    // `gh ... --json number` returns a JSON array like `[{"number":1},{"number":2}]`.
-    // Count top-level `{` characters to get the item count without a JSON parser dep.
+    // `gh ... --json number` returns a JSON array like
+    // `[{"number":1},{"number":2}]`.  Parse it with serde_json instead of
+    // counting `{` characters — the old approach broke as soon as anyone
+    // added a field that contained a brace or pretty-printed the output
+    // (see #79).  `serde_json` is already a workspace dependency.
     let text = String::from_utf8_lossy(&output.stdout);
-    let count = text.chars().filter(|&c| c == '{').count() as u32;
-    Ok(count)
+    let items: Vec<serde_json::Value> = serde_json::from_str(&text).map_err(|e| {
+        LooperError::InvalidArgument(format!(
+            "failed to parse `gh {kind} list` output as JSON array: {e}"
+        ))
+    })?;
+    Ok(items.len() as u32)
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/src/orchestration.rs
+++ b/src/orchestration.rs
@@ -1,3 +1,4 @@
+use crate::config::{PolicyCondition, PolicyRule, PolicyWorkflow, default_policy_rules};
 use crate::error::LooperError;
 use tracing::info;
 
@@ -81,38 +82,85 @@ pub trait ContextResolver: Send + Sync {
     fn resolve(&self) -> Result<RepoContext, LooperError>;
 }
 
+/// Result of the policy engine's branch selection.
+#[derive(Debug, Clone)]
+pub struct BranchSelection {
+    /// The workflow branch to execute.
+    pub branch: WorkflowBranch,
+    /// Prompt override from the matching rule, if any.
+    pub prompt_override: Option<String>,
+    /// Repository context snapshot used to make the decision.
+    pub context: RepoContext,
+}
+
 /// Policy engine: resolves context and selects the appropriate workflow branch.
+///
+/// Rules are evaluated in order; the first rule whose condition matches wins.
+/// Construct with [`PolicyEngine::new`] (uses the default three-rule chain) or
+/// [`PolicyEngine::with_rules`] (uses caller-supplied rules).
 pub struct PolicyEngine {
     resolver: Box<dyn ContextResolver>,
+    rules: Vec<PolicyRule>,
 }
 
 impl PolicyEngine {
+    /// Create a policy engine with the default three-rule chain.
     pub fn new(resolver: Box<dyn ContextResolver>) -> Self {
-        Self { resolver }
+        Self { resolver, rules: default_policy_rules() }
     }
 
-    /// Evaluate repository context and select the highest-priority workflow branch.
+    /// Create a policy engine with a caller-supplied rule list.
     ///
-    /// Decision order:
-    /// 1. Open PRs → PrReview
-    /// 2. Open issues (no PRs) → IssueExecution
-    /// 3. Nothing open → BacklogDiscovery
-    pub fn select_branch(&self) -> Result<(WorkflowBranch, RepoContext), LooperError> {
+    /// An empty `rules` list is accepted; the engine will return an error at
+    /// runtime if no rule matches (since there is no `Always` fallback).
+    pub fn with_rules(resolver: Box<dyn ContextResolver>, rules: Vec<PolicyRule>) -> Self {
+        Self { resolver, rules }
+    }
+
+    /// Evaluate repository context against the configured rule list and return
+    /// the first matching branch selection.
+    ///
+    /// Returns an error if the resolver fails or if no rule matches.
+    pub fn select_branch(&self) -> Result<BranchSelection, LooperError> {
         let ctx = self.resolver.resolve()?;
-        let branch = if ctx.has_open_prs() {
-            WorkflowBranch::PrReview
-        } else if ctx.has_open_issues() {
-            WorkflowBranch::IssueExecution
-        } else {
-            WorkflowBranch::BacklogDiscovery
-        };
-        info!(
-            open_prs = ctx.open_pr_count,
-            open_issues = ctx.open_issue_count,
-            selected_branch = %branch,
-            "Policy engine selected workflow branch"
-        );
-        Ok((branch, ctx))
+
+        for rule in &self.rules {
+            let matches = match rule.condition {
+                PolicyCondition::HasOpenPrs => ctx.has_open_prs(),
+                PolicyCondition::HasOpenIssues => ctx.has_open_issues(),
+                PolicyCondition::Always => true,
+            };
+
+            if matches {
+                let branch = workflow_to_branch(&rule.workflow);
+                info!(
+                    open_prs = ctx.open_pr_count,
+                    open_issues = ctx.open_issue_count,
+                    selected_branch = %branch,
+                    condition = %rule.condition,
+                    "Policy engine selected workflow branch"
+                );
+                return Ok(BranchSelection {
+                    branch,
+                    prompt_override: rule.prompt_override.clone(),
+                    context: ctx,
+                });
+            }
+        }
+
+        Err(LooperError::InvalidArgument(
+            "No policy rule matched the current repository context. \
+             Add an `always` fallback rule to your [[orchestration.policies]] config."
+                .to_string(),
+        ))
+    }
+}
+
+fn workflow_to_branch(workflow: &PolicyWorkflow) -> WorkflowBranch {
+    match workflow {
+        PolicyWorkflow::PrReview => WorkflowBranch::PrReview,
+        PolicyWorkflow::IssueExecution => WorkflowBranch::IssueExecution,
+        PolicyWorkflow::BacklogDiscovery => WorkflowBranch::BacklogDiscovery,
     }
 }
 
@@ -183,8 +231,8 @@ pub mod tests {
         let engine = PolicyEngine::new(Box::new(StubContextResolver {
             context: RepoContext { open_pr_count: 2, open_issue_count: 5 },
         }));
-        let (branch, _) = engine.select_branch().unwrap();
-        assert_eq!(branch, WorkflowBranch::PrReview);
+        let sel = engine.select_branch().unwrap();
+        assert_eq!(sel.branch, WorkflowBranch::PrReview);
     }
 
     #[test]
@@ -192,8 +240,8 @@ pub mod tests {
         let engine = PolicyEngine::new(Box::new(StubContextResolver {
             context: RepoContext { open_pr_count: 0, open_issue_count: 3 },
         }));
-        let (branch, _) = engine.select_branch().unwrap();
-        assert_eq!(branch, WorkflowBranch::IssueExecution);
+        let sel = engine.select_branch().unwrap();
+        assert_eq!(sel.branch, WorkflowBranch::IssueExecution);
     }
 
     #[test]
@@ -201,8 +249,8 @@ pub mod tests {
         let engine = PolicyEngine::new(Box::new(StubContextResolver {
             context: RepoContext { open_pr_count: 0, open_issue_count: 0 },
         }));
-        let (branch, _) = engine.select_branch().unwrap();
-        assert_eq!(branch, WorkflowBranch::BacklogDiscovery);
+        let sel = engine.select_branch().unwrap();
+        assert_eq!(sel.branch, WorkflowBranch::BacklogDiscovery);
     }
 
     #[test]
@@ -210,9 +258,9 @@ pub mod tests {
         let engine = PolicyEngine::new(Box::new(StubContextResolver {
             context: RepoContext { open_pr_count: 1, open_issue_count: 10 },
         }));
-        let (branch, ctx) = engine.select_branch().unwrap();
-        assert_eq!(branch, WorkflowBranch::PrReview);
-        assert_eq!(ctx.open_issue_count, 10);
+        let sel = engine.select_branch().unwrap();
+        assert_eq!(sel.branch, WorkflowBranch::PrReview);
+        assert_eq!(sel.context.open_issue_count, 10);
     }
 
     #[test]
@@ -238,5 +286,115 @@ pub mod tests {
         assert!(!WorkflowBranch::PrReview.default_prompt().is_empty());
         assert!(!WorkflowBranch::IssueExecution.default_prompt().is_empty());
         assert!(!WorkflowBranch::BacklogDiscovery.default_prompt().is_empty());
+    }
+
+    // ── Pluggable policy rules ────────────────────────────────────────────────
+
+    #[test]
+    fn custom_rules_override_default_chain() {
+        use crate::config::{PolicyCondition, PolicyRule, PolicyWorkflow};
+        // Single rule: always → issue-execution (reversed from default).
+        let rules = vec![PolicyRule {
+            condition: PolicyCondition::Always,
+            workflow: PolicyWorkflow::IssueExecution,
+            prompt_override: None,
+        }];
+        let engine = PolicyEngine::with_rules(
+            Box::new(StubContextResolver {
+                context: RepoContext { open_pr_count: 5, open_issue_count: 0 },
+            }),
+            rules,
+        );
+        // Even though there are open PRs, our single rule maps Always → IssueExecution.
+        let sel = engine.select_branch().unwrap();
+        assert_eq!(sel.branch, WorkflowBranch::IssueExecution);
+    }
+
+    #[test]
+    fn prompt_override_is_returned_when_set() {
+        use crate::config::{PolicyCondition, PolicyRule, PolicyWorkflow};
+        let rules = vec![PolicyRule {
+            condition: PolicyCondition::Always,
+            workflow: PolicyWorkflow::PrReview,
+            prompt_override: Some("Custom PR review prompt.".to_string()),
+        }];
+        let engine = PolicyEngine::with_rules(
+            Box::new(StubContextResolver {
+                context: RepoContext { open_pr_count: 1, open_issue_count: 0 },
+            }),
+            rules,
+        );
+        let sel = engine.select_branch().unwrap();
+        assert_eq!(sel.prompt_override.as_deref(), Some("Custom PR review prompt."));
+    }
+
+    #[test]
+    fn no_prompt_override_when_none_set() {
+        use crate::config::{PolicyCondition, PolicyRule, PolicyWorkflow};
+        let rules = vec![PolicyRule {
+            condition: PolicyCondition::Always,
+            workflow: PolicyWorkflow::BacklogDiscovery,
+            prompt_override: None,
+        }];
+        let engine = PolicyEngine::with_rules(
+            Box::new(StubContextResolver {
+                context: RepoContext { open_pr_count: 0, open_issue_count: 0 },
+            }),
+            rules,
+        );
+        let sel = engine.select_branch().unwrap();
+        assert!(sel.prompt_override.is_none());
+    }
+
+    #[test]
+    fn first_matching_rule_wins() {
+        use crate::config::{PolicyCondition, PolicyRule, PolicyWorkflow};
+        let rules = vec![
+            PolicyRule {
+                condition: PolicyCondition::HasOpenIssues,
+                workflow: PolicyWorkflow::IssueExecution,
+                prompt_override: None,
+            },
+            PolicyRule {
+                condition: PolicyCondition::Always,
+                workflow: PolicyWorkflow::BacklogDiscovery,
+                prompt_override: None,
+            },
+        ];
+        let engine = PolicyEngine::with_rules(
+            Box::new(StubContextResolver {
+                context: RepoContext { open_pr_count: 0, open_issue_count: 2 },
+            }),
+            rules,
+        );
+        let sel = engine.select_branch().unwrap();
+        // HasOpenIssues matches first, so IssueExecution wins over Always fallback.
+        assert_eq!(sel.branch, WorkflowBranch::IssueExecution);
+    }
+
+    #[test]
+    fn no_matching_rule_returns_error() {
+        use crate::config::{PolicyCondition, PolicyRule, PolicyWorkflow};
+        // Rules require open PRs, but context has none.
+        let rules = vec![PolicyRule {
+            condition: PolicyCondition::HasOpenPrs,
+            workflow: PolicyWorkflow::PrReview,
+            prompt_override: None,
+        }];
+        let engine = PolicyEngine::with_rules(
+            Box::new(StubContextResolver {
+                context: RepoContext { open_pr_count: 0, open_issue_count: 0 },
+            }),
+            rules,
+        );
+        assert!(engine.select_branch().is_err());
+    }
+
+    #[test]
+    fn policy_condition_display() {
+        use crate::config::PolicyCondition;
+        assert_eq!(PolicyCondition::HasOpenPrs.to_string(), "has_open_prs");
+        assert_eq!(PolicyCondition::HasOpenIssues.to_string(), "has_open_issues");
+        assert_eq!(PolicyCondition::Always.to_string(), "always");
     }
 }

--- a/src/orchestration.rs
+++ b/src/orchestration.rs
@@ -84,6 +84,7 @@ pub trait ContextResolver: Send + Sync {
 
 /// Result of the policy engine's branch selection.
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct BranchSelection {
     /// The workflow branch to execute.
     pub branch: WorkflowBranch,
@@ -105,6 +106,7 @@ pub struct PolicyEngine {
 
 impl PolicyEngine {
     /// Create a policy engine with the default three-rule chain.
+    #[allow(dead_code)]
     pub fn new(resolver: Box<dyn ContextResolver>) -> Self {
         Self { resolver, rules: default_policy_rules() }
     }

--- a/src/orchestration.rs
+++ b/src/orchestration.rs
@@ -1,4 +1,4 @@
-use crate::config::{PolicyCondition, PolicyRule, PolicyWorkflow, default_policy_rules};
+use crate::config::{default_policy_rules, PolicyCondition, PolicyRule, PolicyWorkflow};
 use crate::error::LooperError;
 use tracing::info;
 
@@ -108,7 +108,10 @@ impl PolicyEngine {
     /// Create a policy engine with the default three-rule chain.
     #[allow(dead_code)]
     pub fn new(resolver: Box<dyn ContextResolver>) -> Self {
-        Self { resolver, rules: default_policy_rules() }
+        Self {
+            resolver,
+            rules: default_policy_rules(),
+        }
     }
 
     /// Create a policy engine with a caller-supplied rule list.
@@ -191,7 +194,9 @@ fn count_gh_items(owner: &str, repo: &str, kind: &str) -> Result<u32, LooperErro
 
     let repo_slug = format!("{owner}/{repo}");
     let output = Command::new("gh")
-        .args([kind, "list", "--repo", &repo_slug, "--state", "open", "--json", "number"])
+        .args([
+            kind, "list", "--repo", &repo_slug, "--state", "open", "--json", "number",
+        ])
         .output()
         .map_err(|e| LooperError::ProviderSpawn {
             binary: "gh".to_string(),
@@ -231,7 +236,10 @@ pub mod tests {
     #[test]
     fn selects_pr_review_when_prs_open() {
         let engine = PolicyEngine::new(Box::new(StubContextResolver {
-            context: RepoContext { open_pr_count: 2, open_issue_count: 5 },
+            context: RepoContext {
+                open_pr_count: 2,
+                open_issue_count: 5,
+            },
         }));
         let sel = engine.select_branch().unwrap();
         assert_eq!(sel.branch, WorkflowBranch::PrReview);
@@ -240,7 +248,10 @@ pub mod tests {
     #[test]
     fn selects_issue_execution_when_no_prs_but_issues() {
         let engine = PolicyEngine::new(Box::new(StubContextResolver {
-            context: RepoContext { open_pr_count: 0, open_issue_count: 3 },
+            context: RepoContext {
+                open_pr_count: 0,
+                open_issue_count: 3,
+            },
         }));
         let sel = engine.select_branch().unwrap();
         assert_eq!(sel.branch, WorkflowBranch::IssueExecution);
@@ -249,7 +260,10 @@ pub mod tests {
     #[test]
     fn selects_backlog_discovery_when_nothing_open() {
         let engine = PolicyEngine::new(Box::new(StubContextResolver {
-            context: RepoContext { open_pr_count: 0, open_issue_count: 0 },
+            context: RepoContext {
+                open_pr_count: 0,
+                open_issue_count: 0,
+            },
         }));
         let sel = engine.select_branch().unwrap();
         assert_eq!(sel.branch, WorkflowBranch::BacklogDiscovery);
@@ -258,7 +272,10 @@ pub mod tests {
     #[test]
     fn prs_take_precedence_over_issues() {
         let engine = PolicyEngine::new(Box::new(StubContextResolver {
-            context: RepoContext { open_pr_count: 1, open_issue_count: 10 },
+            context: RepoContext {
+                open_pr_count: 1,
+                open_issue_count: 10,
+            },
         }));
         let sel = engine.select_branch().unwrap();
         assert_eq!(sel.branch, WorkflowBranch::PrReview);
@@ -268,17 +285,29 @@ pub mod tests {
     #[test]
     fn workflow_branch_display() {
         assert_eq!(WorkflowBranch::PrReview.to_string(), "pr-review");
-        assert_eq!(WorkflowBranch::IssueExecution.to_string(), "issue-execution");
-        assert_eq!(WorkflowBranch::BacklogDiscovery.to_string(), "backlog-discovery");
+        assert_eq!(
+            WorkflowBranch::IssueExecution.to_string(),
+            "issue-execution"
+        );
+        assert_eq!(
+            WorkflowBranch::BacklogDiscovery.to_string(),
+            "backlog-discovery"
+        );
     }
 
     #[test]
     fn repo_context_helpers() {
-        let ctx = RepoContext { open_pr_count: 1, open_issue_count: 0 };
+        let ctx = RepoContext {
+            open_pr_count: 1,
+            open_issue_count: 0,
+        };
         assert!(ctx.has_open_prs());
         assert!(!ctx.has_open_issues());
 
-        let ctx2 = RepoContext { open_pr_count: 0, open_issue_count: 2 };
+        let ctx2 = RepoContext {
+            open_pr_count: 0,
+            open_issue_count: 2,
+        };
         assert!(!ctx2.has_open_prs());
         assert!(ctx2.has_open_issues());
     }
@@ -303,7 +332,10 @@ pub mod tests {
         }];
         let engine = PolicyEngine::with_rules(
             Box::new(StubContextResolver {
-                context: RepoContext { open_pr_count: 5, open_issue_count: 0 },
+                context: RepoContext {
+                    open_pr_count: 5,
+                    open_issue_count: 0,
+                },
             }),
             rules,
         );
@@ -322,12 +354,18 @@ pub mod tests {
         }];
         let engine = PolicyEngine::with_rules(
             Box::new(StubContextResolver {
-                context: RepoContext { open_pr_count: 1, open_issue_count: 0 },
+                context: RepoContext {
+                    open_pr_count: 1,
+                    open_issue_count: 0,
+                },
             }),
             rules,
         );
         let sel = engine.select_branch().unwrap();
-        assert_eq!(sel.prompt_override.as_deref(), Some("Custom PR review prompt."));
+        assert_eq!(
+            sel.prompt_override.as_deref(),
+            Some("Custom PR review prompt.")
+        );
     }
 
     #[test]
@@ -340,7 +378,10 @@ pub mod tests {
         }];
         let engine = PolicyEngine::with_rules(
             Box::new(StubContextResolver {
-                context: RepoContext { open_pr_count: 0, open_issue_count: 0 },
+                context: RepoContext {
+                    open_pr_count: 0,
+                    open_issue_count: 0,
+                },
             }),
             rules,
         );
@@ -365,7 +406,10 @@ pub mod tests {
         ];
         let engine = PolicyEngine::with_rules(
             Box::new(StubContextResolver {
-                context: RepoContext { open_pr_count: 0, open_issue_count: 2 },
+                context: RepoContext {
+                    open_pr_count: 0,
+                    open_issue_count: 2,
+                },
             }),
             rules,
         );
@@ -385,7 +429,10 @@ pub mod tests {
         }];
         let engine = PolicyEngine::with_rules(
             Box::new(StubContextResolver {
-                context: RepoContext { open_pr_count: 0, open_issue_count: 0 },
+                context: RepoContext {
+                    open_pr_count: 0,
+                    open_issue_count: 0,
+                },
             }),
             rules,
         );
@@ -396,7 +443,10 @@ pub mod tests {
     fn policy_condition_display() {
         use crate::config::PolicyCondition;
         assert_eq!(PolicyCondition::HasOpenPrs.to_string(), "has_open_prs");
-        assert_eq!(PolicyCondition::HasOpenIssues.to_string(), "has_open_issues");
+        assert_eq!(
+            PolicyCondition::HasOpenIssues.to_string(),
+            "has_open_issues"
+        );
         assert_eq!(PolicyCondition::Always.to_string(), "always");
     }
 }

--- a/src/orchestration.rs
+++ b/src/orchestration.rs
@@ -41,13 +41,23 @@ impl WorkflowBranch {
             WorkflowBranch::IssueExecution => {
                 "Work on open GitHub issues in this repository. Pick the highest-priority \
                  unassigned issue, understand the requirements, implement the changes, \
-                 and update the issue via MCP GitHub tools when done."
+                 and update the issue via MCP GitHub tools when done. \
+                 \n\n**Issue lifecycle rules:**\
+                 \n- Comment at meaningful milestones (plan finalised, first pass done, \
+                 tests added, blocker found).\
+                 \n- If you discover work that is out of scope for the current issue, create \
+                 a new GitHub issue (via MCP) with a clear title, body, and one of the \
+                 standard labels: `bug`, `enhancement`, `tech-debt`, or \
+                 `discovered-during-loop`. Post a cross-reference comment on both issues.\
+                 \n- When the issue checklist is fully checked and changes are committed, \
+                 close the issue with a short summary comment explaining what was done."
             }
             WorkflowBranch::BacklogDiscovery => {
                 "Explore the repository codebase and identify areas for improvement: \
                  missing tests, documentation gaps, refactoring opportunities, or potential \
                  new features. Create GitHub issues for the most impactful opportunities \
-                 using the MCP GitHub tools."
+                 using the MCP GitHub tools. Use one of the standard labels for each new \
+                 issue: `bug`, `enhancement`, `tech-debt`, or `discovered-during-loop`."
             }
         }
     }

--- a/src/policy_guard.rs
+++ b/src/policy_guard.rs
@@ -1,12 +1,28 @@
+//! Policy guard — agent-prompt enforcement of the MCP-only GitHub mutation
+//! path.
+//!
+//! Per ADR-001 (revised), MCP-only is scoped to **agent prompts**:
+//! [`PolicyGuard::augment_prompt`] prepends a preamble telling the provider
+//! to use only MCP server tools for GitHub writes.  The engine itself is
+//! explicitly permitted to shell out to `gh` for its own bookkeeping (PR
+//! creation, issue comments, merge-cleanup branch ops) — see the module
+//! docs in `pr_manager.rs` and `issue_tracker.rs`.
+//!
+//! This module does **not** enforce anything at the process level; enforcement
+//! is prompt-level and trusts the agent to honour the preamble.  A stronger
+//! sandbox would require removing `gh` from the provider's `PATH`, which is
+//! out of scope for this ADR.
+
 /// Configuration for unsafe bypass overrides.
 ///
 /// All overrides are opt-in and disabled by default.  Enabling any of them
-/// weakens the safety guarantees described in the PRD.
+/// weakens the safety guarantees described in ADR-001.
 #[derive(Debug, Clone, Default)]
 pub struct UnsafeOverrides {
-    /// When `true`, the system allows orchestration context to be resolved via
-    /// direct `gh` CLI calls rather than requiring a GitHub MCP server.
-    /// Caution: this bypasses the MCP-only GitHub integration path.
+    /// When `true`, the agent-prompt MCP-only preamble is suppressed, so
+    /// providers are free to use `gh` CLI or raw REST calls for GitHub
+    /// writes.  Engine-side `gh` usage is unaffected by this flag — it is
+    /// already permitted by ADR-001.
     pub allow_direct_github: bool,
 }
 
@@ -31,11 +47,14 @@ impl std::fmt::Display for PolicyViolation {
     }
 }
 
-/// Enforces the MCP-only GitHub mutation path and validates execution config.
+/// Agent-prompt enforcement of the MCP-only GitHub mutation path.
 ///
-/// The guard runs at startup, before any loop iteration, and raises
-/// `PolicyViolation`s for any configuration that would allow GitHub mutations
-/// outside the approved MCP server path.
+/// The guard has a single real responsibility: prepend a preamble to every
+/// provider prompt telling the agent to use MCP server tools for any GitHub
+/// writes (see [`Self::augment_prompt`]).  There is no process-level or
+/// config-level validation — enforcement is prompt-level only, and the
+/// engine itself is explicitly permitted to use `gh` directly per the
+/// revised ADR-001.
 pub struct PolicyGuard {
     overrides: UnsafeOverrides,
 }
@@ -45,25 +64,16 @@ impl PolicyGuard {
         Self { overrides }
     }
 
-    /// Validate that the orchestration configuration is safe.
+    /// Startup sanity check for orchestration config.
     ///
-    /// Returns a list of violations (empty = all clear).
-    pub fn validate_orchestration(&self, orchestration_enabled: bool) -> Vec<PolicyViolation> {
-        let violations = Vec::new();
-
-        if orchestration_enabled && !self.overrides.allow_direct_github {
-            // When orchestration is enabled, context resolution currently falls
-            // back to the `GhCliContextResolver` (direct `gh` CLI).  This is
-            // permitted for READ-ONLY operations, but the guard must ensure the
-            // prompts delivered to providers explicitly require MCP tool use for
-            // any WRITE operations.
-            //
-            // No violation is raised here for reads; the guard instead
-            // augments prompts (see `augment_prompt`) to enforce MCP-only
-            // writes.
-        }
-
-        violations
+    /// Returns a list of violations (empty = all clear).  At present this is
+    /// intentionally a no-op: the guard has no config invariants to check
+    /// beyond what the config loader already validates, and the actual
+    /// MCP-only enforcement happens at the prompt level via
+    /// [`Self::augment_prompt`].  The method is kept so callers have a single
+    /// startup hook to attach future validations to.
+    pub fn check_startup(&self, _orchestration_enabled: bool) -> Vec<PolicyViolation> {
+        Vec::new()
     }
 
     /// Augment a provider prompt with an MCP-use preamble.
@@ -113,11 +123,11 @@ mod tests {
         })
     }
 
-    // ── validate_orchestration ────────────────────────────────────────────────
+    // ── check_startup ────────────────────────────────────────────────
 
     #[test]
     fn no_violations_when_orchestration_disabled() {
-        let violations = default_guard().validate_orchestration(false);
+        let violations = default_guard().check_startup(false);
         assert!(violations.is_empty());
     }
 
@@ -125,13 +135,13 @@ mod tests {
     fn no_violations_when_orchestration_enabled_default_policy() {
         // Orchestration with default (safe) policy: reads via gh are allowed;
         // writes are constrained via prompt augmentation, not a hard violation.
-        let violations = default_guard().validate_orchestration(true);
+        let violations = default_guard().check_startup(true);
         assert!(violations.is_empty());
     }
 
     #[test]
     fn no_violations_with_allow_direct_github_override() {
-        let violations = permissive_guard().validate_orchestration(true);
+        let violations = permissive_guard().check_startup(true);
         assert!(violations.is_empty());
     }
 

--- a/src/policy_guard.rs
+++ b/src/policy_guard.rs
@@ -108,7 +108,9 @@ mod tests {
     }
 
     fn permissive_guard() -> PolicyGuard {
-        PolicyGuard::new(UnsafeOverrides { allow_direct_github: true })
+        PolicyGuard::new(UnsafeOverrides {
+            allow_direct_github: true,
+        })
     }
 
     // ── validate_orchestration ────────────────────────────────────────────────

--- a/src/pr_manager.rs
+++ b/src/pr_manager.rs
@@ -563,6 +563,9 @@ pub struct PrWithState {
     pub state: PrTriageState,
     /// ISO-8601 creation timestamp (used for `oldest`/`newest` ordering).
     pub created_at: String,
+    /// GitHub merge-ability state: `"MERGEABLE"`, `"CONFLICTING"`, or `"UNKNOWN"`.
+    /// `None` when the field was not returned by the API (older `gh` versions).
+    pub mergeable: Option<String>,
 }
 
 /// Outcome of a `PrTriage::select_action` call.
@@ -660,7 +663,7 @@ impl PrLifecycleTriage for GhPrLifecycle {
                 "view",
                 &pr_ref,
                 "--json",
-                "number,url,title,headRefName,labels,statusCheckRollup,reviewDecision,createdAt",
+                "number,url,title,headRefName,labels,statusCheckRollup,reviewDecision,createdAt,mergeable",
             ])
             .output()
             .map_err(|e| PrError::GhCommand(format!("failed to spawn gh: {e}")))?;
@@ -679,6 +682,7 @@ impl PrLifecycleTriage for GhPrLifecycle {
         let title = v["title"].as_str().unwrap_or("").to_string();
         let head_ref = v["headRefName"].as_str().unwrap_or("").to_string();
         let created_at = v["createdAt"].as_str().unwrap_or("").to_string();
+        let mergeable = v["mergeable"].as_str().map(|s| s.to_string());
 
         let pr = PrInfo {
             number,
@@ -698,6 +702,7 @@ impl PrLifecycleTriage for GhPrLifecycle {
                                 reason: name.to_string(),
                             },
                             created_at,
+                            mergeable: mergeable.clone(),
                         });
                     }
                 }
@@ -722,6 +727,7 @@ impl PrLifecycleTriage for GhPrLifecycle {
                 pr,
                 state: PrTriageState::ChecksFailing,
                 created_at,
+                mergeable,
             });
         }
 
@@ -738,6 +744,7 @@ impl PrLifecycleTriage for GhPrLifecycle {
             pr,
             state,
             created_at,
+            mergeable,
         })
     }
 }
@@ -770,10 +777,19 @@ impl<L: PrLifecycleTriage> PrTriage<L> {
             }
         };
 
-        // Apply triage priority ordering.
+        // Apply triage priority ordering for Oldest/Newest (list already comes
+        // from gh in ascending creation order).
         match self.config.triage_priority {
             TriagePriority::Newest => prs.reverse(),
-            TriagePriority::Oldest | TriagePriority::LeastConflicts => {}
+            TriagePriority::Oldest => {}
+            // LeastConflicts requires state for all PRs; handled below.
+            TriagePriority::LeastConflicts => {}
+        }
+
+        // For LeastConflicts mode, fetch all states upfront so we can sort by
+        // merge-ability before iterating.
+        if self.config.triage_priority == TriagePriority::LeastConflicts {
+            return self.select_action_least_conflicts(prs);
         }
 
         for pr_info in prs {
@@ -792,52 +808,102 @@ impl<L: PrLifecycleTriage> PrTriage<L> {
                 }
             };
 
-            match with_state.state {
-                PrTriageState::Skipped { ref reason } => {
-                    tracing::debug!(pr = pr_info.number, %reason, "PrTriage: skipping PR");
-                    continue;
-                }
-                PrTriageState::ChecksFailing => {
-                    let prompt = format!(
-                        "The CI checks on PR #{} («{}») are failing. Check out the branch, \
-                         diagnose the root cause, fix it, commit, and push. Do not merge — \
-                         the loop engine will handle the merge when checks pass.",
-                        with_state.pr.number, with_state.pr.title
-                    );
-                    return TriageAction::FixChecks {
-                        pr: with_state.pr,
-                        prompt,
-                    };
-                }
-                PrTriageState::ChangesRequested => {
-                    let prompt = format!(
-                        "PR #{} («{}») has review comments requesting changes. Read each \
-                         review comment, address the feedback, commit the fixes, and push. \
-                         After pushing, reply to each resolved comment thread.",
-                        with_state.pr.number, with_state.pr.title
-                    );
-                    return TriageAction::AddressReviewFeedback {
-                        pr: with_state.pr,
-                        prompt,
-                    };
-                }
-                PrTriageState::ReadyToMerge => {
-                    if self.config.require_human_review {
-                        tracing::info!(
-                            pr = with_state.pr.number,
-                            "PrTriage: PR ready to merge but require_human_review=true"
-                        );
-                        return TriageAction::BlockedOnHumanReview { pr: with_state.pr };
-                    }
-                    return TriageAction::Merge { pr: with_state.pr };
-                }
-                PrTriageState::NeedsReview => {
-                    tracing::debug!(
+            if let Some(action) = self.evaluate_pr_state(with_state) {
+                return action;
+            }
+        }
+
+        TriageAction::NoActionablePr
+    }
+
+    /// Evaluate a single `PrWithState` and return the triage action, or `None`
+    /// to continue to the next PR.
+    fn evaluate_pr_state(&self, with_state: PrWithState) -> Option<TriageAction> {
+        match with_state.state {
+            PrTriageState::Skipped { ref reason } => {
+                tracing::debug!(pr = with_state.pr.number, %reason, "PrTriage: skipping PR");
+                None
+            }
+            PrTriageState::ChecksFailing => {
+                let prompt = format!(
+                    "The CI checks on PR #{} («{}») are failing. Check out the branch, \
+                     diagnose the root cause, fix it, commit, and push. Do not merge — \
+                     the loop engine will handle the merge when checks pass.",
+                    with_state.pr.number, with_state.pr.title
+                );
+                Some(TriageAction::FixChecks {
+                    pr: with_state.pr,
+                    prompt,
+                })
+            }
+            PrTriageState::ChangesRequested => {
+                let prompt = format!(
+                    "PR #{} («{}») has review comments requesting changes. Read each \
+                     review comment, address the feedback, commit the fixes, and push. \
+                     After pushing, reply to each resolved comment thread.",
+                    with_state.pr.number, with_state.pr.title
+                );
+                Some(TriageAction::AddressReviewFeedback {
+                    pr: with_state.pr,
+                    prompt,
+                })
+            }
+            PrTriageState::ReadyToMerge => {
+                if self.config.require_human_review {
+                    tracing::info!(
                         pr = with_state.pr.number,
-                        "PrTriage: PR awaiting initial review; skipping"
+                        "PrTriage: PR ready to merge but require_human_review=true"
                     );
-                    continue;
+                    Some(TriageAction::BlockedOnHumanReview { pr: with_state.pr })
+                } else {
+                    Some(TriageAction::Merge { pr: with_state.pr })
                 }
+            }
+            PrTriageState::NeedsReview => {
+                tracing::debug!(
+                    pr = with_state.pr.number,
+                    "PrTriage: PR awaiting initial review; skipping"
+                );
+                None
+            }
+        }
+    }
+
+    /// `LeastConflicts` variant: fetch all PR states, sort by merge-ability
+    /// (MERGEABLE first, UNKNOWN second, CONFLICTING last), then evaluate.
+    fn select_action_least_conflicts(&self, prs: Vec<PrInfo>) -> TriageAction {
+        let mut states: Vec<PrWithState> = prs
+            .into_iter()
+            .filter_map(|pr_info| {
+                match self
+                    .lifecycle
+                    .get_pr_state(pr_info.number, &self.config.skip_labels)
+                {
+                    Ok(ws) => Some(ws),
+                    Err(e) => {
+                        tracing::warn!(
+                            pr = pr_info.number,
+                            error = %e,
+                            "PrTriage(least-conflicts): failed to get state; skipping"
+                        );
+                        None
+                    }
+                }
+            })
+            .collect();
+
+        // Sort: MERGEABLE (0) < UNKNOWN (1) < CONFLICTING (2) < missing (3).
+        states.sort_by_key(|ws| mergeable_sort_key(ws.mergeable.as_deref()));
+
+        tracing::debug!(
+            count = states.len(),
+            "PrTriage(least-conflicts): sorted {} PRs by merge-ability",
+            states.len()
+        );
+
+        for with_state in states {
+            if let Some(action) = self.evaluate_pr_state(with_state) {
+                return action;
             }
         }
 
@@ -848,6 +914,23 @@ impl<L: PrLifecycleTriage> PrTriage<L> {
 /// Build a production [`PrTriage`] backed by the `gh` CLI.
 pub fn build_pr_triage(config: PrManagementConfig) -> PrTriage<GhPrLifecycle> {
     PrTriage::new(config, GhPrLifecycle::new())
+}
+
+/// Numeric sort key for the `LeastConflicts` priority.
+///
+/// | GitHub value   | key |
+/// |----------------|-----|
+/// | `"MERGEABLE"`  | 0   |
+/// | `"UNKNOWN"`    | 1   |
+/// | `"CONFLICTING"`| 2   |
+/// | `None`         | 3   |
+fn mergeable_sort_key(mergeable: Option<&str>) -> u8 {
+    match mergeable {
+        Some("MERGEABLE") => 0,
+        Some("UNKNOWN") => 1,
+        Some("CONFLICTING") => 2,
+        _ => 3,
+    }
 }
 
 // ── MockPrLifecycleTriage (test double) ───────────────────────────────────────
@@ -1168,6 +1251,20 @@ mod tests {
             pr,
             state,
             created_at: "2026-01-01T00:00:00Z".into(),
+            mergeable: Some("MERGEABLE".into()),
+        }
+    }
+
+    fn make_state_with_mergeable(
+        pr: PrInfo,
+        state: PrTriageState,
+        mergeable: Option<&str>,
+    ) -> PrWithState {
+        PrWithState {
+            pr,
+            state,
+            created_at: "2026-01-01T00:00:00Z".into(),
+            mergeable: mergeable.map(|s| s.to_string()),
         }
     }
 
@@ -1368,5 +1465,147 @@ mod tests {
         } else {
             panic!("expected TriageAction::Merge");
         }
+    }
+
+    // ── least-conflicts triage priority ──────────────────────────────────────
+
+    #[test]
+    fn least_conflicts_prefers_mergeable_over_conflicting() {
+        // PR 1 is CONFLICTING, PR 2 is MERGEABLE — expect PR 2 to be selected.
+        let mut mock = MockPrLifecycleTriage::new();
+        mock.open_prs = vec![make_pr(1), make_pr(2)];
+        mock.states.insert(
+            1,
+            make_state_with_mergeable(
+                make_pr(1),
+                PrTriageState::ChecksFailing,
+                Some("CONFLICTING"),
+            ),
+        );
+        mock.states.insert(
+            2,
+            make_state_with_mergeable(make_pr(2), PrTriageState::ChecksFailing, Some("MERGEABLE")),
+        );
+
+        let mut cfg = default_config();
+        cfg.triage_priority = TriagePriority::LeastConflicts;
+        let triage = PrTriage::new(cfg, mock);
+
+        if let TriageAction::FixChecks { pr, .. } = triage.select_action() {
+            assert_eq!(pr.number, 2, "MERGEABLE PR should be selected first");
+        } else {
+            panic!("expected FixChecks action");
+        }
+    }
+
+    #[test]
+    fn least_conflicts_unknown_before_conflicting() {
+        // PR 1 is CONFLICTING, PR 2 is UNKNOWN — expect PR 2 (UNKNOWN) first.
+        let mut mock = MockPrLifecycleTriage::new();
+        mock.open_prs = vec![make_pr(1), make_pr(2)];
+        mock.states.insert(
+            1,
+            make_state_with_mergeable(
+                make_pr(1),
+                PrTriageState::ChangesRequested,
+                Some("CONFLICTING"),
+            ),
+        );
+        mock.states.insert(
+            2,
+            make_state_with_mergeable(make_pr(2), PrTriageState::ChangesRequested, Some("UNKNOWN")),
+        );
+
+        let mut cfg = default_config();
+        cfg.triage_priority = TriagePriority::LeastConflicts;
+        let triage = PrTriage::new(cfg, mock);
+
+        if let TriageAction::AddressReviewFeedback { pr, .. } = triage.select_action() {
+            assert_eq!(
+                pr.number, 2,
+                "UNKNOWN PR should be selected before CONFLICTING"
+            );
+        } else {
+            panic!("expected AddressReviewFeedback action");
+        }
+    }
+
+    #[test]
+    fn least_conflicts_all_mergeable_first_pr_wins() {
+        // All PRs are MERGEABLE — standard first-in-list ordering applies.
+        let mut mock = MockPrLifecycleTriage::new();
+        mock.open_prs = vec![make_pr(10), make_pr(20)];
+        mock.states.insert(
+            10,
+            make_state_with_mergeable(make_pr(10), PrTriageState::ChecksFailing, Some("MERGEABLE")),
+        );
+        mock.states.insert(
+            20,
+            make_state_with_mergeable(make_pr(20), PrTriageState::ChecksFailing, Some("MERGEABLE")),
+        );
+
+        let mut cfg = default_config();
+        cfg.triage_priority = TriagePriority::LeastConflicts;
+        let triage = PrTriage::new(cfg, mock);
+
+        if let TriageAction::FixChecks { pr, .. } = triage.select_action() {
+            assert_eq!(pr.number, 10, "When equal, first listed PR wins");
+        } else {
+            panic!("expected FixChecks action");
+        }
+    }
+
+    #[test]
+    fn least_conflicts_no_prs_returns_no_actionable() {
+        let mock = MockPrLifecycleTriage::new();
+        let mut cfg = default_config();
+        cfg.triage_priority = TriagePriority::LeastConflicts;
+        let triage = PrTriage::new(cfg, mock);
+        assert!(matches!(
+            triage.select_action(),
+            TriageAction::NoActionablePr
+        ));
+    }
+
+    #[test]
+    fn least_conflicts_none_mergeable_field_treated_as_last() {
+        // PR 1 has no mergeable field (None), PR 2 is CONFLICTING.
+        // None (key 3) sorts after CONFLICTING (key 2) — PR 2 is selected first.
+        let mut mock = MockPrLifecycleTriage::new();
+        mock.open_prs = vec![make_pr(1), make_pr(2)];
+        mock.states.insert(
+            1,
+            make_state_with_mergeable(make_pr(1), PrTriageState::ChecksFailing, None),
+        );
+        mock.states.insert(
+            2,
+            make_state_with_mergeable(
+                make_pr(2),
+                PrTriageState::ChecksFailing,
+                Some("CONFLICTING"),
+            ),
+        );
+
+        let mut cfg = default_config();
+        cfg.triage_priority = TriagePriority::LeastConflicts;
+        let triage = PrTriage::new(cfg, mock);
+
+        if let TriageAction::FixChecks { pr, .. } = triage.select_action() {
+            assert_eq!(
+                pr.number, 2,
+                "CONFLICTING (key 2) should be selected before None (key 3)"
+            );
+        } else {
+            panic!("expected FixChecks action");
+        }
+    }
+
+    #[test]
+    fn mergeable_sort_key_values() {
+        assert_eq!(mergeable_sort_key(Some("MERGEABLE")), 0);
+        assert_eq!(mergeable_sort_key(Some("UNKNOWN")), 1);
+        assert_eq!(mergeable_sort_key(Some("CONFLICTING")), 2);
+        assert_eq!(mergeable_sort_key(None), 3);
+        assert_eq!(mergeable_sort_key(Some("something-else")), 3);
     }
 }

--- a/src/pr_manager.rs
+++ b/src/pr_manager.rs
@@ -73,7 +73,10 @@ pub fn detect_signal(output: &str, ready_marker: &str) -> Option<ReadySignal> {
     // Try sentinel form first (cheap scan).
     for line in output.lines() {
         if line.trim() == ready_marker {
-            return Some(ReadySignal { summary: None, form: SignalForm::Sentinel });
+            return Some(ReadySignal {
+                summary: None,
+                form: SignalForm::Sentinel,
+            });
         }
     }
 
@@ -83,7 +86,10 @@ pub fn detect_signal(output: &str, ready_marker: &str) -> Option<ReadySignal> {
         if trimmed.starts_with('{') {
             if let Ok(sig) = serde_json::from_str::<JsonSignal>(trimmed) {
                 if sig.looper == "ready-for-review" {
-                    return Some(ReadySignal { summary: sig.summary, form: SignalForm::Json });
+                    return Some(ReadySignal {
+                        summary: sig.summary,
+                        form: SignalForm::Json,
+                    });
                 }
             }
         }
@@ -230,8 +236,11 @@ impl PrLifecycle for GhPrLifecycle {
         ];
 
         // gh pr create accepts multiple --label flags.
-        let label_args: Vec<String> =
-            draft.labels.iter().flat_map(|l| ["--label".to_string(), l.clone()]).collect();
+        let label_args: Vec<String> = draft
+            .labels
+            .iter()
+            .flat_map(|l| ["--label".to_string(), l.clone()])
+            .collect();
         let label_strs: Vec<&str> = label_args.iter().map(String::as_str).collect();
         args.extend_from_slice(&label_strs);
 
@@ -254,9 +263,15 @@ impl PrLifecycle for GhPrLifecycle {
             .rsplit('/')
             .next()
             .and_then(|s| s.parse().ok())
-            .ok_or_else(|| PrError::ParseError(format!("cannot parse PR number from URL: {url}")))?;
+            .ok_or_else(|| {
+                PrError::ParseError(format!("cannot parse PR number from URL: {url}"))
+            })?;
 
-        Ok(PrInfo { number, url, title: draft.title.clone() })
+        Ok(PrInfo {
+            number,
+            url,
+            title: draft.title.clone(),
+        })
     }
 
     fn comment_on_pr(&self, pr_number: u32, body: &str) -> Result<(), PrError> {
@@ -268,7 +283,9 @@ impl PrLifecycle for GhPrLifecycle {
 
         if !out.status.success() {
             let stderr = String::from_utf8_lossy(&out.stderr);
-            return Err(PrError::GhCommand(format!("gh pr comment failed: {stderr}")));
+            return Err(PrError::GhCommand(format!(
+                "gh pr comment failed: {stderr}"
+            )));
         }
         Ok(())
     }
@@ -279,10 +296,19 @@ impl PrLifecycle for GhPrLifecycle {
 /// Recorded call to the mock lifecycle.
 #[cfg(test)]
 #[derive(Debug, Clone, PartialEq)]
+#[allow(clippy::enum_variant_names)]
 pub enum PrCall {
-    FindOpenPr { branch: String },
-    OpenPr { branch: String, base: String, title: String },
-    CommentOnPr { pr_number: u32 },
+    FindOpenPr {
+        branch: String,
+    },
+    OpenPr {
+        branch: String,
+        base: String,
+        title: String,
+    },
+    CommentOnPr {
+        pr_number: u32,
+    },
 }
 
 /// Test double for [`PrLifecycle`].
@@ -332,10 +358,9 @@ impl Default for MockPrLifecycle {
 #[cfg(test)]
 impl PrLifecycle for MockPrLifecycle {
     fn find_open_pr(&self, branch: &str) -> Result<Option<PrInfo>, PrError> {
-        self.calls
-            .lock()
-            .unwrap()
-            .push(PrCall::FindOpenPr { branch: branch.to_string() });
+        self.calls.lock().unwrap().push(PrCall::FindOpenPr {
+            branch: branch.to_string(),
+        });
         Ok(self.existing_pr.lock().unwrap().clone())
     }
 
@@ -350,7 +375,10 @@ impl PrLifecycle for MockPrLifecycle {
 
     fn comment_on_pr(&self, pr_number: u32, body: &str) -> Result<(), PrError> {
         let _ = body;
-        self.calls.lock().unwrap().push(PrCall::CommentOnPr { pr_number });
+        self.calls
+            .lock()
+            .unwrap()
+            .push(PrCall::CommentOnPr { pr_number });
         Ok(())
     }
 }
@@ -387,7 +415,11 @@ impl<L: PrLifecycle> PrManager<L> {
             .ready_marker
             .clone()
             .unwrap_or_else(|| "LOOPER_READY_FOR_REVIEW".to_string());
-        Self { config, lifecycle, ready_marker }
+        Self {
+            config,
+            lifecycle,
+            ready_marker,
+        }
     }
 
     /// Build a PR title from an issue number and title.
@@ -471,14 +503,19 @@ impl<L: PrLifecycle> PrManager<L> {
             Some(pr) => {
                 // Existing PR, human review not required — append a comment.
                 let comment = match signal.summary {
-                    Some(ref s) => format!(
-                        "**Code Looper update** — agent signalled ready-for-review.\n\n{s}"
-                    ),
-                    None => "**Code Looper update** — agent signalled ready-for-review.".to_string(),
+                    Some(ref s) => {
+                        format!("**Code Looper update** — agent signalled ready-for-review.\n\n{s}")
+                    }
+                    None => {
+                        "**Code Looper update** — agent signalled ready-for-review.".to_string()
+                    }
                 };
                 self.lifecycle.comment_on_pr(pr.number, &comment)?;
                 tracing::info!(pr_number = pr.number, "appended comment to existing PR");
-                Ok(PrAction::Updated { pr, comment_added: true })
+                Ok(PrAction::Updated {
+                    pr,
+                    comment_added: true,
+                })
             }
         }
     }
@@ -550,11 +587,7 @@ pub trait PrLifecycleTriage: Send + Sync {
     ///
     /// The implementation queries `gh pr view <number> --json` for check
     /// status, review decision, and labels.
-    fn get_pr_state(
-        &self,
-        pr_number: u32,
-        skip_labels: &[String],
-    ) -> Result<PrWithState, PrError>;
+    fn get_pr_state(&self, pr_number: u32, skip_labels: &[String]) -> Result<PrWithState, PrError>;
 }
 
 impl PrLifecycleTriage for GhPrLifecycle {
@@ -581,14 +614,15 @@ impl PrLifecycleTriage for GhPrLifecycle {
         }
 
         let stdout = String::from_utf8_lossy(&out.stdout);
-        let prs: Vec<serde_json::Value> = serde_json::from_str(&stdout)
-            .map_err(|e| PrError::ParseError(e.to_string()))?;
+        let prs: Vec<serde_json::Value> =
+            serde_json::from_str(&stdout).map_err(|e| PrError::ParseError(e.to_string()))?;
 
         prs.into_iter()
             .map(|v| {
                 let number = v["number"]
                     .as_u64()
-                    .ok_or_else(|| PrError::ParseError("missing number".into()))? as u32;
+                    .ok_or_else(|| PrError::ParseError("missing number".into()))?
+                    as u32;
                 let url = v["url"]
                     .as_str()
                     .ok_or_else(|| PrError::ParseError("missing url".into()))?
@@ -602,11 +636,7 @@ impl PrLifecycleTriage for GhPrLifecycle {
             .collect()
     }
 
-    fn get_pr_state(
-        &self,
-        pr_number: u32,
-        skip_labels: &[String],
-    ) -> Result<PrWithState, PrError> {
+    fn get_pr_state(&self, pr_number: u32, skip_labels: &[String]) -> Result<PrWithState, PrError> {
         let pr_ref = pr_number.to_string();
         let out = Command::new("gh")
             .args([
@@ -625,8 +655,8 @@ impl PrLifecycleTriage for GhPrLifecycle {
         }
 
         let stdout = String::from_utf8_lossy(&out.stdout);
-        let v: serde_json::Value = serde_json::from_str(&stdout)
-            .map_err(|e| PrError::ParseError(e.to_string()))?;
+        let v: serde_json::Value =
+            serde_json::from_str(&stdout).map_err(|e| PrError::ParseError(e.to_string()))?;
 
         let number = v["number"].as_u64().unwrap_or(pr_number as u64) as u32;
         let url = v["url"].as_str().unwrap_or("").to_string();
@@ -642,7 +672,9 @@ impl PrLifecycleTriage for GhPrLifecycle {
                     if skip_labels.iter().any(|s| s == name) {
                         return Ok(PrWithState {
                             pr,
-                            state: PrTriageState::Skipped { reason: name.to_string() },
+                            state: PrTriageState::Skipped {
+                                reason: name.to_string(),
+                            },
                             created_at,
                         });
                     }
@@ -655,7 +687,10 @@ impl PrLifecycleTriage for GhPrLifecycle {
             .as_array()
             .map(|checks| {
                 checks.iter().any(|c| {
-                    c["conclusion"].as_str().map(|s| s == "FAILURE").unwrap_or(false)
+                    c["conclusion"]
+                        .as_str()
+                        .map(|s| s == "FAILURE")
+                        .unwrap_or(false)
                 })
             })
             .unwrap_or(false);
@@ -677,7 +712,11 @@ impl PrLifecycleTriage for GhPrLifecycle {
             _ => PrTriageState::NeedsReview,
         };
 
-        Ok(PrWithState { pr, state, created_at })
+        Ok(PrWithState {
+            pr,
+            state,
+            created_at,
+        })
     }
 }
 
@@ -716,18 +755,20 @@ impl<L: PrLifecycleTriage> PrTriage<L> {
         }
 
         for pr_info in prs {
-            let with_state =
-                match self.lifecycle.get_pr_state(pr_info.number, &self.config.skip_labels) {
-                    Ok(ws) => ws,
-                    Err(e) => {
-                        tracing::warn!(
-                            pr = pr_info.number,
-                            error = %e,
-                            "PrTriage: failed to get state for PR; skipping"
-                        );
-                        continue;
-                    }
-                };
+            let with_state = match self
+                .lifecycle
+                .get_pr_state(pr_info.number, &self.config.skip_labels)
+            {
+                Ok(ws) => ws,
+                Err(e) => {
+                    tracing::warn!(
+                        pr = pr_info.number,
+                        error = %e,
+                        "PrTriage: failed to get state for PR; skipping"
+                    );
+                    continue;
+                }
+            };
 
             match with_state.state {
                 PrTriageState::Skipped { ref reason } => {
@@ -741,7 +782,10 @@ impl<L: PrLifecycleTriage> PrTriage<L> {
                          the loop engine will handle the merge when checks pass.",
                         with_state.pr.number, with_state.pr.title
                     );
-                    return TriageAction::FixChecks { pr: with_state.pr, prompt };
+                    return TriageAction::FixChecks {
+                        pr: with_state.pr,
+                        prompt,
+                    };
                 }
                 PrTriageState::ChangesRequested => {
                     let prompt = format!(
@@ -828,7 +872,9 @@ impl PrLifecycleTriage for MockPrLifecycleTriage {
         self.calls
             .lock()
             .unwrap()
-            .push(TriageCall::ListOpenPrsWithLabel { label: label.to_string() });
+            .push(TriageCall::ListOpenPrsWithLabel {
+                label: label.to_string(),
+            });
         Ok(self.open_prs.clone())
     }
 
@@ -953,12 +999,18 @@ mod tests {
         let mock = MockPrLifecycle::new();
         let mgr = manager_with_mock(mock);
         let output = "LOOPER_READY_FOR_REVIEW";
-        let action =
-            mgr.handle_milestone("loop/1-feat", 1, "My feature", output).unwrap();
+        let action = mgr
+            .handle_milestone("loop/1-feat", 1, "My feature", output)
+            .unwrap();
         assert!(matches!(action, PrAction::Opened(_)));
 
         let calls = mgr.lifecycle.calls.lock().unwrap();
-        assert_eq!(calls[0], PrCall::FindOpenPr { branch: "loop/1-feat".into() });
+        assert_eq!(
+            calls[0],
+            PrCall::FindOpenPr {
+                branch: "loop/1-feat".into()
+            }
+        );
         assert!(matches!(calls[1], PrCall::OpenPr { .. }));
     }
 
@@ -967,12 +1019,19 @@ mod tests {
         let mock = MockPrLifecycle::new();
         let mgr = manager_with_mock(mock);
         let output = "LOOPER_READY_FOR_REVIEW";
-        mgr.handle_milestone("loop/7-auth", 7, "Add auth", output).unwrap();
+        mgr.handle_milestone("loop/7-auth", 7, "Add auth", output)
+            .unwrap();
 
         let calls = mgr.lifecycle.calls.lock().unwrap();
         if let PrCall::OpenPr { title, .. } = &calls[1] {
-            assert!(title.contains("#7"), "title should reference issue: {title}");
-            assert!(title.contains("Add auth"), "title should include issue title: {title}");
+            assert!(
+                title.contains("#7"),
+                "title should reference issue: {title}"
+            );
+            assert!(
+                title.contains("Add auth"),
+                "title should include issue title: {title}"
+            );
         } else {
             panic!("expected OpenPr call");
         }
@@ -990,8 +1049,9 @@ mod tests {
         cfg.require_human_review = true;
         let mgr = PrManager::new(cfg, mock);
 
-        let action =
-            mgr.handle_milestone("loop/1-feat", 1, "feat", "LOOPER_READY_FOR_REVIEW").unwrap();
+        let action = mgr
+            .handle_milestone("loop/1-feat", 1, "feat", "LOOPER_READY_FOR_REVIEW")
+            .unwrap();
         assert!(matches!(action, PrAction::BlockedOnHumanReview(_)));
 
         // Should NOT have tried to open a new PR or add a comment.
@@ -1011,8 +1071,9 @@ mod tests {
         cfg.require_human_review = false;
         let mgr = PrManager::new(cfg, mock);
 
-        let action =
-            mgr.handle_milestone("loop/1-feat", 1, "feat", "LOOPER_READY_FOR_REVIEW").unwrap();
+        let action = mgr
+            .handle_milestone("loop/1-feat", 1, "feat", "LOOPER_READY_FOR_REVIEW")
+            .unwrap();
         assert!(matches!(action, PrAction::Updated { .. }));
 
         let calls = mgr.lifecycle.calls.lock().unwrap();
@@ -1022,13 +1083,19 @@ mod tests {
     #[test]
     fn pr_body_includes_closes_link() {
         let body = PrManager::<MockPrLifecycle>::pr_body(99, None);
-        assert!(body.contains("Closes #99"), "body should reference issue: {body}");
+        assert!(
+            body.contains("Closes #99"),
+            "body should reference issue: {body}"
+        );
     }
 
     #[test]
     fn pr_body_includes_agent_summary() {
         let body = PrManager::<MockPrLifecycle>::pr_body(5, Some("Auth complete"));
-        assert!(body.contains("Auth complete"), "body should include summary: {body}");
+        assert!(
+            body.contains("Auth complete"),
+            "body should include summary: {body}"
+        );
     }
 
     #[test]
@@ -1049,7 +1116,8 @@ mod tests {
         let mock = MockPrLifecycle::new();
         let mgr = manager_with_mock(mock);
         let output = r#"{"looper":"ready-for-review","summary":"Phase 1 done"}"#;
-        mgr.handle_milestone("loop/3-phase", 3, "Phase 1", output).unwrap();
+        mgr.handle_milestone("loop/3-phase", 3, "Phase 1", output)
+            .unwrap();
 
         let calls = mgr.lifecycle.calls.lock().unwrap();
         if let PrCall::OpenPr { title, .. } = &calls[1] {
@@ -1071,14 +1139,21 @@ mod tests {
     }
 
     fn make_state(pr: PrInfo, state: PrTriageState) -> PrWithState {
-        PrWithState { pr, state, created_at: "2026-01-01T00:00:00Z".into() }
+        PrWithState {
+            pr,
+            state,
+            created_at: "2026-01-01T00:00:00Z".into(),
+        }
     }
 
     #[test]
     fn triage_no_open_prs_returns_no_actionable() {
         let mock = MockPrLifecycleTriage::new();
         let triage = PrTriage::new(default_config(), mock);
-        assert!(matches!(triage.select_action(), TriageAction::NoActionablePr));
+        assert!(matches!(
+            triage.select_action(),
+            TriageAction::NoActionablePr
+        ));
     }
 
     #[test]
@@ -1086,9 +1161,20 @@ mod tests {
         let mut mock = MockPrLifecycleTriage::new();
         let pr = make_pr(1);
         mock.open_prs = vec![pr.clone()];
-        mock.states.insert(1, make_state(pr, PrTriageState::Skipped { reason: "wip".into() }));
+        mock.states.insert(
+            1,
+            make_state(
+                pr,
+                PrTriageState::Skipped {
+                    reason: "wip".into(),
+                },
+            ),
+        );
         let triage = PrTriage::new(default_config(), mock);
-        assert!(matches!(triage.select_action(), TriageAction::NoActionablePr));
+        assert!(matches!(
+            triage.select_action(),
+            TriageAction::NoActionablePr
+        ));
     }
 
     #[test]
@@ -1096,7 +1182,8 @@ mod tests {
         let mut mock = MockPrLifecycleTriage::new();
         let pr = make_pr(2);
         mock.open_prs = vec![pr.clone()];
-        mock.states.insert(2, make_state(pr, PrTriageState::ChecksFailing));
+        mock.states
+            .insert(2, make_state(pr, PrTriageState::ChecksFailing));
         let triage = PrTriage::new(default_config(), mock);
         let action = triage.select_action();
         assert!(matches!(action, TriageAction::FixChecks { .. }));
@@ -1111,7 +1198,8 @@ mod tests {
         let mut mock = MockPrLifecycleTriage::new();
         let pr = make_pr(3);
         mock.open_prs = vec![pr.clone()];
-        mock.states.insert(3, make_state(pr, PrTriageState::ChangesRequested));
+        mock.states
+            .insert(3, make_state(pr, PrTriageState::ChangesRequested));
         let triage = PrTriage::new(default_config(), mock);
         let action = triage.select_action();
         assert!(matches!(action, TriageAction::AddressReviewFeedback { .. }));
@@ -1126,11 +1214,15 @@ mod tests {
         let mut mock = MockPrLifecycleTriage::new();
         let pr = make_pr(4);
         mock.open_prs = vec![pr.clone()];
-        mock.states.insert(4, make_state(pr, PrTriageState::ReadyToMerge));
+        mock.states
+            .insert(4, make_state(pr, PrTriageState::ReadyToMerge));
         let mut cfg = default_config();
         cfg.require_human_review = true;
         let triage = PrTriage::new(cfg, mock);
-        assert!(matches!(triage.select_action(), TriageAction::BlockedOnHumanReview { .. }));
+        assert!(matches!(
+            triage.select_action(),
+            TriageAction::BlockedOnHumanReview { .. }
+        ));
     }
 
     #[test]
@@ -1138,7 +1230,8 @@ mod tests {
         let mut mock = MockPrLifecycleTriage::new();
         let pr = make_pr(5);
         mock.open_prs = vec![pr.clone()];
-        mock.states.insert(5, make_state(pr, PrTriageState::ReadyToMerge));
+        mock.states
+            .insert(5, make_state(pr, PrTriageState::ReadyToMerge));
         let mut cfg = default_config();
         cfg.require_human_review = false;
         let triage = PrTriage::new(cfg, mock);
@@ -1150,9 +1243,13 @@ mod tests {
         let mut mock = MockPrLifecycleTriage::new();
         let pr = make_pr(6);
         mock.open_prs = vec![pr.clone()];
-        mock.states.insert(6, make_state(pr, PrTriageState::NeedsReview));
+        mock.states
+            .insert(6, make_state(pr, PrTriageState::NeedsReview));
         let triage = PrTriage::new(default_config(), mock);
-        assert!(matches!(triage.select_action(), TriageAction::NoActionablePr));
+        assert!(matches!(
+            triage.select_action(),
+            TriageAction::NoActionablePr
+        ));
     }
 
     #[test]
@@ -1162,9 +1259,17 @@ mod tests {
         let pr2 = make_pr(11);
         mock.open_prs = vec![pr1.clone(), pr2.clone()];
         // First PR skipped, second has checks failing.
+        mock.states.insert(
+            10,
+            make_state(
+                pr1,
+                PrTriageState::Skipped {
+                    reason: "wip".into(),
+                },
+            ),
+        );
         mock.states
-            .insert(10, make_state(pr1, PrTriageState::Skipped { reason: "wip".into() }));
-        mock.states.insert(11, make_state(pr2, PrTriageState::ChecksFailing));
+            .insert(11, make_state(pr2, PrTriageState::ChecksFailing));
         let triage = PrTriage::new(default_config(), mock);
         let action = triage.select_action();
         if let TriageAction::FixChecks { pr, .. } = action {
@@ -1181,8 +1286,10 @@ mod tests {
         let pr1 = make_pr(20);
         let pr2 = make_pr(21);
         mock.open_prs = vec![pr1.clone(), pr2.clone()]; // oldest first
-        mock.states.insert(20, make_state(pr1, PrTriageState::ChecksFailing));
-        mock.states.insert(21, make_state(pr2, PrTriageState::ChecksFailing));
+        mock.states
+            .insert(20, make_state(pr1, PrTriageState::ChecksFailing));
+        mock.states
+            .insert(21, make_state(pr2, PrTriageState::ChecksFailing));
         let mut cfg = default_config();
         cfg.triage_priority = TriagePriority::Newest;
         let triage = PrTriage::new(cfg, mock);
@@ -1199,11 +1306,14 @@ mod tests {
         let mut mock = MockPrLifecycleTriage::new();
         let pr = make_pr(30);
         mock.open_prs = vec![pr.clone()];
-        mock.states.insert(30, make_state(pr, PrTriageState::NeedsReview));
+        mock.states
+            .insert(30, make_state(pr, PrTriageState::NeedsReview));
         let triage = PrTriage::new(default_config(), mock);
         triage.select_action();
         let calls = triage.lifecycle.calls.lock().unwrap();
-        assert!(calls.contains(&TriageCall::ListOpenPrsWithLabel { label: "code-looper".into() }));
+        assert!(calls.contains(&TriageCall::ListOpenPrsWithLabel {
+            label: "code-looper".into()
+        }));
         assert!(calls.contains(&TriageCall::GetPrState { pr_number: 30 }));
     }
 }

--- a/src/pr_manager.rs
+++ b/src/pr_manager.rs
@@ -1,0 +1,699 @@
+/// PR lifecycle management: shippable-signal detection, PR creation, and PR
+/// update for the `single-pr` and `multi-pr` strategies.
+///
+/// # Shippable signal protocol
+///
+/// The loop engine scans each provider iteration's stdout for a *shippable
+/// signal* — an explicit marker that the agent believes the current branch
+/// contains review-ready work.  Two forms are accepted (first match wins):
+///
+/// 1. **Sentinel line** — the output contains a line whose trimmed content
+///    equals the configured `ready_marker` string (default:
+///    `LOOPER_READY_FOR_REVIEW`).
+///
+/// 2. **JSON block** — the output contains a JSON object with a `"looper"`
+///    key set to `"ready-for-review"`.  An optional `"summary"` key provides
+///    a human-readable description that appears in the PR body:
+///    ```json
+///    {"looper":"ready-for-review","summary":"Implemented user auth"}
+///    ```
+///
+/// When a signal is detected the engine calls [`PrManager::handle_milestone`]
+/// which opens a new PR (if none exists for the branch) or appends a comment
+/// (if one already exists).  Human-review gating is enforced: when
+/// `require_human_review` is `true` (the default) the engine never merges the
+/// PR itself.
+///
+/// # MCP-only policy
+///
+/// All GitHub mutations (PR creation, PR comments) are performed through the
+/// `gh` CLI, which is the approved mutation path in the Code Looper policy
+/// guard layer.  Direct REST API calls without the CLI are not used.
+use std::process::Command;
+
+use serde::Deserialize;
+
+use crate::config::PrManagementConfig;
+
+// ── Signal detection ──────────────────────────────────────────────────────────
+
+/// The parsed shippable signal emitted by the agent.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReadySignal {
+    /// Optional human-readable summary extracted from a JSON signal block.
+    pub summary: Option<String>,
+    /// Which form of signal was detected.
+    pub form: SignalForm,
+}
+
+/// How the shippable signal was encoded in the agent output.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SignalForm {
+    /// Plain sentinel line (`LOOPER_READY_FOR_REVIEW`).
+    Sentinel,
+    /// Structured JSON block.
+    Json,
+}
+
+/// Internal JSON shape for the structured signal form.
+#[derive(Deserialize)]
+struct JsonSignal {
+    looper: String,
+    summary: Option<String>,
+}
+
+/// Scan `output` for a shippable signal.
+///
+/// Returns `Some(ReadySignal)` when found, `None` when the output does not
+/// contain any recognised signal form.
+///
+/// The `ready_marker` string is compared case-sensitively against each trimmed
+/// line.
+pub fn detect_signal(output: &str, ready_marker: &str) -> Option<ReadySignal> {
+    // Try sentinel form first (cheap scan).
+    for line in output.lines() {
+        if line.trim() == ready_marker {
+            return Some(ReadySignal { summary: None, form: SignalForm::Sentinel });
+        }
+    }
+
+    // Try JSON form: look for lines / blocks that parse as JsonSignal.
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('{') {
+            if let Ok(sig) = serde_json::from_str::<JsonSignal>(trimmed) {
+                if sig.looper == "ready-for-review" {
+                    return Some(ReadySignal { summary: sig.summary, form: SignalForm::Json });
+                }
+            }
+        }
+    }
+
+    None
+}
+
+// ── PR data types ─────────────────────────────────────────────────────────────
+
+/// Lightweight description of an open pull request.
+#[derive(Debug, Clone)]
+pub struct PrInfo {
+    pub number: u32,
+    pub url: String,
+    pub title: String,
+}
+
+/// Input for opening a new pull request.
+#[derive(Debug, Clone)]
+pub struct PrDraft {
+    /// Source branch (head).
+    pub branch: String,
+    /// Target branch (base).
+    pub base_branch: String,
+    /// PR title.
+    pub title: String,
+    /// PR body in Markdown.
+    pub body: String,
+    /// Labels to apply.
+    pub labels: Vec<String>,
+}
+
+// ── Error type ────────────────────────────────────────────────────────────────
+
+/// Errors produced by PR lifecycle operations.
+#[derive(Debug, thiserror::Error)]
+pub enum PrError {
+    #[error("gh CLI command failed: {0}")]
+    GhCommand(String),
+
+    #[error("failed to parse gh output: {0}")]
+    ParseError(String),
+
+    #[error("PR already exists for branch '{0}'")]
+    AlreadyExists(String),
+}
+
+// ── PrLifecycle trait ─────────────────────────────────────────────────────────
+
+/// Abstraction over PR CRUD operations.
+///
+/// The production implementation shells out to the `gh` CLI.  Tests inject a
+/// [`MockPrLifecycle`] to verify call patterns without network I/O.
+pub trait PrLifecycle: Send + Sync {
+    /// Find an open PR whose head branch matches `branch`.
+    ///
+    /// Returns `None` when no such PR exists.
+    fn find_open_pr(&self, branch: &str) -> Result<Option<PrInfo>, PrError>;
+
+    /// Open a new pull request described by `draft`.
+    fn open_pr(&self, draft: &PrDraft) -> Result<PrInfo, PrError>;
+
+    /// Append `body` as a comment on the pull request identified by
+    /// `pr_number`.
+    fn comment_on_pr(&self, pr_number: u32, body: &str) -> Result<(), PrError>;
+}
+
+// ── GhPrLifecycle (production) ────────────────────────────────────────────────
+
+/// Production [`PrLifecycle`] implementation backed by the `gh` CLI.
+pub struct GhPrLifecycle;
+
+impl GhPrLifecycle {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for GhPrLifecycle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PrLifecycle for GhPrLifecycle {
+    fn find_open_pr(&self, branch: &str) -> Result<Option<PrInfo>, PrError> {
+        let out = Command::new("gh")
+            .args([
+                "pr",
+                "list",
+                "--head",
+                branch,
+                "--state",
+                "open",
+                "--json",
+                "number,url,title",
+                "--limit",
+                "1",
+            ])
+            .output()
+            .map_err(|e| PrError::GhCommand(format!("failed to spawn gh: {e}")))?;
+
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            return Err(PrError::GhCommand(format!("gh pr list failed: {stderr}")));
+        }
+
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let prs: Vec<serde_json::Value> = serde_json::from_str(&stdout)
+            .map_err(|e| PrError::ParseError(format!("failed to parse gh pr list output: {e}")))?;
+
+        if let Some(pr) = prs.into_iter().next() {
+            let number = pr["number"].as_u64().ok_or_else(|| {
+                PrError::ParseError("missing 'number' field in gh pr list output".into())
+            })? as u32;
+            let url = pr["url"]
+                .as_str()
+                .ok_or_else(|| PrError::ParseError("missing 'url' field".into()))?
+                .to_string();
+            let title = pr["title"]
+                .as_str()
+                .ok_or_else(|| PrError::ParseError("missing 'title' field".into()))?
+                .to_string();
+            Ok(Some(PrInfo { number, url, title }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn open_pr(&self, draft: &PrDraft) -> Result<PrInfo, PrError> {
+        let mut args = vec![
+            "pr",
+            "create",
+            "--head",
+            draft.branch.as_str(),
+            "--base",
+            draft.base_branch.as_str(),
+            "--title",
+            draft.title.as_str(),
+            "--body",
+            draft.body.as_str(),
+        ];
+
+        // gh pr create accepts multiple --label flags.
+        let label_args: Vec<String> =
+            draft.labels.iter().flat_map(|l| ["--label".to_string(), l.clone()]).collect();
+        let label_strs: Vec<&str> = label_args.iter().map(String::as_str).collect();
+        args.extend_from_slice(&label_strs);
+
+        let out = Command::new("gh")
+            .args(&args)
+            .output()
+            .map_err(|e| PrError::GhCommand(format!("failed to spawn gh: {e}")))?;
+
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            return Err(PrError::GhCommand(format!("gh pr create failed: {stderr}")));
+        }
+
+        // `gh pr create` prints the PR URL to stdout.
+        let url = String::from_utf8_lossy(&out.stdout).trim().to_string();
+
+        // Retrieve the PR number from the URL (last path segment).
+        let number: u32 = url
+            .trim_end_matches('/')
+            .rsplit('/')
+            .next()
+            .and_then(|s| s.parse().ok())
+            .ok_or_else(|| PrError::ParseError(format!("cannot parse PR number from URL: {url}")))?;
+
+        Ok(PrInfo { number, url, title: draft.title.clone() })
+    }
+
+    fn comment_on_pr(&self, pr_number: u32, body: &str) -> Result<(), PrError> {
+        let pr_ref = pr_number.to_string();
+        let out = Command::new("gh")
+            .args(["pr", "comment", &pr_ref, "--body", body])
+            .output()
+            .map_err(|e| PrError::GhCommand(format!("failed to spawn gh: {e}")))?;
+
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            return Err(PrError::GhCommand(format!("gh pr comment failed: {stderr}")));
+        }
+        Ok(())
+    }
+}
+
+// ── MockPrLifecycle (test double) ─────────────────────────────────────────────
+
+/// Recorded call to the mock lifecycle.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PrCall {
+    FindOpenPr { branch: String },
+    OpenPr { branch: String, base: String, title: String },
+    CommentOnPr { pr_number: u32 },
+}
+
+/// Test double for [`PrLifecycle`].
+///
+/// Callers configure the scripted responses before injecting the mock, then
+/// assert on `calls` after exercising the code under test.
+pub struct MockPrLifecycle {
+    /// Pre-configured response for `find_open_pr`.  `None` means "no open PR".
+    pub existing_pr: std::sync::Mutex<Option<PrInfo>>,
+    /// Pre-configured response for `open_pr`.
+    pub opened_pr: PrInfo,
+    /// All calls made to the mock, in order.
+    pub calls: std::sync::Mutex<Vec<PrCall>>,
+}
+
+impl MockPrLifecycle {
+    /// Create a mock with no pre-existing PR.  `open_pr` returns a dummy PR
+    /// at number `42`.
+    pub fn new() -> Self {
+        Self {
+            existing_pr: std::sync::Mutex::new(None),
+            opened_pr: PrInfo {
+                number: 42,
+                url: "https://github.com/owner/repo/pull/42".into(),
+                title: "[LOOPER] Test PR".into(),
+            },
+            calls: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Configure the mock to report an existing open PR.
+    pub fn with_existing_pr(self, pr: PrInfo) -> Self {
+        *self.existing_pr.lock().unwrap() = Some(pr);
+        self
+    }
+}
+
+impl Default for MockPrLifecycle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PrLifecycle for MockPrLifecycle {
+    fn find_open_pr(&self, branch: &str) -> Result<Option<PrInfo>, PrError> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push(PrCall::FindOpenPr { branch: branch.to_string() });
+        Ok(self.existing_pr.lock().unwrap().clone())
+    }
+
+    fn open_pr(&self, draft: &PrDraft) -> Result<PrInfo, PrError> {
+        self.calls.lock().unwrap().push(PrCall::OpenPr {
+            branch: draft.branch.clone(),
+            base: draft.base_branch.clone(),
+            title: draft.title.clone(),
+        });
+        Ok(self.opened_pr.clone())
+    }
+
+    fn comment_on_pr(&self, pr_number: u32, body: &str) -> Result<(), PrError> {
+        let _ = body;
+        self.calls.lock().unwrap().push(PrCall::CommentOnPr { pr_number });
+        Ok(())
+    }
+}
+
+// ── PrManager ─────────────────────────────────────────────────────────────────
+
+/// Result of handling a shippable milestone.
+#[derive(Debug, Clone)]
+pub enum PrAction {
+    /// A new PR was opened.
+    Opened(PrInfo),
+    /// An existing PR was updated with a new comment.
+    Updated { pr: PrInfo, comment_added: bool },
+    /// The shippable signal was not present — no action taken.
+    NoSignal,
+    /// Signal detected but PR creation skipped because `require_human_review`
+    /// is `true` and a PR is already open (no further automated action).
+    BlockedOnHumanReview(PrInfo),
+}
+
+/// Orchestrates shippable-signal detection and PR lifecycle management.
+pub struct PrManager<L: PrLifecycle> {
+    config: PrManagementConfig,
+    lifecycle: L,
+    /// Sentinel string to look for in agent output (default:
+    /// `LOOPER_READY_FOR_REVIEW`).
+    ready_marker: String,
+}
+
+impl<L: PrLifecycle> PrManager<L> {
+    pub fn new(config: PrManagementConfig, lifecycle: L) -> Self {
+        let ready_marker = config
+            .ready_marker
+            .clone()
+            .unwrap_or_else(|| "LOOPER_READY_FOR_REVIEW".to_string());
+        Self { config, lifecycle, ready_marker }
+    }
+
+    /// Build a PR title from an issue number and title.
+    fn pr_title(issue_number: u64, issue_title: &str) -> String {
+        format!("[LOOPER] #{issue_number}: {issue_title}")
+    }
+
+    /// Build a PR body linking back to the originating issue and including an
+    /// optional agent-provided summary.
+    fn pr_body(issue_number: u64, run_summary: Option<&str>) -> String {
+        let mut body = format!(
+            "Closes #{issue_number}\n\n\
+             > This pull request was opened automatically by [Code Looper](https://github.com/jamesbrayton/code-looper).\n"
+        );
+        if let Some(summary) = run_summary {
+            body.push_str(&format!("\n## Agent summary\n\n{summary}\n"));
+        }
+        body
+    }
+
+    /// Standard labels applied to every auto-opened PR.
+    fn default_labels() -> Vec<String> {
+        vec!["code-looper".to_string(), "needs-review".to_string()]
+    }
+
+    /// Inspect `agent_output` for a shippable signal and act accordingly.
+    ///
+    /// - If no signal: returns `PrAction::NoSignal`.
+    /// - If signal and no open PR: opens a new PR.
+    /// - If signal and an open PR exists:
+    ///   - When `require_human_review` is `true`: returns
+    ///     `PrAction::BlockedOnHumanReview`.
+    ///   - Otherwise: adds a comment to the existing PR.
+    pub fn handle_milestone(
+        &self,
+        branch: &str,
+        issue_number: u64,
+        issue_title: &str,
+        agent_output: &str,
+    ) -> Result<PrAction, PrError> {
+        let signal = detect_signal(agent_output, &self.ready_marker);
+        if signal.is_none() {
+            return Ok(PrAction::NoSignal);
+        }
+        let signal = signal.unwrap();
+
+        tracing::info!(
+            branch,
+            issue_number,
+            form = ?signal.form,
+            "shippable signal detected; checking for existing PR"
+        );
+
+        let existing = self.lifecycle.find_open_pr(branch)?;
+
+        match existing {
+            None => {
+                // Open a fresh PR.
+                let draft = PrDraft {
+                    branch: branch.to_string(),
+                    base_branch: self.config.base_branch.clone(),
+                    title: Self::pr_title(issue_number, issue_title),
+                    body: Self::pr_body(issue_number, signal.summary.as_deref()),
+                    labels: Self::default_labels(),
+                };
+                let pr = self.lifecycle.open_pr(&draft)?;
+                tracing::info!(
+                    pr_number = pr.number,
+                    url = %pr.url,
+                    "opened PR for branch"
+                );
+                Ok(PrAction::Opened(pr))
+            }
+            Some(pr) if self.config.require_human_review => {
+                tracing::info!(
+                    pr_number = pr.number,
+                    "PR already open; require_human_review=true — no automated action"
+                );
+                Ok(PrAction::BlockedOnHumanReview(pr))
+            }
+            Some(pr) => {
+                // Existing PR, human review not required — append a comment.
+                let comment = match signal.summary {
+                    Some(ref s) => format!(
+                        "**Code Looper update** — agent signalled ready-for-review.\n\n{s}"
+                    ),
+                    None => "**Code Looper update** — agent signalled ready-for-review.".to_string(),
+                };
+                self.lifecycle.comment_on_pr(pr.number, &comment)?;
+                tracing::info!(pr_number = pr.number, "appended comment to existing PR");
+                Ok(PrAction::Updated { pr, comment_added: true })
+            }
+        }
+    }
+}
+
+// ── Convenience constructor for production use ────────────────────────────────
+
+/// Build a production [`PrManager`] backed by the `gh` CLI.
+pub fn build_pr_manager(config: PrManagementConfig) -> PrManager<GhPrLifecycle> {
+    PrManager::new(config, GhPrLifecycle::new())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::PrManagementConfig;
+
+    const DEFAULT_MARKER: &str = "LOOPER_READY_FOR_REVIEW";
+
+    fn default_config() -> PrManagementConfig {
+        PrManagementConfig::default()
+    }
+
+    // ── detect_signal ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn detects_sentinel_line() {
+        let output = "Some output\nLOOPER_READY_FOR_REVIEW\nMore output";
+        let sig = detect_signal(output, DEFAULT_MARKER).unwrap();
+        assert_eq!(sig.form, SignalForm::Sentinel);
+        assert!(sig.summary.is_none());
+    }
+
+    #[test]
+    fn sentinel_line_trimmed() {
+        let output = "  LOOPER_READY_FOR_REVIEW  ";
+        let sig = detect_signal(output, DEFAULT_MARKER).unwrap();
+        assert_eq!(sig.form, SignalForm::Sentinel);
+    }
+
+    #[test]
+    fn sentinel_partial_match_not_detected() {
+        let output = "PREFIX_LOOPER_READY_FOR_REVIEW";
+        assert!(detect_signal(output, DEFAULT_MARKER).is_none());
+    }
+
+    #[test]
+    fn detects_json_signal_without_summary() {
+        let output = r#"{"looper":"ready-for-review"}"#;
+        let sig = detect_signal(output, DEFAULT_MARKER).unwrap();
+        assert_eq!(sig.form, SignalForm::Json);
+        assert!(sig.summary.is_none());
+    }
+
+    #[test]
+    fn detects_json_signal_with_summary() {
+        let output = r#"{"looper":"ready-for-review","summary":"Auth module complete"}"#;
+        let sig = detect_signal(output, DEFAULT_MARKER).unwrap();
+        assert_eq!(sig.form, SignalForm::Json);
+        assert_eq!(sig.summary.as_deref(), Some("Auth module complete"));
+    }
+
+    #[test]
+    fn json_wrong_looper_value_not_detected() {
+        let output = r#"{"looper":"something-else"}"#;
+        assert!(detect_signal(output, DEFAULT_MARKER).is_none());
+    }
+
+    #[test]
+    fn no_signal_in_empty_output() {
+        assert!(detect_signal("", DEFAULT_MARKER).is_none());
+    }
+
+    #[test]
+    fn no_signal_in_ordinary_output() {
+        let output = "All tests passed.\nBuild succeeded.";
+        assert!(detect_signal(output, DEFAULT_MARKER).is_none());
+    }
+
+    #[test]
+    fn custom_ready_marker_detected() {
+        let output = "CUSTOM_SHIP_IT";
+        let sig = detect_signal(output, "CUSTOM_SHIP_IT").unwrap();
+        assert_eq!(sig.form, SignalForm::Sentinel);
+    }
+
+    #[test]
+    fn sentinel_preferred_over_json_when_both_present() {
+        // Sentinel scan runs first; if the sentinel is found the JSON block is
+        // never reached.
+        let output = "LOOPER_READY_FOR_REVIEW\n{\"looper\":\"ready-for-review\",\"summary\":\"s\"}";
+        let sig = detect_signal(output, DEFAULT_MARKER).unwrap();
+        assert_eq!(sig.form, SignalForm::Sentinel);
+    }
+
+    // ── PrManager ─────────────────────────────────────────────────────────────
+
+    fn manager_with_mock(mock: MockPrLifecycle) -> PrManager<MockPrLifecycle> {
+        PrManager::new(default_config(), mock)
+    }
+
+    #[test]
+    fn no_signal_returns_no_action() {
+        let mgr = manager_with_mock(MockPrLifecycle::new());
+        let action = mgr
+            .handle_milestone("loop/1-branch", 1, "My feature", "ordinary output")
+            .unwrap();
+        assert!(matches!(action, PrAction::NoSignal));
+        assert!(mgr.lifecycle.calls.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn signal_opens_pr_when_none_exists() {
+        let mock = MockPrLifecycle::new();
+        let mgr = manager_with_mock(mock);
+        let output = "LOOPER_READY_FOR_REVIEW";
+        let action =
+            mgr.handle_milestone("loop/1-feat", 1, "My feature", output).unwrap();
+        assert!(matches!(action, PrAction::Opened(_)));
+
+        let calls = mgr.lifecycle.calls.lock().unwrap();
+        assert_eq!(calls[0], PrCall::FindOpenPr { branch: "loop/1-feat".into() });
+        assert!(matches!(calls[1], PrCall::OpenPr { .. }));
+    }
+
+    #[test]
+    fn opened_pr_title_references_issue() {
+        let mock = MockPrLifecycle::new();
+        let mgr = manager_with_mock(mock);
+        let output = "LOOPER_READY_FOR_REVIEW";
+        mgr.handle_milestone("loop/7-auth", 7, "Add auth", output).unwrap();
+
+        let calls = mgr.lifecycle.calls.lock().unwrap();
+        if let PrCall::OpenPr { title, .. } = &calls[1] {
+            assert!(title.contains("#7"), "title should reference issue: {title}");
+            assert!(title.contains("Add auth"), "title should include issue title: {title}");
+        } else {
+            panic!("expected OpenPr call");
+        }
+    }
+
+    #[test]
+    fn signal_blocked_on_human_review_when_pr_exists() {
+        let existing = PrInfo {
+            number: 10,
+            url: "https://github.com/o/r/pull/10".into(),
+            title: "[LOOPER] #1: feat".into(),
+        };
+        let mock = MockPrLifecycle::new().with_existing_pr(existing);
+        let mut cfg = default_config();
+        cfg.require_human_review = true;
+        let mgr = PrManager::new(cfg, mock);
+
+        let action =
+            mgr.handle_milestone("loop/1-feat", 1, "feat", "LOOPER_READY_FOR_REVIEW").unwrap();
+        assert!(matches!(action, PrAction::BlockedOnHumanReview(_)));
+
+        // Should NOT have tried to open a new PR or add a comment.
+        let calls = mgr.lifecycle.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1, "only find_open_pr should be called");
+    }
+
+    #[test]
+    fn signal_comments_on_existing_pr_when_review_not_required() {
+        let existing = PrInfo {
+            number: 10,
+            url: "https://github.com/o/r/pull/10".into(),
+            title: "[LOOPER] #1: feat".into(),
+        };
+        let mock = MockPrLifecycle::new().with_existing_pr(existing);
+        let mut cfg = default_config();
+        cfg.require_human_review = false;
+        let mgr = PrManager::new(cfg, mock);
+
+        let action =
+            mgr.handle_milestone("loop/1-feat", 1, "feat", "LOOPER_READY_FOR_REVIEW").unwrap();
+        assert!(matches!(action, PrAction::Updated { .. }));
+
+        let calls = mgr.lifecycle.calls.lock().unwrap();
+        assert!(matches!(calls[1], PrCall::CommentOnPr { pr_number: 10 }));
+    }
+
+    #[test]
+    fn pr_body_includes_closes_link() {
+        let body = PrManager::<MockPrLifecycle>::pr_body(99, None);
+        assert!(body.contains("Closes #99"), "body should reference issue: {body}");
+    }
+
+    #[test]
+    fn pr_body_includes_agent_summary() {
+        let body = PrManager::<MockPrLifecycle>::pr_body(5, Some("Auth complete"));
+        assert!(body.contains("Auth complete"), "body should include summary: {body}");
+    }
+
+    #[test]
+    fn pr_title_format() {
+        let title = PrManager::<MockPrLifecycle>::pr_title(42, "Add caching");
+        assert_eq!(title, "[LOOPER] #42: Add caching");
+    }
+
+    #[test]
+    fn default_labels_contains_code_looper_and_needs_review() {
+        let labels = PrManager::<MockPrLifecycle>::default_labels();
+        assert!(labels.contains(&"code-looper".to_string()));
+        assert!(labels.contains(&"needs-review".to_string()));
+    }
+
+    #[test]
+    fn json_summary_included_in_pr_body() {
+        let mock = MockPrLifecycle::new();
+        let mgr = manager_with_mock(mock);
+        let output = r#"{"looper":"ready-for-review","summary":"Phase 1 done"}"#;
+        mgr.handle_milestone("loop/3-phase", 3, "Phase 1", output).unwrap();
+
+        let calls = mgr.lifecycle.calls.lock().unwrap();
+        if let PrCall::OpenPr { title, .. } = &calls[1] {
+            // Title comes from issue, not JSON summary
+            assert!(title.contains("#3"));
+        } else {
+            panic!("expected OpenPr call, got: {calls:?}");
+        }
+    }
+}

--- a/src/pr_manager.rs
+++ b/src/pr_manager.rs
@@ -24,11 +24,16 @@
 /// `require_human_review` is `true` (the default) the engine never merges the
 /// PR itself.
 ///
-/// # MCP-only policy
+/// # MCP-only policy and engine `gh` usage
 ///
-/// All GitHub mutations (PR creation, PR comments) are performed through the
-/// `gh` CLI, which is the approved mutation path in the Code Looper policy
-/// guard layer.  Direct REST API calls without the CLI are not used.
+/// Per the revised ADR-001, the MCP-only GitHub mutation policy is scoped to
+/// **agent prompts** — the `PolicyGuard` preamble instructs providers to use
+/// MCP server tools for any GitHub writes.  The **engine** (this module and
+/// [`crate::issue_tracker`]) is explicitly permitted to shell out to the `gh`
+/// CLI for its own PR and issue bookkeeping: engine actions are already
+/// audited through the structured logs, per-run manifest, and session
+/// summary.  See `docs/ADRs/ADR-001-mcp-only-github-mutations.md` for the
+/// full rationale and the list of non-goals this decision implies.
 use std::process::Command;
 
 use serde::Deserialize;

--- a/src/pr_manager.rs
+++ b/src/pr_manager.rs
@@ -106,6 +106,8 @@ pub struct PrInfo {
     pub number: u32,
     pub url: String,
     pub title: String,
+    /// Head branch name (e.g. `loop/42-fix-bug`).  Empty string when unknown.
+    pub head_ref: String,
 }
 
 /// Input for opening a new pull request.
@@ -187,7 +189,7 @@ impl PrLifecycle for GhPrLifecycle {
                 "--state",
                 "open",
                 "--json",
-                "number,url,title",
+                "number,url,title,headRefName",
                 "--limit",
                 "1",
             ])
@@ -215,7 +217,13 @@ impl PrLifecycle for GhPrLifecycle {
                 .as_str()
                 .ok_or_else(|| PrError::ParseError("missing 'title' field".into()))?
                 .to_string();
-            Ok(Some(PrInfo { number, url, title }))
+            let head_ref = pr["headRefName"].as_str().unwrap_or(branch).to_string();
+            Ok(Some(PrInfo {
+                number,
+                url,
+                title,
+                head_ref,
+            }))
         } else {
             Ok(None)
         }
@@ -271,6 +279,7 @@ impl PrLifecycle for GhPrLifecycle {
             number,
             url,
             title: draft.title.clone(),
+            head_ref: draft.branch.clone(),
         })
     }
 
@@ -336,6 +345,7 @@ impl MockPrLifecycle {
                 number: 42,
                 url: "https://github.com/owner/repo/pull/42".into(),
                 title: "[LOOPER] Test PR".into(),
+                head_ref: "loop/42-test-pr".into(),
             },
             calls: std::sync::Mutex::new(Vec::new()),
         }
@@ -601,7 +611,7 @@ impl PrLifecycleTriage for GhPrLifecycle {
                 "--state",
                 "open",
                 "--json",
-                "number,url,title",
+                "number,url,title,headRefName",
                 "--limit",
                 "100",
             ])
@@ -631,7 +641,13 @@ impl PrLifecycleTriage for GhPrLifecycle {
                     .as_str()
                     .ok_or_else(|| PrError::ParseError("missing title".into()))?
                     .to_string();
-                Ok(PrInfo { number, url, title })
+                let head_ref = v["headRefName"].as_str().unwrap_or("").to_string();
+                Ok(PrInfo {
+                    number,
+                    url,
+                    title,
+                    head_ref,
+                })
             })
             .collect()
     }
@@ -644,7 +660,7 @@ impl PrLifecycleTriage for GhPrLifecycle {
                 "view",
                 &pr_ref,
                 "--json",
-                "number,url,title,labels,statusCheckRollup,reviewDecision,createdAt",
+                "number,url,title,headRefName,labels,statusCheckRollup,reviewDecision,createdAt",
             ])
             .output()
             .map_err(|e| PrError::GhCommand(format!("failed to spawn gh: {e}")))?;
@@ -661,9 +677,15 @@ impl PrLifecycleTriage for GhPrLifecycle {
         let number = v["number"].as_u64().unwrap_or(pr_number as u64) as u32;
         let url = v["url"].as_str().unwrap_or("").to_string();
         let title = v["title"].as_str().unwrap_or("").to_string();
+        let head_ref = v["headRefName"].as_str().unwrap_or("").to_string();
         let created_at = v["createdAt"].as_str().unwrap_or("").to_string();
 
-        let pr = PrInfo { number, url, title };
+        let pr = PrInfo {
+            number,
+            url,
+            title,
+            head_ref,
+        };
 
         // Check skip labels.
         if let Some(labels) = v["labels"].as_array() {
@@ -1043,6 +1065,7 @@ mod tests {
             number: 10,
             url: "https://github.com/o/r/pull/10".into(),
             title: "[LOOPER] #1: feat".into(),
+            head_ref: "loop/1-feat".into(),
         };
         let mock = MockPrLifecycle::new().with_existing_pr(existing);
         let mut cfg = default_config();
@@ -1065,6 +1088,7 @@ mod tests {
             number: 10,
             url: "https://github.com/o/r/pull/10".into(),
             title: "[LOOPER] #1: feat".into(),
+            head_ref: "loop/1-feat".into(),
         };
         let mock = MockPrLifecycle::new().with_existing_pr(existing);
         let mut cfg = default_config();
@@ -1135,6 +1159,7 @@ mod tests {
             number,
             url: format!("https://github.com/o/r/pull/{number}"),
             title: format!("PR {number}"),
+            head_ref: format!("loop/{number}-pr"),
         }
     }
 
@@ -1315,5 +1340,33 @@ mod tests {
             label: "code-looper".into()
         }));
         assert!(calls.contains(&TriageCall::GetPrState { pr_number: 30 }));
+    }
+
+    // ── PrInfo::head_ref ──────────────────────────────────────────────────────
+
+    #[test]
+    fn pr_info_head_ref_is_set_by_make_pr_helper() {
+        let pr = make_pr(5);
+        assert_eq!(pr.head_ref, "loop/5-pr");
+    }
+
+    #[test]
+    fn merge_triage_action_carries_head_ref() {
+        let mut mock = MockPrLifecycleTriage::new();
+        let pr = make_pr(99);
+        mock.open_prs = vec![pr.clone()];
+        mock.states
+            .insert(99, make_state(pr, PrTriageState::ReadyToMerge));
+        let mut cfg = default_config();
+        cfg.require_human_review = false;
+        let triage = PrTriage::new(cfg, mock);
+        if let TriageAction::Merge { pr } = triage.select_action() {
+            assert_eq!(
+                pr.head_ref, "loop/99-pr",
+                "Merge action must preserve head_ref for post-merge cleanup"
+            );
+        } else {
+            panic!("expected TriageAction::Merge");
+        }
     }
 }

--- a/src/pr_manager.rs
+++ b/src/pr_manager.rs
@@ -129,6 +129,7 @@ pub enum PrError {
     ParseError(String),
 
     #[error("PR already exists for branch '{0}'")]
+    #[allow(dead_code)]
     AlreadyExists(String),
 }
 
@@ -276,6 +277,7 @@ impl PrLifecycle for GhPrLifecycle {
 // ── MockPrLifecycle (test double) ─────────────────────────────────────────────
 
 /// Recorded call to the mock lifecycle.
+#[cfg(test)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum PrCall {
     FindOpenPr { branch: String },
@@ -287,6 +289,7 @@ pub enum PrCall {
 ///
 /// Callers configure the scripted responses before injecting the mock, then
 /// assert on `calls` after exercising the code under test.
+#[cfg(test)]
 pub struct MockPrLifecycle {
     /// Pre-configured response for `find_open_pr`.  `None` means "no open PR".
     pub existing_pr: std::sync::Mutex<Option<PrInfo>>,
@@ -296,6 +299,7 @@ pub struct MockPrLifecycle {
     pub calls: std::sync::Mutex<Vec<PrCall>>,
 }
 
+#[cfg(test)]
 impl MockPrLifecycle {
     /// Create a mock with no pre-existing PR.  `open_pr` returns a dummy PR
     /// at number `42`.
@@ -318,12 +322,14 @@ impl MockPrLifecycle {
     }
 }
 
+#[cfg(test)]
 impl Default for MockPrLifecycle {
     fn default() -> Self {
         Self::new()
     }
 }
 
+#[cfg(test)]
 impl PrLifecycle for MockPrLifecycle {
     fn find_open_pr(&self, branch: &str) -> Result<Option<PrInfo>, PrError> {
         self.calls
@@ -353,6 +359,7 @@ impl PrLifecycle for MockPrLifecycle {
 
 /// Result of handling a shippable milestone.
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub enum PrAction {
     /// A new PR was opened.
     Opened(PrInfo),
@@ -503,6 +510,7 @@ pub enum PrTriageState {
 
 /// An open PR with its resolved triage state.
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct PrWithState {
     pub pr: PrInfo,
     pub state: PrTriageState,
@@ -779,6 +787,7 @@ pub fn build_pr_triage(config: PrManagementConfig) -> PrTriage<GhPrLifecycle> {
 // ── MockPrLifecycleTriage (test double) ───────────────────────────────────────
 
 /// Pre-scripted responses for [`PrLifecycleTriage`] in tests.
+#[cfg(test)]
 pub struct MockPrLifecycleTriage {
     /// PRs returned by `list_open_prs_with_label`.
     pub open_prs: Vec<PrInfo>,
@@ -788,12 +797,14 @@ pub struct MockPrLifecycleTriage {
     pub calls: std::sync::Mutex<Vec<TriageCall>>,
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum TriageCall {
     ListOpenPrsWithLabel { label: String },
     GetPrState { pr_number: u32 },
 }
 
+#[cfg(test)]
 impl MockPrLifecycleTriage {
     pub fn new() -> Self {
         Self {
@@ -804,12 +815,14 @@ impl MockPrLifecycleTriage {
     }
 }
 
+#[cfg(test)]
 impl Default for MockPrLifecycleTriage {
     fn default() -> Self {
         Self::new()
     }
 }
 
+#[cfg(test)]
 impl PrLifecycleTriage for MockPrLifecycleTriage {
     fn list_open_prs_with_label(&self, label: &str) -> Result<Vec<PrInfo>, PrError> {
         self.calls

--- a/src/pr_manager.rs
+++ b/src/pr_manager.rs
@@ -111,8 +111,13 @@ pub struct PrInfo {
     pub number: u32,
     pub url: String,
     pub title: String,
-    /// Head branch name (e.g. `loop/42-fix-bug`).  Empty string when unknown.
-    pub head_ref: String,
+    /// Head branch name (e.g. `loop/42-fix-bug`).
+    ///
+    /// `None` when `gh` did not return a `headRefName` field for this PR —
+    /// post-merge remote cleanup and any other head-branch-dependent logic
+    /// must skip the PR in that case.  See #74 for the history of this
+    /// field (it used to be an empty-string sentinel).
+    pub head_ref: Option<String>,
 }
 
 /// Input for opening a new pull request.
@@ -140,10 +145,6 @@ pub enum PrError {
 
     #[error("failed to parse gh output: {0}")]
     ParseError(String),
-
-    #[error("PR already exists for branch '{0}'")]
-    #[allow(dead_code)]
-    AlreadyExists(String),
 }
 
 // ── PrLifecycle trait ─────────────────────────────────────────────────────────
@@ -222,12 +223,20 @@ impl PrLifecycle for GhPrLifecycle {
                 .as_str()
                 .ok_or_else(|| PrError::ParseError("missing 'title' field".into()))?
                 .to_string();
-            let head_ref = pr["headRefName"].as_str().unwrap_or(branch).to_string();
+            // Fail loud on a missing `headRefName` rather than silently
+            // falling back to the requested branch name — the latter masks
+            // a `gh` schema drift as a successful lookup (see #74).
+            let head_ref = pr["headRefName"]
+                .as_str()
+                .map(|s| s.to_string())
+                .ok_or_else(|| {
+                    PrError::ParseError("missing 'headRefName' field in gh pr list output".into())
+                })?;
             Ok(Some(PrInfo {
                 number,
                 url,
                 title,
-                head_ref,
+                head_ref: Some(head_ref),
             }))
         } else {
             Ok(None)
@@ -284,7 +293,7 @@ impl PrLifecycle for GhPrLifecycle {
             number,
             url,
             title: draft.title.clone(),
-            head_ref: draft.branch.clone(),
+            head_ref: Some(draft.branch.clone()),
         })
     }
 
@@ -350,7 +359,7 @@ impl MockPrLifecycle {
                 number: 42,
                 url: "https://github.com/owner/repo/pull/42".into(),
                 title: "[LOOPER] Test PR".into(),
-                head_ref: "loop/42-test-pr".into(),
+                head_ref: Some("loop/42-test-pr".into()),
             },
             calls: std::sync::Mutex::new(Vec::new()),
         }
@@ -568,9 +577,62 @@ pub struct PrWithState {
     pub state: PrTriageState,
     /// ISO-8601 creation timestamp (used for `oldest`/`newest` ordering).
     pub created_at: String,
-    /// GitHub merge-ability state: `"MERGEABLE"`, `"CONFLICTING"`, or `"UNKNOWN"`.
-    /// `None` when the field was not returned by the API (older `gh` versions).
-    pub mergeable: Option<String>,
+    /// GitHub merge-ability state.
+    ///
+    /// `None` when the field was not returned by the API (older `gh`
+    /// versions) *or* when `gh` reported a string value we don't recognise.
+    /// Unknown-string parsing logs a warning at the parse site so we notice
+    /// GitHub schema drift — see [`Mergeable::from_gh_str`] and #77.
+    pub mergeable: Option<Mergeable>,
+}
+
+/// GitHub merge-ability state, parsed from the `mergeable` field returned by
+/// `gh pr view --json mergeable`.
+///
+/// The field is documented to take one of three values, but a stringly-typed
+/// `Option<String>` used to silently degrade on unknown values in
+/// `mergeable_sort_key` (see #77) — `BLOCKED` or a typo would map to the
+/// "missing" bucket and silently change the `least-conflicts` triage order.
+/// Parsing at the `gh` boundary centralises the value set and lets us log a
+/// warning when something unexpected comes back.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(clippy::enum_variant_names)]
+pub enum Mergeable {
+    Mergeable,
+    Unknown,
+    Conflicting,
+}
+
+impl Mergeable {
+    /// Parse a raw `gh` mergeable string, returning `None` for values we
+    /// do not recognise (and logging a warning at `warn!` level so schema
+    /// drift is visible to operators).
+    pub fn from_gh_str(s: &str) -> Option<Self> {
+        match s {
+            "MERGEABLE" => Some(Mergeable::Mergeable),
+            "UNKNOWN" => Some(Mergeable::Unknown),
+            "CONFLICTING" => Some(Mergeable::Conflicting),
+            other => {
+                tracing::warn!(
+                    value = other,
+                    "gh pr view returned unrecognised `mergeable` value; \
+                     treating as missing. This may silently change \
+                     least-conflicts triage order if it becomes common."
+                );
+                None
+            }
+        }
+    }
+
+    /// Sort key for the `LeastConflicts` triage priority: lower sorts first.
+    fn sort_key(m: Option<Self>) -> u8 {
+        match m {
+            Some(Mergeable::Mergeable) => 0,
+            Some(Mergeable::Unknown) => 1,
+            Some(Mergeable::Conflicting) => 2,
+            None => 3,
+        }
+    }
 }
 
 /// Outcome of a `PrTriage::select_action` call.
@@ -649,12 +711,15 @@ impl PrLifecycleTriage for GhPrLifecycle {
                     .as_str()
                     .ok_or_else(|| PrError::ParseError("missing title".into()))?
                     .to_string();
-                let head_ref = v["headRefName"].as_str().unwrap_or("").to_string();
+                let head_ref = v["headRefName"]
+                    .as_str()
+                    .map(|s| s.to_string())
+                    .ok_or_else(|| PrError::ParseError("missing 'headRefName' field".into()))?;
                 Ok(PrInfo {
                     number,
                     url,
                     title,
-                    head_ref,
+                    head_ref: Some(head_ref),
                 })
             })
             .collect()
@@ -682,18 +747,34 @@ impl PrLifecycleTriage for GhPrLifecycle {
         let v: serde_json::Value =
             serde_json::from_str(&stdout).map_err(|e| PrError::ParseError(e.to_string()))?;
 
-        let number = v["number"].as_u64().unwrap_or(pr_number as u64) as u32;
-        let url = v["url"].as_str().unwrap_or("").to_string();
-        let title = v["title"].as_str().unwrap_or("").to_string();
-        let head_ref = v["headRefName"].as_str().unwrap_or("").to_string();
+        // Fail loud on missing required fields rather than substituting
+        // empty-string sentinels (#74).  `created_at` and `mergeable` are
+        // allowed to be missing because downstream consumers already
+        // tolerate `None` for them.
+        let number = v["number"]
+            .as_u64()
+            .ok_or_else(|| PrError::ParseError("missing 'number' field".into()))?
+            as u32;
+        let url = v["url"]
+            .as_str()
+            .ok_or_else(|| PrError::ParseError("missing 'url' field".into()))?
+            .to_string();
+        let title = v["title"]
+            .as_str()
+            .ok_or_else(|| PrError::ParseError("missing 'title' field".into()))?
+            .to_string();
+        let head_ref = v["headRefName"]
+            .as_str()
+            .map(|s| s.to_string())
+            .ok_or_else(|| PrError::ParseError("missing 'headRefName' field".into()))?;
         let created_at = v["createdAt"].as_str().unwrap_or("").to_string();
-        let mergeable = v["mergeable"].as_str().map(|s| s.to_string());
+        let mergeable = v["mergeable"].as_str().and_then(Mergeable::from_gh_str);
 
         let pr = PrInfo {
             number,
             url,
             title,
-            head_ref,
+            head_ref: Some(head_ref),
         };
 
         // Check skip labels.
@@ -707,7 +788,7 @@ impl PrLifecycleTriage for GhPrLifecycle {
                                 reason: name.to_string(),
                             },
                             created_at,
-                            mergeable: mergeable.clone(),
+                            mergeable,
                         });
                     }
                 }
@@ -898,7 +979,7 @@ impl<L: PrLifecycleTriage> PrTriage<L> {
             .collect();
 
         // Sort: MERGEABLE (0) < UNKNOWN (1) < CONFLICTING (2) < missing (3).
-        states.sort_by_key(|ws| mergeable_sort_key(ws.mergeable.as_deref()));
+        states.sort_by_key(|ws| Mergeable::sort_key(ws.mergeable));
 
         tracing::debug!(
             count = states.len(),
@@ -921,22 +1002,8 @@ pub fn build_pr_triage(config: PrManagementConfig) -> PrTriage<GhPrLifecycle> {
     PrTriage::new(config, GhPrLifecycle::new())
 }
 
-/// Numeric sort key for the `LeastConflicts` priority.
-///
-/// | GitHub value   | key |
-/// |----------------|-----|
-/// | `"MERGEABLE"`  | 0   |
-/// | `"UNKNOWN"`    | 1   |
-/// | `"CONFLICTING"`| 2   |
-/// | `None`         | 3   |
-fn mergeable_sort_key(mergeable: Option<&str>) -> u8 {
-    match mergeable {
-        Some("MERGEABLE") => 0,
-        Some("UNKNOWN") => 1,
-        Some("CONFLICTING") => 2,
-        _ => 3,
-    }
-}
+// `mergeable_sort_key` has moved to `Mergeable::sort_key` — the enum is the
+// single source of truth for both parsing and ordering (see #77).
 
 // ── MockPrLifecycleTriage (test double) ───────────────────────────────────────
 
@@ -1153,7 +1220,7 @@ mod tests {
             number: 10,
             url: "https://github.com/o/r/pull/10".into(),
             title: "[LOOPER] #1: feat".into(),
-            head_ref: "loop/1-feat".into(),
+            head_ref: Some("loop/1-feat".into()),
         };
         let mock = MockPrLifecycle::new().with_existing_pr(existing);
         let mut cfg = default_config();
@@ -1176,7 +1243,7 @@ mod tests {
             number: 10,
             url: "https://github.com/o/r/pull/10".into(),
             title: "[LOOPER] #1: feat".into(),
-            head_ref: "loop/1-feat".into(),
+            head_ref: Some("loop/1-feat".into()),
         };
         let mock = MockPrLifecycle::new().with_existing_pr(existing);
         let mut cfg = default_config();
@@ -1247,7 +1314,7 @@ mod tests {
             number,
             url: format!("https://github.com/o/r/pull/{number}"),
             title: format!("PR {number}"),
-            head_ref: format!("loop/{number}-pr"),
+            head_ref: Some(format!("loop/{number}-pr")),
         }
     }
 
@@ -1256,7 +1323,7 @@ mod tests {
             pr,
             state,
             created_at: "2026-01-01T00:00:00Z".into(),
-            mergeable: Some("MERGEABLE".into()),
+            mergeable: Some(Mergeable::Mergeable),
         }
     }
 
@@ -1269,7 +1336,7 @@ mod tests {
             pr,
             state,
             created_at: "2026-01-01T00:00:00Z".into(),
-            mergeable: mergeable.map(|s| s.to_string()),
+            mergeable: mergeable.and_then(Mergeable::from_gh_str),
         }
     }
 
@@ -1449,7 +1516,7 @@ mod tests {
     #[test]
     fn pr_info_head_ref_is_set_by_make_pr_helper() {
         let pr = make_pr(5);
-        assert_eq!(pr.head_ref, "loop/5-pr");
+        assert_eq!(pr.head_ref.as_deref(), Some("loop/5-pr"));
     }
 
     #[test]
@@ -1464,7 +1531,8 @@ mod tests {
         let triage = PrTriage::new(cfg, mock);
         if let TriageAction::Merge { pr } = triage.select_action() {
             assert_eq!(
-                pr.head_ref, "loop/99-pr",
+                pr.head_ref.as_deref(),
+                Some("loop/99-pr"),
                 "Merge action must preserve head_ref for post-merge cleanup"
             );
         } else {
@@ -1607,10 +1675,36 @@ mod tests {
 
     #[test]
     fn mergeable_sort_key_values() {
-        assert_eq!(mergeable_sort_key(Some("MERGEABLE")), 0);
-        assert_eq!(mergeable_sort_key(Some("UNKNOWN")), 1);
-        assert_eq!(mergeable_sort_key(Some("CONFLICTING")), 2);
-        assert_eq!(mergeable_sort_key(None), 3);
-        assert_eq!(mergeable_sort_key(Some("something-else")), 3);
+        assert_eq!(Mergeable::sort_key(Some(Mergeable::Mergeable)), 0);
+        assert_eq!(Mergeable::sort_key(Some(Mergeable::Unknown)), 1);
+        assert_eq!(Mergeable::sort_key(Some(Mergeable::Conflicting)), 2);
+        assert_eq!(Mergeable::sort_key(None), 3);
+    }
+
+    #[test]
+    fn mergeable_from_gh_str_happy_path() {
+        assert_eq!(
+            Mergeable::from_gh_str("MERGEABLE"),
+            Some(Mergeable::Mergeable)
+        );
+        assert_eq!(Mergeable::from_gh_str("UNKNOWN"), Some(Mergeable::Unknown));
+        assert_eq!(
+            Mergeable::from_gh_str("CONFLICTING"),
+            Some(Mergeable::Conflicting)
+        );
+    }
+
+    /// Regression test for #77: a GitHub schema change that introduced a
+    /// new mergeable state (`BLOCKED`, a typo, or a lowercase variant) used
+    /// to silently degrade the `least-conflicts` triage order by mapping
+    /// every unknown value to the "missing" sort bucket.  Now those values
+    /// are treated as `None` at parse time *with a warning log*, and the
+    /// unit test locks the behaviour.
+    #[test]
+    fn mergeable_from_gh_str_unknown_value_returns_none() {
+        assert_eq!(Mergeable::from_gh_str("BLOCKED"), None);
+        assert_eq!(Mergeable::from_gh_str("mergeable"), None); // wrong case
+        assert_eq!(Mergeable::from_gh_str(""), None);
+        assert_eq!(Mergeable::from_gh_str("something-else"), None);
     }
 }

--- a/src/pr_manager.rs
+++ b/src/pr_manager.rs
@@ -33,7 +33,7 @@ use std::process::Command;
 
 use serde::Deserialize;
 
-use crate::config::PrManagementConfig;
+use crate::config::{PrManagementConfig, TriagePriority};
 
 // ── Signal detection ──────────────────────────────────────────────────────────
 
@@ -484,6 +484,356 @@ pub fn build_pr_manager(config: PrManagementConfig) -> PrManager<GhPrLifecycle> 
     PrManager::new(config, GhPrLifecycle::new())
 }
 
+// ── PR triage types ───────────────────────────────────────────────────────────
+
+/// Review/check state of an open PR as seen by the triage step.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PrTriageState {
+    /// One or more CI checks are failing.
+    ChecksFailing,
+    /// Reviewer has requested changes.
+    ChangesRequested,
+    /// Approved (or no review required) and all checks pass — ready to merge.
+    ReadyToMerge,
+    /// Awaiting initial review; not yet approved.
+    NeedsReview,
+    /// PR is labeled with a skip label (`do-not-loop`, `wip`, etc.).
+    Skipped { reason: String },
+}
+
+/// An open PR with its resolved triage state.
+#[derive(Debug, Clone)]
+pub struct PrWithState {
+    pub pr: PrInfo,
+    pub state: PrTriageState,
+    /// ISO-8601 creation timestamp (used for `oldest`/`newest` ordering).
+    pub created_at: String,
+}
+
+/// Outcome of a `PrTriage::select_action` call.
+#[derive(Debug, Clone)]
+pub enum TriageAction {
+    /// Instruct the agent to fix CI failures on this PR.
+    FixChecks { pr: PrInfo, prompt: String },
+    /// Instruct the agent to address review feedback on this PR.
+    AddressReviewFeedback { pr: PrInfo, prompt: String },
+    /// The PR is ready to merge; the engine will merge it directly (when
+    /// `require_human_review = false`).
+    Merge { pr: PrInfo },
+    /// The PR is ready to merge but `require_human_review = true`; engine
+    /// reports the situation and falls through.
+    BlockedOnHumanReview { pr: PrInfo },
+    /// No open PR could be advanced — fall through to issue work.
+    NoActionablePr,
+}
+
+// ── Extended PrLifecycle methods (triage) ────────────────────────────────────
+
+/// Extra methods on [`PrLifecycle`] required by the triage step.
+///
+/// Kept as a separate trait so existing implementations are not broken, and to
+/// make it easy to implement only what is needed in tests.
+pub trait PrLifecycleTriage: Send + Sync {
+    /// List open PRs that carry `label`.  Returns PRs in ascending creation
+    /// order (oldest first).
+    fn list_open_prs_with_label(&self, label: &str) -> Result<Vec<PrInfo>, PrError>;
+
+    /// Fetch the triage state for a single PR.
+    ///
+    /// The implementation queries `gh pr view <number> --json` for check
+    /// status, review decision, and labels.
+    fn get_pr_state(
+        &self,
+        pr_number: u32,
+        skip_labels: &[String],
+    ) -> Result<PrWithState, PrError>;
+}
+
+impl PrLifecycleTriage for GhPrLifecycle {
+    fn list_open_prs_with_label(&self, label: &str) -> Result<Vec<PrInfo>, PrError> {
+        let out = Command::new("gh")
+            .args([
+                "pr",
+                "list",
+                "--label",
+                label,
+                "--state",
+                "open",
+                "--json",
+                "number,url,title",
+                "--limit",
+                "100",
+            ])
+            .output()
+            .map_err(|e| PrError::GhCommand(format!("failed to spawn gh: {e}")))?;
+
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            return Err(PrError::GhCommand(format!("gh pr list failed: {stderr}")));
+        }
+
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let prs: Vec<serde_json::Value> = serde_json::from_str(&stdout)
+            .map_err(|e| PrError::ParseError(e.to_string()))?;
+
+        prs.into_iter()
+            .map(|v| {
+                let number = v["number"]
+                    .as_u64()
+                    .ok_or_else(|| PrError::ParseError("missing number".into()))? as u32;
+                let url = v["url"]
+                    .as_str()
+                    .ok_or_else(|| PrError::ParseError("missing url".into()))?
+                    .to_string();
+                let title = v["title"]
+                    .as_str()
+                    .ok_or_else(|| PrError::ParseError("missing title".into()))?
+                    .to_string();
+                Ok(PrInfo { number, url, title })
+            })
+            .collect()
+    }
+
+    fn get_pr_state(
+        &self,
+        pr_number: u32,
+        skip_labels: &[String],
+    ) -> Result<PrWithState, PrError> {
+        let pr_ref = pr_number.to_string();
+        let out = Command::new("gh")
+            .args([
+                "pr",
+                "view",
+                &pr_ref,
+                "--json",
+                "number,url,title,labels,statusCheckRollup,reviewDecision,createdAt",
+            ])
+            .output()
+            .map_err(|e| PrError::GhCommand(format!("failed to spawn gh: {e}")))?;
+
+        if !out.status.success() {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            return Err(PrError::GhCommand(format!("gh pr view failed: {stderr}")));
+        }
+
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let v: serde_json::Value = serde_json::from_str(&stdout)
+            .map_err(|e| PrError::ParseError(e.to_string()))?;
+
+        let number = v["number"].as_u64().unwrap_or(pr_number as u64) as u32;
+        let url = v["url"].as_str().unwrap_or("").to_string();
+        let title = v["title"].as_str().unwrap_or("").to_string();
+        let created_at = v["createdAt"].as_str().unwrap_or("").to_string();
+
+        let pr = PrInfo { number, url, title };
+
+        // Check skip labels.
+        if let Some(labels) = v["labels"].as_array() {
+            for lv in labels {
+                if let Some(name) = lv["name"].as_str() {
+                    if skip_labels.iter().any(|s| s == name) {
+                        return Ok(PrWithState {
+                            pr,
+                            state: PrTriageState::Skipped { reason: name.to_string() },
+                            created_at,
+                        });
+                    }
+                }
+            }
+        }
+
+        // Check CI status.
+        let checks_failing = v["statusCheckRollup"]
+            .as_array()
+            .map(|checks| {
+                checks.iter().any(|c| {
+                    c["conclusion"].as_str().map(|s| s == "FAILURE").unwrap_or(false)
+                })
+            })
+            .unwrap_or(false);
+
+        if checks_failing {
+            return Ok(PrWithState {
+                pr,
+                state: PrTriageState::ChecksFailing,
+                created_at,
+            });
+        }
+
+        // Check review decision.
+        let review_decision = v["reviewDecision"].as_str().unwrap_or("");
+        let state = match review_decision {
+            "CHANGES_REQUESTED" => PrTriageState::ChangesRequested,
+            "APPROVED" | "" => PrTriageState::ReadyToMerge,
+            "REVIEW_REQUIRED" => PrTriageState::NeedsReview,
+            _ => PrTriageState::NeedsReview,
+        };
+
+        Ok(PrWithState { pr, state, created_at })
+    }
+}
+
+// ── PrTriage ──────────────────────────────────────────────────────────────────
+
+/// Implements the multi-PR triage step: inspect open PRs and decide which
+/// action to take (or fall through to issue work).
+pub struct PrTriage<L: PrLifecycleTriage> {
+    config: PrManagementConfig,
+    lifecycle: L,
+}
+
+impl<L: PrLifecycleTriage> PrTriage<L> {
+    pub fn new(config: PrManagementConfig, lifecycle: L) -> Self {
+        Self { config, lifecycle }
+    }
+
+    /// Select the highest-priority actionable PR and return the triage action.
+    ///
+    /// PRs are fetched by the `code-looper` label, then filtered (skip
+    /// labels), sorted by triage priority, and the first actionable one is
+    /// returned.
+    pub fn select_action(&self) -> TriageAction {
+        let mut prs = match self.lifecycle.list_open_prs_with_label("code-looper") {
+            Ok(prs) => prs,
+            Err(e) => {
+                tracing::warn!(error = %e, "PrTriage: failed to list open PRs; falling through");
+                return TriageAction::NoActionablePr;
+            }
+        };
+
+        // Apply triage priority ordering.
+        match self.config.triage_priority {
+            TriagePriority::Newest => prs.reverse(),
+            TriagePriority::Oldest | TriagePriority::LeastConflicts => {}
+        }
+
+        for pr_info in prs {
+            let with_state =
+                match self.lifecycle.get_pr_state(pr_info.number, &self.config.skip_labels) {
+                    Ok(ws) => ws,
+                    Err(e) => {
+                        tracing::warn!(
+                            pr = pr_info.number,
+                            error = %e,
+                            "PrTriage: failed to get state for PR; skipping"
+                        );
+                        continue;
+                    }
+                };
+
+            match with_state.state {
+                PrTriageState::Skipped { ref reason } => {
+                    tracing::debug!(pr = pr_info.number, %reason, "PrTriage: skipping PR");
+                    continue;
+                }
+                PrTriageState::ChecksFailing => {
+                    let prompt = format!(
+                        "The CI checks on PR #{} («{}») are failing. Check out the branch, \
+                         diagnose the root cause, fix it, commit, and push. Do not merge — \
+                         the loop engine will handle the merge when checks pass.",
+                        with_state.pr.number, with_state.pr.title
+                    );
+                    return TriageAction::FixChecks { pr: with_state.pr, prompt };
+                }
+                PrTriageState::ChangesRequested => {
+                    let prompt = format!(
+                        "PR #{} («{}») has review comments requesting changes. Read each \
+                         review comment, address the feedback, commit the fixes, and push. \
+                         After pushing, reply to each resolved comment thread.",
+                        with_state.pr.number, with_state.pr.title
+                    );
+                    return TriageAction::AddressReviewFeedback {
+                        pr: with_state.pr,
+                        prompt,
+                    };
+                }
+                PrTriageState::ReadyToMerge => {
+                    if self.config.require_human_review {
+                        tracing::info!(
+                            pr = with_state.pr.number,
+                            "PrTriage: PR ready to merge but require_human_review=true"
+                        );
+                        return TriageAction::BlockedOnHumanReview { pr: with_state.pr };
+                    }
+                    return TriageAction::Merge { pr: with_state.pr };
+                }
+                PrTriageState::NeedsReview => {
+                    tracing::debug!(
+                        pr = with_state.pr.number,
+                        "PrTriage: PR awaiting initial review; skipping"
+                    );
+                    continue;
+                }
+            }
+        }
+
+        TriageAction::NoActionablePr
+    }
+}
+
+/// Build a production [`PrTriage`] backed by the `gh` CLI.
+pub fn build_pr_triage(config: PrManagementConfig) -> PrTriage<GhPrLifecycle> {
+    PrTriage::new(config, GhPrLifecycle::new())
+}
+
+// ── MockPrLifecycleTriage (test double) ───────────────────────────────────────
+
+/// Pre-scripted responses for [`PrLifecycleTriage`] in tests.
+pub struct MockPrLifecycleTriage {
+    /// PRs returned by `list_open_prs_with_label`.
+    pub open_prs: Vec<PrInfo>,
+    /// State returned for each PR by number.
+    pub states: std::collections::HashMap<u32, PrWithState>,
+    /// All calls recorded in order.
+    pub calls: std::sync::Mutex<Vec<TriageCall>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TriageCall {
+    ListOpenPrsWithLabel { label: String },
+    GetPrState { pr_number: u32 },
+}
+
+impl MockPrLifecycleTriage {
+    pub fn new() -> Self {
+        Self {
+            open_prs: Vec::new(),
+            states: std::collections::HashMap::new(),
+            calls: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl Default for MockPrLifecycleTriage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PrLifecycleTriage for MockPrLifecycleTriage {
+    fn list_open_prs_with_label(&self, label: &str) -> Result<Vec<PrInfo>, PrError> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push(TriageCall::ListOpenPrsWithLabel { label: label.to_string() });
+        Ok(self.open_prs.clone())
+    }
+
+    fn get_pr_state(
+        &self,
+        pr_number: u32,
+        _skip_labels: &[String],
+    ) -> Result<PrWithState, PrError> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push(TriageCall::GetPrState { pr_number });
+        self.states.get(&pr_number).cloned().ok_or_else(|| {
+            PrError::GhCommand(format!("mock: no state configured for PR #{pr_number}"))
+        })
+    }
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -695,5 +1045,152 @@ mod tests {
         } else {
             panic!("expected OpenPr call, got: {calls:?}");
         }
+    }
+
+    // ── PrTriage::select_action ───────────────────────────────────────────────
+
+    fn make_pr(number: u32) -> PrInfo {
+        PrInfo {
+            number,
+            url: format!("https://github.com/o/r/pull/{number}"),
+            title: format!("PR {number}"),
+        }
+    }
+
+    fn make_state(pr: PrInfo, state: PrTriageState) -> PrWithState {
+        PrWithState { pr, state, created_at: "2026-01-01T00:00:00Z".into() }
+    }
+
+    #[test]
+    fn triage_no_open_prs_returns_no_actionable() {
+        let mock = MockPrLifecycleTriage::new();
+        let triage = PrTriage::new(default_config(), mock);
+        assert!(matches!(triage.select_action(), TriageAction::NoActionablePr));
+    }
+
+    #[test]
+    fn triage_all_skipped_returns_no_actionable() {
+        let mut mock = MockPrLifecycleTriage::new();
+        let pr = make_pr(1);
+        mock.open_prs = vec![pr.clone()];
+        mock.states.insert(1, make_state(pr, PrTriageState::Skipped { reason: "wip".into() }));
+        let triage = PrTriage::new(default_config(), mock);
+        assert!(matches!(triage.select_action(), TriageAction::NoActionablePr));
+    }
+
+    #[test]
+    fn triage_checks_failing_returns_fix_checks() {
+        let mut mock = MockPrLifecycleTriage::new();
+        let pr = make_pr(2);
+        mock.open_prs = vec![pr.clone()];
+        mock.states.insert(2, make_state(pr, PrTriageState::ChecksFailing));
+        let triage = PrTriage::new(default_config(), mock);
+        let action = triage.select_action();
+        assert!(matches!(action, TriageAction::FixChecks { .. }));
+        if let TriageAction::FixChecks { pr, prompt } = action {
+            assert_eq!(pr.number, 2);
+            assert!(prompt.contains("CI checks"));
+        }
+    }
+
+    #[test]
+    fn triage_changes_requested_returns_address_review() {
+        let mut mock = MockPrLifecycleTriage::new();
+        let pr = make_pr(3);
+        mock.open_prs = vec![pr.clone()];
+        mock.states.insert(3, make_state(pr, PrTriageState::ChangesRequested));
+        let triage = PrTriage::new(default_config(), mock);
+        let action = triage.select_action();
+        assert!(matches!(action, TriageAction::AddressReviewFeedback { .. }));
+        if let TriageAction::AddressReviewFeedback { pr, prompt } = action {
+            assert_eq!(pr.number, 3);
+            assert!(prompt.contains("review comment"));
+        }
+    }
+
+    #[test]
+    fn triage_ready_to_merge_require_human_review_returns_blocked() {
+        let mut mock = MockPrLifecycleTriage::new();
+        let pr = make_pr(4);
+        mock.open_prs = vec![pr.clone()];
+        mock.states.insert(4, make_state(pr, PrTriageState::ReadyToMerge));
+        let mut cfg = default_config();
+        cfg.require_human_review = true;
+        let triage = PrTriage::new(cfg, mock);
+        assert!(matches!(triage.select_action(), TriageAction::BlockedOnHumanReview { .. }));
+    }
+
+    #[test]
+    fn triage_ready_to_merge_no_human_review_returns_merge() {
+        let mut mock = MockPrLifecycleTriage::new();
+        let pr = make_pr(5);
+        mock.open_prs = vec![pr.clone()];
+        mock.states.insert(5, make_state(pr, PrTriageState::ReadyToMerge));
+        let mut cfg = default_config();
+        cfg.require_human_review = false;
+        let triage = PrTriage::new(cfg, mock);
+        assert!(matches!(triage.select_action(), TriageAction::Merge { .. }));
+    }
+
+    #[test]
+    fn triage_needs_review_skipped_falls_through() {
+        let mut mock = MockPrLifecycleTriage::new();
+        let pr = make_pr(6);
+        mock.open_prs = vec![pr.clone()];
+        mock.states.insert(6, make_state(pr, PrTriageState::NeedsReview));
+        let triage = PrTriage::new(default_config(), mock);
+        assert!(matches!(triage.select_action(), TriageAction::NoActionablePr));
+    }
+
+    #[test]
+    fn triage_picks_first_actionable_pr_in_order() {
+        let mut mock = MockPrLifecycleTriage::new();
+        let pr1 = make_pr(10);
+        let pr2 = make_pr(11);
+        mock.open_prs = vec![pr1.clone(), pr2.clone()];
+        // First PR skipped, second has checks failing.
+        mock.states
+            .insert(10, make_state(pr1, PrTriageState::Skipped { reason: "wip".into() }));
+        mock.states.insert(11, make_state(pr2, PrTriageState::ChecksFailing));
+        let triage = PrTriage::new(default_config(), mock);
+        let action = triage.select_action();
+        if let TriageAction::FixChecks { pr, .. } = action {
+            assert_eq!(pr.number, 11);
+        } else {
+            panic!("expected FixChecks");
+        }
+    }
+
+    #[test]
+    fn triage_newest_priority_reverses_pr_order() {
+        use crate::config::TriagePriority;
+        let mut mock = MockPrLifecycleTriage::new();
+        let pr1 = make_pr(20);
+        let pr2 = make_pr(21);
+        mock.open_prs = vec![pr1.clone(), pr2.clone()]; // oldest first
+        mock.states.insert(20, make_state(pr1, PrTriageState::ChecksFailing));
+        mock.states.insert(21, make_state(pr2, PrTriageState::ChecksFailing));
+        let mut cfg = default_config();
+        cfg.triage_priority = TriagePriority::Newest;
+        let triage = PrTriage::new(cfg, mock);
+        // With Newest first, the last in the list (21) should be selected.
+        if let TriageAction::FixChecks { pr, .. } = triage.select_action() {
+            assert_eq!(pr.number, 21);
+        } else {
+            panic!("expected FixChecks for PR 21");
+        }
+    }
+
+    #[test]
+    fn triage_calls_list_then_get_state_for_each_pr() {
+        let mut mock = MockPrLifecycleTriage::new();
+        let pr = make_pr(30);
+        mock.open_prs = vec![pr.clone()];
+        mock.states.insert(30, make_state(pr, PrTriageState::NeedsReview));
+        let triage = PrTriage::new(default_config(), mock);
+        triage.select_action();
+        let calls = triage.lifecycle.calls.lock().unwrap();
+        assert!(calls.contains(&TriageCall::ListOpenPrsWithLabel { label: "code-looper".into() }));
+        assert!(calls.contains(&TriageCall::GetPrState { pr_number: 30 }));
     }
 }

--- a/src/pr_strategy.rs
+++ b/src/pr_strategy.rs
@@ -307,6 +307,7 @@ mod tests {
                 pr,
                 state: PrTriageState::ChecksFailing,
                 created_at: "2026-01-01T00:00:00Z".into(),
+                mergeable: None,
             },
         );
         let triage = PrTriage::new(cfg.clone(), mock);
@@ -336,6 +337,7 @@ mod tests {
                 pr,
                 state: PrTriageState::ChangesRequested,
                 created_at: "2026-01-01T00:00:00Z".into(),
+                mergeable: None,
             },
         );
         let triage = PrTriage::new(cfg.clone(), mock);
@@ -366,6 +368,7 @@ mod tests {
                 pr,
                 state: PrTriageState::ReadyToMerge,
                 created_at: "2026-01-01T00:00:00Z".into(),
+                mergeable: None,
             },
         );
         let triage = PrTriage::new(cfg.clone(), mock);
@@ -398,6 +401,7 @@ mod tests {
                     reason: "wip".into(),
                 },
                 created_at: "2026-01-01T00:00:00Z".into(),
+                mergeable: None,
             },
         );
         let triage = PrTriage::new(cfg.clone(), mock);

--- a/src/pr_strategy.rs
+++ b/src/pr_strategy.rs
@@ -1,0 +1,238 @@
+use crate::config::{PrManagementConfig, PrMode};
+
+/// The plan produced by a `PrStrategy` before each iteration.
+///
+/// The loop engine passes this to the orchestration policy engine so the
+/// prompt can reflect the active PR strategy.
+#[derive(Debug, Clone, PartialEq)]
+pub struct IterationPlan {
+    /// Human-readable description of what the strategy intends to do this
+    /// iteration (used in structured logs and prompt preambles).
+    pub description: String,
+    /// The PR mode that produced this plan.
+    pub mode: PrMode,
+}
+
+/// Trait implemented by all PR strategy variants.
+///
+/// Each strategy is constructed once at loop startup from the resolved
+/// `PrManagementConfig` and called once per iteration to produce an
+/// `IterationPlan`.  The loop engine passes the plan to the orchestration
+/// policy engine; the actual provider invocation is unchanged.
+pub trait PrStrategy: Send + Sync {
+    /// Produce an `IterationPlan` for the upcoming iteration.
+    ///
+    /// `iteration` is 1-based.
+    fn plan_iteration(&self, iteration: u64) -> IterationPlan;
+}
+
+// ── Strategy implementations ──────────────────────────────────────────────────
+
+/// No-PR strategy: commit and push to a feature branch; never open a PR.
+pub struct NoPrStrategy {
+    config: PrManagementConfig,
+}
+
+impl NoPrStrategy {
+    pub fn new(config: PrManagementConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl PrStrategy for NoPrStrategy {
+    fn plan_iteration(&self, iteration: u64) -> IterationPlan {
+        tracing::debug!(
+            iteration,
+            mode = %self.config.mode,
+            base_branch = %self.config.base_branch,
+            "NoPrStrategy: committing to feature branch only"
+        );
+        IterationPlan {
+            description: format!(
+                "no-pr: commit work to feature branch (base: {})",
+                self.config.base_branch
+            ),
+            mode: PrMode::NoPr,
+        }
+    }
+}
+
+/// Single-PR strategy: open one PR when work is shippable; keep pushing to it.
+pub struct SinglePrStrategy {
+    config: PrManagementConfig,
+}
+
+impl SinglePrStrategy {
+    pub fn new(config: PrManagementConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl PrStrategy for SinglePrStrategy {
+    fn plan_iteration(&self, iteration: u64) -> IterationPlan {
+        tracing::debug!(
+            iteration,
+            mode = %self.config.mode,
+            base_branch = %self.config.base_branch,
+            require_human_review = self.config.require_human_review,
+            "SinglePrStrategy: work on feature branch; open PR when shippable"
+        );
+        IterationPlan {
+            description: format!(
+                "single-pr: work on feature branch; open PR into {} when shippable \
+                 (human review required: {})",
+                self.config.base_branch, self.config.require_human_review
+            ),
+            mode: PrMode::SinglePr,
+        }
+    }
+}
+
+/// Multi-PR strategy: triage open PRs first; start new feature branch work
+/// only when no PR can be advanced.
+pub struct MultiPrStrategy {
+    config: PrManagementConfig,
+}
+
+impl MultiPrStrategy {
+    pub fn new(config: PrManagementConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl PrStrategy for MultiPrStrategy {
+    fn plan_iteration(&self, iteration: u64) -> IterationPlan {
+        tracing::debug!(
+            iteration,
+            mode = %self.config.mode,
+            base_branch = %self.config.base_branch,
+            require_human_review = self.config.require_human_review,
+            "MultiPrStrategy: triage open PRs first, then issue work"
+        );
+        IterationPlan {
+            description: format!(
+                "multi-pr: triage open PRs first, then open new feature branch for issue \
+                 work (base: {}, human review required: {})",
+                self.config.base_branch, self.config.require_human_review
+            ),
+            mode: PrMode::MultiPr,
+        }
+    }
+}
+
+// ── Constructor ───────────────────────────────────────────────────────────────
+
+/// Build the concrete `PrStrategy` for the given config.
+pub fn build_strategy(config: PrManagementConfig) -> Box<dyn PrStrategy> {
+    match config.mode {
+        PrMode::NoPr => Box::new(NoPrStrategy::new(config)),
+        PrMode::SinglePr => Box::new(SinglePrStrategy::new(config)),
+        PrMode::MultiPr => Box::new(MultiPrStrategy::new(config)),
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::PrManagementConfig;
+
+    fn default_config() -> PrManagementConfig {
+        PrManagementConfig::default()
+    }
+
+    fn config_with_mode(mode: PrMode) -> PrManagementConfig {
+        PrManagementConfig { mode, ..default_config() }
+    }
+
+    // ── NoPrStrategy ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn no_pr_strategy_plan_contains_mode() {
+        let strategy = NoPrStrategy::new(config_with_mode(PrMode::NoPr));
+        let plan = strategy.plan_iteration(1);
+        assert_eq!(plan.mode, PrMode::NoPr);
+        assert!(plan.description.contains("no-pr"));
+    }
+
+    #[test]
+    fn no_pr_strategy_plan_references_base_branch() {
+        let mut cfg = config_with_mode(PrMode::NoPr);
+        cfg.base_branch = "develop".to_string();
+        let strategy = NoPrStrategy::new(cfg);
+        let plan = strategy.plan_iteration(3);
+        assert!(plan.description.contains("develop"));
+    }
+
+    // ── SinglePrStrategy ─────────────────────────────────────────────────────
+
+    #[test]
+    fn single_pr_strategy_plan_contains_mode() {
+        let strategy = SinglePrStrategy::new(config_with_mode(PrMode::SinglePr));
+        let plan = strategy.plan_iteration(1);
+        assert_eq!(plan.mode, PrMode::SinglePr);
+        assert!(plan.description.contains("single-pr"));
+    }
+
+    #[test]
+    fn single_pr_strategy_reflects_human_review_flag() {
+        let mut cfg = config_with_mode(PrMode::SinglePr);
+        cfg.require_human_review = false;
+        let strategy = SinglePrStrategy::new(cfg);
+        let plan = strategy.plan_iteration(1);
+        assert!(plan.description.contains("false"));
+    }
+
+    // ── MultiPrStrategy ──────────────────────────────────────────────────────
+
+    #[test]
+    fn multi_pr_strategy_plan_contains_mode() {
+        let strategy = MultiPrStrategy::new(config_with_mode(PrMode::MultiPr));
+        let plan = strategy.plan_iteration(1);
+        assert_eq!(plan.mode, PrMode::MultiPr);
+        assert!(plan.description.contains("multi-pr"));
+    }
+
+    #[test]
+    fn multi_pr_strategy_mentions_triage() {
+        let strategy = MultiPrStrategy::new(config_with_mode(PrMode::MultiPr));
+        let plan = strategy.plan_iteration(2);
+        assert!(plan.description.contains("triage"));
+    }
+
+    // ── build_strategy ───────────────────────────────────────────────────────
+
+    #[test]
+    fn build_strategy_no_pr() {
+        let strategy = build_strategy(config_with_mode(PrMode::NoPr));
+        let plan = strategy.plan_iteration(1);
+        assert_eq!(plan.mode, PrMode::NoPr);
+    }
+
+    #[test]
+    fn build_strategy_single_pr() {
+        let strategy = build_strategy(config_with_mode(PrMode::SinglePr));
+        let plan = strategy.plan_iteration(1);
+        assert_eq!(plan.mode, PrMode::SinglePr);
+    }
+
+    #[test]
+    fn build_strategy_multi_pr() {
+        let strategy = build_strategy(config_with_mode(PrMode::MultiPr));
+        let plan = strategy.plan_iteration(1);
+        assert_eq!(plan.mode, PrMode::MultiPr);
+    }
+
+    // ── Iteration number propagation ─────────────────────────────────────────
+
+    #[test]
+    fn strategy_called_with_correct_iteration_number() {
+        let strategy = build_strategy(config_with_mode(PrMode::NoPr));
+        // Just verifying plan_iteration is callable with any u64 without panic.
+        for n in [1u64, 5, 100] {
+            let plan = strategy.plan_iteration(n);
+            assert_eq!(plan.mode, PrMode::NoPr);
+        }
+    }
+}

--- a/src/pr_strategy.rs
+++ b/src/pr_strategy.rs
@@ -297,6 +297,7 @@ mod tests {
             number: 7,
             url: "https://example.com/pull/7".into(),
             title: "Fix foo".into(),
+            head_ref: "loop/7-fix-foo".into(),
         };
         let mut mock = MockPrLifecycleTriage::new();
         mock.open_prs = vec![pr.clone()];
@@ -325,6 +326,7 @@ mod tests {
             number: 8,
             url: "https://example.com/pull/8".into(),
             title: "Add bar".into(),
+            head_ref: "loop/8-add-bar".into(),
         };
         let mut mock = MockPrLifecycleTriage::new();
         mock.open_prs = vec![pr.clone()];
@@ -354,6 +356,7 @@ mod tests {
             number: 9,
             url: "https://example.com/pull/9".into(),
             title: "Ship it".into(),
+            head_ref: "loop/9-ship-it".into(),
         };
         let mut mock = MockPrLifecycleTriage::new();
         mock.open_prs = vec![pr.clone()];
@@ -383,6 +386,7 @@ mod tests {
             number: 10,
             url: "https://example.com/pull/10".into(),
             title: "WIP".into(),
+            head_ref: "loop/10-wip".into(),
         };
         let mut mock = MockPrLifecycleTriage::new();
         mock.open_prs = vec![pr.clone()];

--- a/src/pr_strategy.rs
+++ b/src/pr_strategy.rs
@@ -116,6 +116,7 @@ impl MultiPrStrategy<crate::pr_manager::GhPrLifecycle> {
 
 impl<L: PrLifecycleTriage + 'static> MultiPrStrategy<L> {
     /// Build a `MultiPrStrategy` with a custom triage lifecycle (for testing).
+    #[allow(dead_code)]
     pub fn with_triage(config: PrManagementConfig, triage: PrTriage<L>) -> Self {
         Self { config, triage }
     }
@@ -186,6 +187,7 @@ pub fn build_strategy(config: PrManagementConfig) -> Box<dyn PrStrategy> {
 }
 
 /// Build a `MultiPrStrategy` with a custom triage lifecycle (for testing).
+#[allow(dead_code)]
 pub fn build_multi_pr_strategy_with_triage<L: PrLifecycleTriage + 'static>(
     config: PrManagementConfig,
     triage: PrTriage<L>,

--- a/src/pr_strategy.rs
+++ b/src/pr_strategy.rs
@@ -297,7 +297,7 @@ mod tests {
             number: 7,
             url: "https://example.com/pull/7".into(),
             title: "Fix foo".into(),
-            head_ref: "loop/7-fix-foo".into(),
+            head_ref: Some("loop/7-fix-foo".into()),
         };
         let mut mock = MockPrLifecycleTriage::new();
         mock.open_prs = vec![pr.clone()];
@@ -327,7 +327,7 @@ mod tests {
             number: 8,
             url: "https://example.com/pull/8".into(),
             title: "Add bar".into(),
-            head_ref: "loop/8-add-bar".into(),
+            head_ref: Some("loop/8-add-bar".into()),
         };
         let mut mock = MockPrLifecycleTriage::new();
         mock.open_prs = vec![pr.clone()];
@@ -358,7 +358,7 @@ mod tests {
             number: 9,
             url: "https://example.com/pull/9".into(),
             title: "Ship it".into(),
-            head_ref: "loop/9-ship-it".into(),
+            head_ref: Some("loop/9-ship-it".into()),
         };
         let mut mock = MockPrLifecycleTriage::new();
         mock.open_prs = vec![pr.clone()];
@@ -389,7 +389,7 @@ mod tests {
             number: 10,
             url: "https://example.com/pull/10".into(),
             title: "WIP".into(),
-            head_ref: "loop/10-wip".into(),
+            head_ref: Some("loop/10-wip".into()),
         };
         let mut mock = MockPrLifecycleTriage::new();
         mock.open_prs = vec![pr.clone()];

--- a/src/pr_strategy.rs
+++ b/src/pr_strategy.rs
@@ -1,5 +1,5 @@
 use crate::config::{PrManagementConfig, PrMode};
-use crate::pr_manager::{PrTriage, PrLifecycleTriage, TriageAction, build_pr_triage};
+use crate::pr_manager::{build_pr_triage, PrLifecycleTriage, PrTriage, TriageAction};
 
 /// The plan produced by a `PrStrategy` before each iteration.
 ///
@@ -136,7 +136,10 @@ impl<L: PrLifecycleTriage + 'static> PrStrategy for MultiPrStrategy<L> {
 
         let (description, prompt_override) = match &action {
             TriageAction::FixChecks { pr, prompt } => (
-                format!("multi-pr: fix CI checks on PR #{} ({})", pr.number, pr.title),
+                format!(
+                    "multi-pr: fix CI checks on PR #{} ({})",
+                    pr.number, pr.title
+                ),
                 Some(prompt.clone()),
             ),
             TriageAction::AddressReviewFeedback { pr, prompt } => (
@@ -207,7 +210,10 @@ mod tests {
     }
 
     fn config_with_mode(mode: PrMode) -> PrManagementConfig {
-        PrManagementConfig { mode, ..default_config() }
+        PrManagementConfig {
+            mode,
+            ..default_config()
+        }
     }
 
     // ── NoPrStrategy ─────────────────────────────────────────────────────────
@@ -250,7 +256,9 @@ mod tests {
 
     // ── MultiPrStrategy ──────────────────────────────────────────────────────
 
-    fn mock_triage(config: PrManagementConfig) -> PrTriage<crate::pr_manager::MockPrLifecycleTriage> {
+    fn mock_triage(
+        config: PrManagementConfig,
+    ) -> PrTriage<crate::pr_manager::MockPrLifecycleTriage> {
         PrTriage::new(config, crate::pr_manager::MockPrLifecycleTriage::new())
     }
 
@@ -274,21 +282,32 @@ mod tests {
         assert_eq!(plan.mode, PrMode::MultiPr);
         assert!(plan.prompt_override.is_none());
         // Description should mention issue work fall-through.
-        assert!(plan.description.contains("issue work") || plan.description.contains("no actionable"));
+        assert!(
+            plan.description.contains("issue work") || plan.description.contains("no actionable")
+        );
     }
 
     #[test]
     fn multi_pr_strategy_checks_failing_returns_prompt_override() {
-        use crate::pr_manager::{MockPrLifecycleTriage, PrInfo, PrTriage, PrTriageState, PrWithState};
+        use crate::pr_manager::{
+            MockPrLifecycleTriage, PrInfo, PrTriage, PrTriageState, PrWithState,
+        };
         let cfg = config_with_mode(PrMode::MultiPr);
-        let pr = PrInfo { number: 7, url: "https://example.com/pull/7".into(), title: "Fix foo".into() };
+        let pr = PrInfo {
+            number: 7,
+            url: "https://example.com/pull/7".into(),
+            title: "Fix foo".into(),
+        };
         let mut mock = MockPrLifecycleTriage::new();
         mock.open_prs = vec![pr.clone()];
-        mock.states.insert(7, PrWithState {
-            pr,
-            state: PrTriageState::ChecksFailing,
-            created_at: "2026-01-01T00:00:00Z".into(),
-        });
+        mock.states.insert(
+            7,
+            PrWithState {
+                pr,
+                state: PrTriageState::ChecksFailing,
+                created_at: "2026-01-01T00:00:00Z".into(),
+            },
+        );
         let triage = PrTriage::new(cfg.clone(), mock);
         let strategy = MultiPrStrategy::with_triage(cfg, triage);
         let plan = strategy.plan_iteration(1);
@@ -298,16 +317,25 @@ mod tests {
 
     #[test]
     fn multi_pr_strategy_changes_requested_returns_prompt_override() {
-        use crate::pr_manager::{MockPrLifecycleTriage, PrInfo, PrTriage, PrTriageState, PrWithState};
+        use crate::pr_manager::{
+            MockPrLifecycleTriage, PrInfo, PrTriage, PrTriageState, PrWithState,
+        };
         let cfg = config_with_mode(PrMode::MultiPr);
-        let pr = PrInfo { number: 8, url: "https://example.com/pull/8".into(), title: "Add bar".into() };
+        let pr = PrInfo {
+            number: 8,
+            url: "https://example.com/pull/8".into(),
+            title: "Add bar".into(),
+        };
         let mut mock = MockPrLifecycleTriage::new();
         mock.open_prs = vec![pr.clone()];
-        mock.states.insert(8, PrWithState {
-            pr,
-            state: PrTriageState::ChangesRequested,
-            created_at: "2026-01-01T00:00:00Z".into(),
-        });
+        mock.states.insert(
+            8,
+            PrWithState {
+                pr,
+                state: PrTriageState::ChangesRequested,
+                created_at: "2026-01-01T00:00:00Z".into(),
+            },
+        );
         let triage = PrTriage::new(cfg.clone(), mock);
         let strategy = MultiPrStrategy::with_triage(cfg, triage);
         let plan = strategy.plan_iteration(1);
@@ -317,17 +345,26 @@ mod tests {
 
     #[test]
     fn multi_pr_strategy_ready_to_merge_human_review_required() {
-        use crate::pr_manager::{MockPrLifecycleTriage, PrInfo, PrTriage, PrTriageState, PrWithState};
+        use crate::pr_manager::{
+            MockPrLifecycleTriage, PrInfo, PrTriage, PrTriageState, PrWithState,
+        };
         let mut cfg = config_with_mode(PrMode::MultiPr);
         cfg.require_human_review = true;
-        let pr = PrInfo { number: 9, url: "https://example.com/pull/9".into(), title: "Ship it".into() };
+        let pr = PrInfo {
+            number: 9,
+            url: "https://example.com/pull/9".into(),
+            title: "Ship it".into(),
+        };
         let mut mock = MockPrLifecycleTriage::new();
         mock.open_prs = vec![pr.clone()];
-        mock.states.insert(9, PrWithState {
-            pr,
-            state: PrTriageState::ReadyToMerge,
-            created_at: "2026-01-01T00:00:00Z".into(),
-        });
+        mock.states.insert(
+            9,
+            PrWithState {
+                pr,
+                state: PrTriageState::ReadyToMerge,
+                created_at: "2026-01-01T00:00:00Z".into(),
+            },
+        );
         let triage = PrTriage::new(cfg.clone(), mock);
         let strategy = MultiPrStrategy::with_triage(cfg, triage);
         let plan = strategy.plan_iteration(1);
@@ -338,16 +375,27 @@ mod tests {
 
     #[test]
     fn multi_pr_strategy_skipped_pr_falls_through() {
-        use crate::pr_manager::{MockPrLifecycleTriage, PrInfo, PrTriage, PrTriageState, PrWithState};
+        use crate::pr_manager::{
+            MockPrLifecycleTriage, PrInfo, PrTriage, PrTriageState, PrWithState,
+        };
         let cfg = config_with_mode(PrMode::MultiPr);
-        let pr = PrInfo { number: 10, url: "https://example.com/pull/10".into(), title: "WIP".into() };
+        let pr = PrInfo {
+            number: 10,
+            url: "https://example.com/pull/10".into(),
+            title: "WIP".into(),
+        };
         let mut mock = MockPrLifecycleTriage::new();
         mock.open_prs = vec![pr.clone()];
-        mock.states.insert(10, PrWithState {
-            pr,
-            state: PrTriageState::Skipped { reason: "wip".into() },
-            created_at: "2026-01-01T00:00:00Z".into(),
-        });
+        mock.states.insert(
+            10,
+            PrWithState {
+                pr,
+                state: PrTriageState::Skipped {
+                    reason: "wip".into(),
+                },
+                created_at: "2026-01-01T00:00:00Z".into(),
+            },
+        );
         let triage = PrTriage::new(cfg.clone(), mock);
         let strategy = MultiPrStrategy::with_triage(cfg, triage);
         let plan = strategy.plan_iteration(1);

--- a/src/pr_strategy.rs
+++ b/src/pr_strategy.rs
@@ -1,16 +1,23 @@
 use crate::config::{PrManagementConfig, PrMode};
+use crate::pr_manager::{PrTriage, PrLifecycleTriage, TriageAction, build_pr_triage};
 
 /// The plan produced by a `PrStrategy` before each iteration.
 ///
 /// The loop engine passes this to the orchestration policy engine so the
 /// prompt can reflect the active PR strategy.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct IterationPlan {
     /// Human-readable description of what the strategy intends to do this
     /// iteration (used in structured logs and prompt preambles).
     pub description: String,
     /// The PR mode that produced this plan.
     pub mode: PrMode,
+    /// When set, the loop engine uses this prompt instead of the normal
+    /// resolved prompt.  Used by multi-PR triage to direct the agent toward
+    /// a specific PR action.
+    pub prompt_override: Option<String>,
+    /// The triage action that produced this plan (present for multi-PR mode).
+    pub triage_action: Option<TriageAction>,
 }
 
 /// Trait implemented by all PR strategy variants.
@@ -53,6 +60,8 @@ impl PrStrategy for NoPrStrategy {
                 self.config.base_branch
             ),
             mode: PrMode::NoPr,
+            prompt_override: None,
+            triage_action: None,
         }
     }
 }
@@ -84,38 +93,83 @@ impl PrStrategy for SinglePrStrategy {
                 self.config.base_branch, self.config.require_human_review
             ),
             mode: PrMode::SinglePr,
+            prompt_override: None,
+            triage_action: None,
         }
     }
 }
 
 /// Multi-PR strategy: triage open PRs first; start new feature branch work
 /// only when no PR can be advanced.
-pub struct MultiPrStrategy {
+pub struct MultiPrStrategy<L: PrLifecycleTriage + 'static> {
     config: PrManagementConfig,
+    triage: PrTriage<L>,
 }
 
-impl MultiPrStrategy {
+impl MultiPrStrategy<crate::pr_manager::GhPrLifecycle> {
+    /// Build a production `MultiPrStrategy` backed by the `gh` CLI.
     pub fn new(config: PrManagementConfig) -> Self {
-        Self { config }
+        let triage = build_pr_triage(config.clone());
+        Self { config, triage }
     }
 }
 
-impl PrStrategy for MultiPrStrategy {
+impl<L: PrLifecycleTriage + 'static> MultiPrStrategy<L> {
+    /// Build a `MultiPrStrategy` with a custom triage lifecycle (for testing).
+    pub fn with_triage(config: PrManagementConfig, triage: PrTriage<L>) -> Self {
+        Self { config, triage }
+    }
+}
+
+impl<L: PrLifecycleTriage + 'static> PrStrategy for MultiPrStrategy<L> {
     fn plan_iteration(&self, iteration: u64) -> IterationPlan {
         tracing::debug!(
             iteration,
             mode = %self.config.mode,
             base_branch = %self.config.base_branch,
             require_human_review = self.config.require_human_review,
-            "MultiPrStrategy: triage open PRs first, then issue work"
+            "MultiPrStrategy: running PR triage step"
         );
-        IterationPlan {
-            description: format!(
-                "multi-pr: triage open PRs first, then open new feature branch for issue \
-                 work (base: {}, human review required: {})",
-                self.config.base_branch, self.config.require_human_review
+
+        let action = self.triage.select_action();
+
+        let (description, prompt_override) = match &action {
+            TriageAction::FixChecks { pr, prompt } => (
+                format!("multi-pr: fix CI checks on PR #{} ({})", pr.number, pr.title),
+                Some(prompt.clone()),
             ),
+            TriageAction::AddressReviewFeedback { pr, prompt } => (
+                format!(
+                    "multi-pr: address review feedback on PR #{} ({})",
+                    pr.number, pr.title
+                ),
+                Some(prompt.clone()),
+            ),
+            TriageAction::Merge { pr } => (
+                format!("multi-pr: merging PR #{} ({})", pr.number, pr.title),
+                None,
+            ),
+            TriageAction::BlockedOnHumanReview { pr } => (
+                format!(
+                    "multi-pr: PR #{} ready but blocked on human review — falling through",
+                    pr.number
+                ),
+                None,
+            ),
+            TriageAction::NoActionablePr => (
+                format!(
+                    "multi-pr: no actionable open PR — proceed with issue work (base: {})",
+                    self.config.base_branch
+                ),
+                None,
+            ),
+        };
+
+        IterationPlan {
+            description,
             mode: PrMode::MultiPr,
+            prompt_override,
+            triage_action: Some(action),
         }
     }
 }
@@ -129,6 +183,14 @@ pub fn build_strategy(config: PrManagementConfig) -> Box<dyn PrStrategy> {
         PrMode::SinglePr => Box::new(SinglePrStrategy::new(config)),
         PrMode::MultiPr => Box::new(MultiPrStrategy::new(config)),
     }
+}
+
+/// Build a `MultiPrStrategy` with a custom triage lifecycle (for testing).
+pub fn build_multi_pr_strategy_with_triage<L: PrLifecycleTriage + 'static>(
+    config: PrManagementConfig,
+    triage: PrTriage<L>,
+) -> Box<dyn PrStrategy> {
+    Box::new(MultiPrStrategy::with_triage(config, triage))
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -186,19 +248,109 @@ mod tests {
 
     // ── MultiPrStrategy ──────────────────────────────────────────────────────
 
+    fn mock_triage(config: PrManagementConfig) -> PrTriage<crate::pr_manager::MockPrLifecycleTriage> {
+        PrTriage::new(config, crate::pr_manager::MockPrLifecycleTriage::new())
+    }
+
     #[test]
     fn multi_pr_strategy_plan_contains_mode() {
-        let strategy = MultiPrStrategy::new(config_with_mode(PrMode::MultiPr));
+        let cfg = config_with_mode(PrMode::MultiPr);
+        let triage = mock_triage(cfg.clone());
+        let strategy = MultiPrStrategy::with_triage(cfg, triage);
         let plan = strategy.plan_iteration(1);
         assert_eq!(plan.mode, PrMode::MultiPr);
         assert!(plan.description.contains("multi-pr"));
     }
 
     #[test]
-    fn multi_pr_strategy_mentions_triage() {
-        let strategy = MultiPrStrategy::new(config_with_mode(PrMode::MultiPr));
-        let plan = strategy.plan_iteration(2);
-        assert!(plan.description.contains("triage"));
+    fn multi_pr_strategy_no_actionable_pr_falls_through() {
+        // Empty mock → select_action returns NoActionablePr.
+        let cfg = config_with_mode(PrMode::MultiPr);
+        let triage = mock_triage(cfg.clone());
+        let strategy = MultiPrStrategy::with_triage(cfg, triage);
+        let plan = strategy.plan_iteration(1);
+        assert_eq!(plan.mode, PrMode::MultiPr);
+        assert!(plan.prompt_override.is_none());
+        // Description should mention issue work fall-through.
+        assert!(plan.description.contains("issue work") || plan.description.contains("no actionable"));
+    }
+
+    #[test]
+    fn multi_pr_strategy_checks_failing_returns_prompt_override() {
+        use crate::pr_manager::{MockPrLifecycleTriage, PrInfo, PrTriage, PrTriageState, PrWithState};
+        let cfg = config_with_mode(PrMode::MultiPr);
+        let pr = PrInfo { number: 7, url: "https://example.com/pull/7".into(), title: "Fix foo".into() };
+        let mut mock = MockPrLifecycleTriage::new();
+        mock.open_prs = vec![pr.clone()];
+        mock.states.insert(7, PrWithState {
+            pr,
+            state: PrTriageState::ChecksFailing,
+            created_at: "2026-01-01T00:00:00Z".into(),
+        });
+        let triage = PrTriage::new(cfg.clone(), mock);
+        let strategy = MultiPrStrategy::with_triage(cfg, triage);
+        let plan = strategy.plan_iteration(1);
+        assert!(plan.prompt_override.is_some());
+        assert!(plan.prompt_override.unwrap().contains("CI checks"));
+    }
+
+    #[test]
+    fn multi_pr_strategy_changes_requested_returns_prompt_override() {
+        use crate::pr_manager::{MockPrLifecycleTriage, PrInfo, PrTriage, PrTriageState, PrWithState};
+        let cfg = config_with_mode(PrMode::MultiPr);
+        let pr = PrInfo { number: 8, url: "https://example.com/pull/8".into(), title: "Add bar".into() };
+        let mut mock = MockPrLifecycleTriage::new();
+        mock.open_prs = vec![pr.clone()];
+        mock.states.insert(8, PrWithState {
+            pr,
+            state: PrTriageState::ChangesRequested,
+            created_at: "2026-01-01T00:00:00Z".into(),
+        });
+        let triage = PrTriage::new(cfg.clone(), mock);
+        let strategy = MultiPrStrategy::with_triage(cfg, triage);
+        let plan = strategy.plan_iteration(1);
+        assert!(plan.prompt_override.is_some());
+        assert!(plan.prompt_override.unwrap().contains("review comment"));
+    }
+
+    #[test]
+    fn multi_pr_strategy_ready_to_merge_human_review_required() {
+        use crate::pr_manager::{MockPrLifecycleTriage, PrInfo, PrTriage, PrTriageState, PrWithState};
+        let mut cfg = config_with_mode(PrMode::MultiPr);
+        cfg.require_human_review = true;
+        let pr = PrInfo { number: 9, url: "https://example.com/pull/9".into(), title: "Ship it".into() };
+        let mut mock = MockPrLifecycleTriage::new();
+        mock.open_prs = vec![pr.clone()];
+        mock.states.insert(9, PrWithState {
+            pr,
+            state: PrTriageState::ReadyToMerge,
+            created_at: "2026-01-01T00:00:00Z".into(),
+        });
+        let triage = PrTriage::new(cfg.clone(), mock);
+        let strategy = MultiPrStrategy::with_triage(cfg, triage);
+        let plan = strategy.plan_iteration(1);
+        // Blocked on human review → no prompt override, falls through
+        assert!(plan.prompt_override.is_none());
+        assert!(plan.description.contains("human review"));
+    }
+
+    #[test]
+    fn multi_pr_strategy_skipped_pr_falls_through() {
+        use crate::pr_manager::{MockPrLifecycleTriage, PrInfo, PrTriage, PrTriageState, PrWithState};
+        let cfg = config_with_mode(PrMode::MultiPr);
+        let pr = PrInfo { number: 10, url: "https://example.com/pull/10".into(), title: "WIP".into() };
+        let mut mock = MockPrLifecycleTriage::new();
+        mock.open_prs = vec![pr.clone()];
+        mock.states.insert(10, PrWithState {
+            pr,
+            state: PrTriageState::Skipped { reason: "wip".into() },
+            created_at: "2026-01-01T00:00:00Z".into(),
+        });
+        let triage = PrTriage::new(cfg.clone(), mock);
+        let strategy = MultiPrStrategy::with_triage(cfg, triage);
+        let plan = strategy.plan_iteration(1);
+        // All PRs skipped → no prompt override
+        assert!(plan.prompt_override.is_none());
     }
 
     // ── build_strategy ───────────────────────────────────────────────────────
@@ -215,13 +367,6 @@ mod tests {
         let strategy = build_strategy(config_with_mode(PrMode::SinglePr));
         let plan = strategy.plan_iteration(1);
         assert_eq!(plan.mode, PrMode::SinglePr);
-    }
-
-    #[test]
-    fn build_strategy_multi_pr() {
-        let strategy = build_strategy(config_with_mode(PrMode::MultiPr));
-        let plan = strategy.plan_iteration(1);
-        assert_eq!(plan.mode, PrMode::MultiPr);
     }
 
     // ── Iteration number propagation ─────────────────────────────────────────

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -1,5 +1,6 @@
 use crate::config::Provider as ProviderKind;
 use crate::error::LooperError;
+use crate::security::redact_secrets;
 use std::time::Duration;
 use tracing::trace;
 
@@ -140,6 +141,7 @@ fn run_provider_process(
             let reader = BufReader::new(stdout_pipe);
             let mut captured = String::new();
             for line in reader.lines().flatten() {
+                let line = redact_secrets(&line);
                 println!("[stdout] {}", line);
                 trace!(stream = "stdout", "{}", line);
                 captured.push_str(&line);
@@ -151,6 +153,7 @@ fn run_provider_process(
         let mut stderr_captured = String::new();
         let stderr_reader = BufReader::new(stderr_pipe);
         for line in stderr_reader.lines().flatten() {
+            let line = redact_secrets(&line);
             eprintln!("[stderr] {}", line);
             trace!(stream = "stderr", "{}", line);
             stderr_captured.push_str(&line);
@@ -182,8 +185,8 @@ fn run_provider_process(
 
         Ok(ExecutionResult {
             exit_code: output.status.code(),
-            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            stdout: redact_secrets(&String::from_utf8_lossy(&output.stdout)),
+            stderr: redact_secrets(&String::from_utf8_lossy(&output.stderr)),
             duration,
         })
     }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -60,9 +60,21 @@ pub fn build_adapter(
     timeout_secs: Option<u64>,
 ) -> Box<dyn ProviderAdapter> {
     match kind {
-        ProviderKind::Claude => Box::new(ClaudeAdapter { stream_output, working_dir, timeout_secs }),
-        ProviderKind::Copilot => Box::new(CopilotAdapter { stream_output, working_dir, timeout_secs }),
-        ProviderKind::Codex => Box::new(CodexAdapter { stream_output, working_dir, timeout_secs }),
+        ProviderKind::Claude => Box::new(ClaudeAdapter {
+            stream_output,
+            working_dir,
+            timeout_secs,
+        }),
+        ProviderKind::Copilot => Box::new(CopilotAdapter {
+            stream_output,
+            working_dir,
+            timeout_secs,
+        }),
+        ProviderKind::Codex => Box::new(CodexAdapter {
+            stream_output,
+            working_dir,
+            timeout_secs,
+        }),
     }
 }
 
@@ -128,7 +140,13 @@ impl ProviderAdapter for CodexAdapter {
     }
 
     fn execute(&self, prompt: &str) -> Result<ExecutionResult, LooperError> {
-        run_provider_process("codex", &[prompt], self.stream_output, self.working_dir.as_deref(), self.timeout_secs)
+        run_provider_process(
+            "codex",
+            &[prompt],
+            self.stream_output,
+            self.working_dir.as_deref(),
+            self.timeout_secs,
+        )
     }
 }
 
@@ -215,10 +233,14 @@ fn run_provider_process(
         }
 
         let stdout_captured = stdout_handle.join().unwrap_or_default();
-        let status = child.lock().unwrap().wait().map_err(|e| LooperError::ProviderSpawn {
-            binary: binary.to_string(),
-            source: e,
-        })?;
+        let status = child
+            .lock()
+            .unwrap()
+            .wait()
+            .map_err(|e| LooperError::ProviderSpawn {
+                binary: binary.to_string(),
+                source: e,
+            })?;
         let duration = start.elapsed();
 
         if timeout_fired.load(Ordering::Relaxed) {
@@ -392,9 +414,18 @@ pub mod tests {
 
     #[test]
     fn build_adapter_returns_correct_names() {
-        assert_eq!(build_adapter(&ProviderKind::Claude, false, None, None).name(), "claude");
-        assert_eq!(build_adapter(&ProviderKind::Copilot, false, None, None).name(), "copilot");
-        assert_eq!(build_adapter(&ProviderKind::Codex, false, None, None).name(), "codex");
+        assert_eq!(
+            build_adapter(&ProviderKind::Claude, false, None, None).name(),
+            "claude"
+        );
+        assert_eq!(
+            build_adapter(&ProviderKind::Copilot, false, None, None).name(),
+            "copilot"
+        );
+        assert_eq!(
+            build_adapter(&ProviderKind::Codex, false, None, None).name(),
+            "codex"
+        );
     }
 
     // ── Timeout adapter ───────────────────────────────────────────────────────
@@ -425,13 +456,7 @@ pub mod tests {
     #[cfg(unix)]
     fn non_streaming_process_is_killed_on_timeout() {
         // sleep for 60s, but timeout after 1s
-        let result = super::run_provider_process(
-            "sleep",
-            &["60"],
-            false,
-            None,
-            Some(1),
-        );
+        let result = super::run_provider_process("sleep", &["60"], false, None, Some(1));
         match result {
             Err(LooperError::ProviderTimeout { timeout_secs, .. }) => {
                 assert_eq!(timeout_secs, 1);
@@ -444,13 +469,7 @@ pub mod tests {
     #[test]
     #[cfg(unix)]
     fn non_streaming_fast_process_is_not_timed_out() {
-        let result = super::run_provider_process(
-            "echo",
-            &["hello"],
-            false,
-            None,
-            Some(5),
-        );
+        let result = super::run_provider_process("echo", &["hello"], false, None, Some(5));
         match result {
             Ok(r) => assert!(r.succeeded(), "expected success, got: {:?}", r.exit_code),
             Err(e) => panic!("expected Ok, got: {e}"),

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -7,6 +7,27 @@ use std::sync::Arc;
 use std::time::Duration;
 use tracing::trace;
 
+/// Approved provider executables.
+///
+/// Only binaries in this list may be spawned by the loop engine.  This
+/// allowlist is enforced at runtime in non-test builds by
+/// [`check_allowed_binary`] to prevent arbitrary command injection in case of
+/// future refactors that relax the hardcoded binary names inside adapters.
+pub const ALLOWED_PROVIDER_BINARIES: &[&str] = &["claude", "gh", "codex"];
+
+/// Return `Ok(())` if `binary` is in [`ALLOWED_PROVIDER_BINARIES`], or a
+/// [`LooperError::DisallowedExecutable`] if it is not.
+pub fn check_allowed_binary(binary: &str) -> Result<(), LooperError> {
+    if ALLOWED_PROVIDER_BINARIES.contains(&binary) {
+        Ok(())
+    } else {
+        Err(LooperError::DisallowedExecutable {
+            binary: binary.to_string(),
+            allowed: ALLOWED_PROVIDER_BINARIES.join(", "),
+        })
+    }
+}
+
 /// Outcome of a single provider execution.
 #[derive(Debug, Clone)]
 pub struct ExecutionResult {
@@ -171,6 +192,12 @@ fn run_provider_process(
     use std::io::{BufRead, BufReader};
     use std::process::{Command, Stdio};
     use std::time::Instant;
+
+    // Enforce the executable allowlist in non-test builds.  Test builds bypass
+    // this so unit tests can spawn utilities like `sleep` or `echo` to exercise
+    // timeout/streaming behaviour without requiring real provider CLIs.
+    #[cfg(not(test))]
+    check_allowed_binary(binary)?;
 
     let start = Instant::now();
 
@@ -444,6 +471,62 @@ pub mod tests {
                 timeout_secs: 1,
             })
         }
+    }
+
+    // ── check_allowed_binary ──────────────────────────────────────────────────
+
+    #[test]
+    fn allowlist_accepts_claude() {
+        assert!(super::check_allowed_binary("claude").is_ok());
+    }
+
+    #[test]
+    fn allowlist_accepts_gh() {
+        assert!(super::check_allowed_binary("gh").is_ok());
+    }
+
+    #[test]
+    fn allowlist_accepts_codex() {
+        assert!(super::check_allowed_binary("codex").is_ok());
+    }
+
+    #[test]
+    fn allowlist_rejects_disallowed_binary() {
+        let err = super::check_allowed_binary("rm").unwrap_err();
+        assert!(
+            matches!(err, LooperError::DisallowedExecutable { ref binary, .. } if binary == "rm")
+        );
+    }
+
+    #[test]
+    fn allowlist_rejects_arbitrary_path() {
+        let err = super::check_allowed_binary("/usr/bin/bash").unwrap_err();
+        assert!(matches!(err, LooperError::DisallowedExecutable { .. }));
+    }
+
+    #[test]
+    fn disallowed_executable_error_message_lists_permitted_binaries() {
+        let err = super::check_allowed_binary("bad-binary").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("bad-binary"));
+        assert!(msg.contains("claude"));
+        assert!(msg.contains("gh"));
+        assert!(msg.contains("codex"));
+    }
+
+    #[test]
+    fn all_adapter_binaries_are_in_allowlist() {
+        // Ensure every binary used by the three concrete adapters is covered.
+        // This test will fail if a new adapter is added without updating the allowlist.
+        assert!(
+            super::check_allowed_binary("claude").is_ok(),
+            "claude missing"
+        );
+        assert!(super::check_allowed_binary("gh").is_ok(), "gh missing");
+        assert!(
+            super::check_allowed_binary("codex").is_ok(),
+            "codex missing"
+        );
     }
 
     // ── run_provider_process timeout (real subprocess) ────────────────────────

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -410,6 +410,19 @@ pub mod tests {
                 }),
             }
         }
+
+        /// Construct a fake adapter that exits with a specific exit code.
+        pub fn with_exit_code(name: &str, code: i32) -> Self {
+            Self {
+                name: name.to_string(),
+                result: Ok(ExecutionResult {
+                    exit_code: Some(code),
+                    stdout: String::new(),
+                    stderr: format!("exit {code}"),
+                    duration: Duration::from_millis(5),
+                }),
+            }
+        }
     }
 
     impl ProviderAdapter for FakeAdapter {

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -158,7 +158,7 @@ fn run_provider_process(
         let stdout_handle = std::thread::spawn(move || {
             let reader = BufReader::new(stdout_pipe);
             let mut captured = String::new();
-            for line in reader.lines().flatten() {
+            for line in reader.lines().map_while(Result::ok) {
                 let line = redact_secrets(&line);
                 println!("[stdout] {}", line);
                 trace!(stream = "stdout", "{}", line);
@@ -170,7 +170,7 @@ fn run_provider_process(
 
         let mut stderr_captured = String::new();
         let stderr_reader = BufReader::new(stderr_pipe);
-        for line in stderr_reader.lines().flatten() {
+        for line in stderr_reader.lines().map_while(Result::ok) {
             let line = redact_secrets(&line);
             eprintln!("[stderr] {}", line);
             trace!(stream = "stderr", "{}", line);

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -1,6 +1,7 @@
 use crate::config::Provider as ProviderKind;
 use crate::error::LooperError;
 use std::time::Duration;
+use tracing::trace;
 
 /// Outcome of a single provider execution.
 #[derive(Debug, Clone)]
@@ -38,17 +39,22 @@ pub trait ProviderAdapter: Send + Sync {
 // ── Adapter constructors ──────────────────────────────────────────────────────
 
 /// Build the concrete adapter for the given `ProviderKind`.
-pub fn build_adapter(kind: &ProviderKind) -> Box<dyn ProviderAdapter> {
+///
+/// When `stream_output` is `true`, each adapter will print tagged stdout/stderr
+/// lines to the terminal in real time as the provider runs.
+pub fn build_adapter(kind: &ProviderKind, stream_output: bool) -> Box<dyn ProviderAdapter> {
     match kind {
-        ProviderKind::Claude => Box::new(ClaudeAdapter),
-        ProviderKind::Copilot => Box::new(CopilotAdapter),
-        ProviderKind::Codex => Box::new(CodexAdapter),
+        ProviderKind::Claude => Box::new(ClaudeAdapter { stream_output }),
+        ProviderKind::Copilot => Box::new(CopilotAdapter { stream_output }),
+        ProviderKind::Codex => Box::new(CodexAdapter { stream_output }),
     }
 }
 
 // ── Claude Code CLI adapter ───────────────────────────────────────────────────
 
-pub struct ClaudeAdapter;
+pub struct ClaudeAdapter {
+    pub stream_output: bool,
+}
 
 impl ProviderAdapter for ClaudeAdapter {
     fn name(&self) -> &str {
@@ -56,13 +62,19 @@ impl ProviderAdapter for ClaudeAdapter {
     }
 
     fn execute(&self, prompt: &str) -> Result<ExecutionResult, LooperError> {
-        run_provider_process("claude", &["-p", "--dangerously-skip-permissions", prompt])
+        run_provider_process(
+            "claude",
+            &["-p", "--dangerously-skip-permissions", prompt],
+            self.stream_output,
+        )
     }
 }
 
 // ── GitHub Copilot CLI adapter ────────────────────────────────────────────────
 
-pub struct CopilotAdapter;
+pub struct CopilotAdapter {
+    pub stream_output: bool,
+}
 
 impl ProviderAdapter for CopilotAdapter {
     fn name(&self) -> &str {
@@ -70,13 +82,19 @@ impl ProviderAdapter for CopilotAdapter {
     }
 
     fn execute(&self, prompt: &str) -> Result<ExecutionResult, LooperError> {
-        run_provider_process("gh", &["copilot", "suggest", "-t", "shell", prompt])
+        run_provider_process(
+            "gh",
+            &["copilot", "suggest", "-t", "shell", prompt],
+            self.stream_output,
+        )
     }
 }
 
 // ── Codex CLI adapter ─────────────────────────────────────────────────────────
 
-pub struct CodexAdapter;
+pub struct CodexAdapter {
+    pub stream_output: bool,
+}
 
 impl ProviderAdapter for CodexAdapter {
     fn name(&self) -> &str {
@@ -84,33 +102,91 @@ impl ProviderAdapter for CodexAdapter {
     }
 
     fn execute(&self, prompt: &str) -> Result<ExecutionResult, LooperError> {
-        run_provider_process("codex", &[prompt])
+        run_provider_process("codex", &[prompt], self.stream_output)
     }
 }
 
 // ── Shared helper ─────────────────────────────────────────────────────────────
 
-fn run_provider_process(binary: &str, args: &[&str]) -> Result<ExecutionResult, LooperError> {
-    use std::process::Command;
+/// Run a provider process, optionally streaming stdout/stderr to the terminal
+/// as tagged lines (`[stdout]` / `[stderr]`).
+fn run_provider_process(
+    binary: &str,
+    args: &[&str],
+    stream: bool,
+) -> Result<ExecutionResult, LooperError> {
+    use std::io::{BufRead, BufReader};
+    use std::process::{Command, Stdio};
     use std::time::Instant;
 
     let start = Instant::now();
-    let output =
-        Command::new(binary)
+
+    if stream {
+        let mut child = Command::new(binary)
+            .args(args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| LooperError::ProviderSpawn {
+                binary: binary.to_string(),
+                source: e,
+            })?;
+
+        let stdout_pipe = child.stdout.take().expect("stdout piped");
+        let stderr_pipe = child.stderr.take().expect("stderr piped");
+
+        // Read stdout on a background thread so we don't deadlock on stderr.
+        let stdout_handle = std::thread::spawn(move || {
+            let reader = BufReader::new(stdout_pipe);
+            let mut captured = String::new();
+            for line in reader.lines().flatten() {
+                println!("[stdout] {}", line);
+                trace!(stream = "stdout", "{}", line);
+                captured.push_str(&line);
+                captured.push('\n');
+            }
+            captured
+        });
+
+        let mut stderr_captured = String::new();
+        let stderr_reader = BufReader::new(stderr_pipe);
+        for line in stderr_reader.lines().flatten() {
+            eprintln!("[stderr] {}", line);
+            trace!(stream = "stderr", "{}", line);
+            stderr_captured.push_str(&line);
+            stderr_captured.push('\n');
+        }
+
+        let stdout_captured = stdout_handle.join().unwrap_or_default();
+        let status = child.wait().map_err(|e| LooperError::ProviderSpawn {
+            binary: binary.to_string(),
+            source: e,
+        })?;
+        let duration = start.elapsed();
+
+        Ok(ExecutionResult {
+            exit_code: status.code(),
+            stdout: stdout_captured,
+            stderr: stderr_captured,
+            duration,
+        })
+    } else {
+        let output = Command::new(binary)
             .args(args)
             .output()
             .map_err(|e| LooperError::ProviderSpawn {
                 binary: binary.to_string(),
                 source: e,
             })?;
-    let duration = start.elapsed();
+        let duration = start.elapsed();
 
-    Ok(ExecutionResult {
-        exit_code: output.status.code(),
-        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-        duration,
-    })
+        Ok(ExecutionResult {
+            exit_code: output.status.code(),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            duration,
+        })
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -204,8 +280,8 @@ pub mod tests {
 
     #[test]
     fn build_adapter_returns_correct_names() {
-        assert_eq!(build_adapter(&ProviderKind::Claude).name(), "claude");
-        assert_eq!(build_adapter(&ProviderKind::Copilot).name(), "copilot");
-        assert_eq!(build_adapter(&ProviderKind::Codex).name(), "codex");
+        assert_eq!(build_adapter(&ProviderKind::Claude, false).name(), "claude");
+        assert_eq!(build_adapter(&ProviderKind::Copilot, false).name(), "copilot");
+        assert_eq!(build_adapter(&ProviderKind::Codex, false).name(), "codex");
     }
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -1,6 +1,7 @@
 use crate::config::Provider as ProviderKind;
 use crate::error::LooperError;
 use crate::security::redact_secrets;
+use std::path::PathBuf;
 use std::time::Duration;
 use tracing::trace;
 
@@ -43,11 +44,18 @@ pub trait ProviderAdapter: Send + Sync {
 ///
 /// When `stream_output` is `true`, each adapter will print tagged stdout/stderr
 /// lines to the terminal in real time as the provider runs.
-pub fn build_adapter(kind: &ProviderKind, stream_output: bool) -> Box<dyn ProviderAdapter> {
+///
+/// `working_dir` overrides the subprocess working directory.  When `None` the
+/// subprocess inherits the current working directory of the code-looper process.
+pub fn build_adapter(
+    kind: &ProviderKind,
+    stream_output: bool,
+    working_dir: Option<PathBuf>,
+) -> Box<dyn ProviderAdapter> {
     match kind {
-        ProviderKind::Claude => Box::new(ClaudeAdapter { stream_output }),
-        ProviderKind::Copilot => Box::new(CopilotAdapter { stream_output }),
-        ProviderKind::Codex => Box::new(CodexAdapter { stream_output }),
+        ProviderKind::Claude => Box::new(ClaudeAdapter { stream_output, working_dir }),
+        ProviderKind::Copilot => Box::new(CopilotAdapter { stream_output, working_dir }),
+        ProviderKind::Codex => Box::new(CodexAdapter { stream_output, working_dir }),
     }
 }
 
@@ -55,6 +63,7 @@ pub fn build_adapter(kind: &ProviderKind, stream_output: bool) -> Box<dyn Provid
 
 pub struct ClaudeAdapter {
     pub stream_output: bool,
+    pub working_dir: Option<PathBuf>,
 }
 
 impl ProviderAdapter for ClaudeAdapter {
@@ -67,6 +76,7 @@ impl ProviderAdapter for ClaudeAdapter {
             "claude",
             &["-p", "--dangerously-skip-permissions", prompt],
             self.stream_output,
+            self.working_dir.as_deref(),
         )
     }
 }
@@ -75,6 +85,7 @@ impl ProviderAdapter for ClaudeAdapter {
 
 pub struct CopilotAdapter {
     pub stream_output: bool,
+    pub working_dir: Option<PathBuf>,
 }
 
 impl ProviderAdapter for CopilotAdapter {
@@ -87,6 +98,7 @@ impl ProviderAdapter for CopilotAdapter {
             "gh",
             &["copilot", "suggest", "-t", "shell", prompt],
             self.stream_output,
+            self.working_dir.as_deref(),
         )
     }
 }
@@ -95,6 +107,7 @@ impl ProviderAdapter for CopilotAdapter {
 
 pub struct CodexAdapter {
     pub stream_output: bool,
+    pub working_dir: Option<PathBuf>,
 }
 
 impl ProviderAdapter for CodexAdapter {
@@ -103,7 +116,7 @@ impl ProviderAdapter for CodexAdapter {
     }
 
     fn execute(&self, prompt: &str) -> Result<ExecutionResult, LooperError> {
-        run_provider_process("codex", &[prompt], self.stream_output)
+        run_provider_process("codex", &[prompt], self.stream_output, self.working_dir.as_deref())
     }
 }
 
@@ -111,10 +124,14 @@ impl ProviderAdapter for CodexAdapter {
 
 /// Run a provider process, optionally streaming stdout/stderr to the terminal
 /// as tagged lines (`[stdout]` / `[stderr]`).
+///
+/// `working_dir` sets the subprocess working directory.  `None` inherits the
+/// current working directory of the code-looper process.
 fn run_provider_process(
     binary: &str,
     args: &[&str],
     stream: bool,
+    working_dir: Option<&std::path::Path>,
 ) -> Result<ExecutionResult, LooperError> {
     use std::io::{BufRead, BufReader};
     use std::process::{Command, Stdio};
@@ -123,11 +140,12 @@ fn run_provider_process(
     let start = Instant::now();
 
     if stream {
-        let mut child = Command::new(binary)
-            .args(args)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
+        let mut cmd = Command::new(binary);
+        cmd.args(args).stdout(Stdio::piped()).stderr(Stdio::piped());
+        if let Some(dir) = working_dir {
+            cmd.current_dir(dir);
+        }
+        let mut child = cmd.spawn()
             .map_err(|e| LooperError::ProviderSpawn {
                 binary: binary.to_string(),
                 source: e,
@@ -174,10 +192,12 @@ fn run_provider_process(
             duration,
         })
     } else {
-        let output = Command::new(binary)
-            .args(args)
-            .output()
-            .map_err(|e| LooperError::ProviderSpawn {
+        let mut cmd = Command::new(binary);
+        cmd.args(args);
+        if let Some(dir) = working_dir {
+            cmd.current_dir(dir);
+        }
+        let output = cmd.output().map_err(|e| LooperError::ProviderSpawn {
                 binary: binary.to_string(),
                 source: e,
             })?;
@@ -283,8 +303,8 @@ pub mod tests {
 
     #[test]
     fn build_adapter_returns_correct_names() {
-        assert_eq!(build_adapter(&ProviderKind::Claude, false).name(), "claude");
-        assert_eq!(build_adapter(&ProviderKind::Copilot, false).name(), "copilot");
-        assert_eq!(build_adapter(&ProviderKind::Codex, false).name(), "codex");
+        assert_eq!(build_adapter(&ProviderKind::Claude, false, None).name(), "claude");
+        assert_eq!(build_adapter(&ProviderKind::Copilot, false, None).name(), "copilot");
+        assert_eq!(build_adapter(&ProviderKind::Codex, false, None).name(), "codex");
     }
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -2,6 +2,8 @@ use crate::config::Provider as ProviderKind;
 use crate::error::LooperError;
 use crate::security::redact_secrets;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 use tracing::trace;
 
@@ -47,15 +49,20 @@ pub trait ProviderAdapter: Send + Sync {
 ///
 /// `working_dir` overrides the subprocess working directory.  When `None` the
 /// subprocess inherits the current working directory of the code-looper process.
+///
+/// `timeout_secs` sets a per-invocation wall-clock deadline.  When the provider
+/// does not exit within `timeout_secs` seconds, the process is killed and
+/// `LooperError::ProviderTimeout` is returned.  `None` means no timeout.
 pub fn build_adapter(
     kind: &ProviderKind,
     stream_output: bool,
     working_dir: Option<PathBuf>,
+    timeout_secs: Option<u64>,
 ) -> Box<dyn ProviderAdapter> {
     match kind {
-        ProviderKind::Claude => Box::new(ClaudeAdapter { stream_output, working_dir }),
-        ProviderKind::Copilot => Box::new(CopilotAdapter { stream_output, working_dir }),
-        ProviderKind::Codex => Box::new(CodexAdapter { stream_output, working_dir }),
+        ProviderKind::Claude => Box::new(ClaudeAdapter { stream_output, working_dir, timeout_secs }),
+        ProviderKind::Copilot => Box::new(CopilotAdapter { stream_output, working_dir, timeout_secs }),
+        ProviderKind::Codex => Box::new(CodexAdapter { stream_output, working_dir, timeout_secs }),
     }
 }
 
@@ -64,6 +71,7 @@ pub fn build_adapter(
 pub struct ClaudeAdapter {
     pub stream_output: bool,
     pub working_dir: Option<PathBuf>,
+    pub timeout_secs: Option<u64>,
 }
 
 impl ProviderAdapter for ClaudeAdapter {
@@ -77,6 +85,7 @@ impl ProviderAdapter for ClaudeAdapter {
             &["-p", "--dangerously-skip-permissions", prompt],
             self.stream_output,
             self.working_dir.as_deref(),
+            self.timeout_secs,
         )
     }
 }
@@ -86,6 +95,7 @@ impl ProviderAdapter for ClaudeAdapter {
 pub struct CopilotAdapter {
     pub stream_output: bool,
     pub working_dir: Option<PathBuf>,
+    pub timeout_secs: Option<u64>,
 }
 
 impl ProviderAdapter for CopilotAdapter {
@@ -99,6 +109,7 @@ impl ProviderAdapter for CopilotAdapter {
             &["copilot", "suggest", "-t", "shell", prompt],
             self.stream_output,
             self.working_dir.as_deref(),
+            self.timeout_secs,
         )
     }
 }
@@ -108,6 +119,7 @@ impl ProviderAdapter for CopilotAdapter {
 pub struct CodexAdapter {
     pub stream_output: bool,
     pub working_dir: Option<PathBuf>,
+    pub timeout_secs: Option<u64>,
 }
 
 impl ProviderAdapter for CodexAdapter {
@@ -116,7 +128,7 @@ impl ProviderAdapter for CodexAdapter {
     }
 
     fn execute(&self, prompt: &str) -> Result<ExecutionResult, LooperError> {
-        run_provider_process("codex", &[prompt], self.stream_output, self.working_dir.as_deref())
+        run_provider_process("codex", &[prompt], self.stream_output, self.working_dir.as_deref(), self.timeout_secs)
     }
 }
 
@@ -127,11 +139,16 @@ impl ProviderAdapter for CodexAdapter {
 ///
 /// `working_dir` sets the subprocess working directory.  `None` inherits the
 /// current working directory of the code-looper process.
+///
+/// `timeout_secs` sets a maximum wall-clock duration for the provider.  When
+/// the timeout fires the process is killed and `LooperError::ProviderTimeout`
+/// is returned.  `None` means no timeout.
 fn run_provider_process(
     binary: &str,
     args: &[&str],
     stream: bool,
     working_dir: Option<&std::path::Path>,
+    timeout_secs: Option<u64>,
 ) -> Result<ExecutionResult, LooperError> {
     use std::io::{BufRead, BufReader};
     use std::process::{Command, Stdio};
@@ -145,14 +162,33 @@ fn run_provider_process(
         if let Some(dir) = working_dir {
             cmd.current_dir(dir);
         }
-        let mut child = cmd.spawn()
-            .map_err(|e| LooperError::ProviderSpawn {
-                binary: binary.to_string(),
-                source: e,
-            })?;
+        let mut child = cmd.spawn().map_err(|e| LooperError::ProviderSpawn {
+            binary: binary.to_string(),
+            source: e,
+        })?;
 
         let stdout_pipe = child.stdout.take().expect("stdout piped");
         let stderr_pipe = child.stderr.take().expect("stderr piped");
+
+        // Wrap child in Arc<Mutex> so the optional watchdog thread can kill it.
+        let child = std::sync::Arc::new(std::sync::Mutex::new(child));
+        let timeout_fired = Arc::new(AtomicBool::new(false));
+
+        if let Some(secs) = timeout_secs {
+            let child_clone = Arc::clone(&child);
+            let fired = Arc::clone(&timeout_fired);
+            std::thread::spawn(move || {
+                std::thread::sleep(Duration::from_secs(secs));
+                if let Ok(mut c) = child_clone.lock() {
+                    // Only mark as timed-out when kill() succeeds.  If the child
+                    // already exited and was reaped, kill() returns an error and we
+                    // leave `fired` false, avoiding a false-positive timeout report.
+                    if c.kill().is_ok() {
+                        fired.store(true, Ordering::Relaxed);
+                    }
+                }
+            });
+        }
 
         // Read stdout on a background thread so we don't deadlock on stderr.
         let stdout_handle = std::thread::spawn(move || {
@@ -179,11 +215,18 @@ fn run_provider_process(
         }
 
         let stdout_captured = stdout_handle.join().unwrap_or_default();
-        let status = child.wait().map_err(|e| LooperError::ProviderSpawn {
+        let status = child.lock().unwrap().wait().map_err(|e| LooperError::ProviderSpawn {
             binary: binary.to_string(),
             source: e,
         })?;
         let duration = start.elapsed();
+
+        if timeout_fired.load(Ordering::Relaxed) {
+            return Err(LooperError::ProviderTimeout {
+                binary: binary.to_string(),
+                timeout_secs: timeout_secs.unwrap_or(0),
+            });
+        }
 
         Ok(ExecutionResult {
             exit_code: status.code(),
@@ -193,20 +236,66 @@ fn run_provider_process(
         })
     } else {
         let mut cmd = Command::new(binary);
-        cmd.args(args);
+        cmd.args(args).stdout(Stdio::piped()).stderr(Stdio::piped());
         if let Some(dir) = working_dir {
             cmd.current_dir(dir);
         }
-        let output = cmd.output().map_err(|e| LooperError::ProviderSpawn {
-                binary: binary.to_string(),
-                source: e,
-            })?;
+        let mut child = cmd.spawn().map_err(|e| LooperError::ProviderSpawn {
+            binary: binary.to_string(),
+            source: e,
+        })?;
+
+        let stdout_pipe = child.stdout.take().expect("stdout piped");
+        let stderr_pipe = child.stderr.take().expect("stderr piped");
+
+        // Wrap child so the optional watchdog can kill it.
+        let child = Arc::new(std::sync::Mutex::new(child));
+        let timeout_fired = Arc::new(AtomicBool::new(false));
+
+        if let Some(secs) = timeout_secs {
+            let child_clone = Arc::clone(&child);
+            let fired = Arc::clone(&timeout_fired);
+            std::thread::spawn(move || {
+                std::thread::sleep(Duration::from_secs(secs));
+                if let Ok(mut c) = child_clone.lock() {
+                    let _ = c.kill();
+                }
+                fired.store(true, Ordering::Relaxed);
+            });
+        }
+
+        // Drain both pipes on background threads to prevent deadlock when the
+        // child fills its pipe buffers.  The drain threads block until EOF,
+        // which happens when the child exits or is killed by the watchdog.
+        let stdout_handle = std::thread::spawn(move || {
+            use std::io::Read;
+            let mut buf = Vec::new();
+            let _ = { stdout_pipe }.read_to_end(&mut buf);
+            buf
+        });
+        let stderr_handle = std::thread::spawn(move || {
+            use std::io::Read;
+            let mut buf = Vec::new();
+            let _ = { stderr_pipe }.read_to_end(&mut buf);
+            buf
+        });
+
+        let stdout_bytes = stdout_handle.join().unwrap_or_default();
+        let stderr_bytes = stderr_handle.join().unwrap_or_default();
+        let exit_code = child.lock().unwrap().wait().ok().and_then(|s| s.code());
         let duration = start.elapsed();
 
+        if timeout_fired.load(Ordering::Relaxed) {
+            return Err(LooperError::ProviderTimeout {
+                binary: binary.to_string(),
+                timeout_secs: timeout_secs.unwrap_or(0),
+            });
+        }
+
         Ok(ExecutionResult {
-            exit_code: output.status.code(),
-            stdout: redact_secrets(&String::from_utf8_lossy(&output.stdout)),
-            stderr: redact_secrets(&String::from_utf8_lossy(&output.stderr)),
+            exit_code,
+            stdout: redact_secrets(&String::from_utf8_lossy(&stdout_bytes)),
+            stderr: redact_secrets(&String::from_utf8_lossy(&stderr_bytes)),
             duration,
         })
     }
@@ -303,8 +392,68 @@ pub mod tests {
 
     #[test]
     fn build_adapter_returns_correct_names() {
-        assert_eq!(build_adapter(&ProviderKind::Claude, false, None).name(), "claude");
-        assert_eq!(build_adapter(&ProviderKind::Copilot, false, None).name(), "copilot");
-        assert_eq!(build_adapter(&ProviderKind::Codex, false, None).name(), "codex");
+        assert_eq!(build_adapter(&ProviderKind::Claude, false, None, None).name(), "claude");
+        assert_eq!(build_adapter(&ProviderKind::Copilot, false, None, None).name(), "copilot");
+        assert_eq!(build_adapter(&ProviderKind::Codex, false, None, None).name(), "codex");
+    }
+
+    // ── Timeout adapter ───────────────────────────────────────────────────────
+
+    /// Adapter that always returns ProviderTimeout (simulates a timed-out call).
+    pub struct TimeoutAdapter;
+
+    impl ProviderAdapter for TimeoutAdapter {
+        fn name(&self) -> &str {
+            "timeout-fake"
+        }
+
+        fn execute(&self, _prompt: &str) -> Result<ExecutionResult, LooperError> {
+            Err(LooperError::ProviderTimeout {
+                binary: "fake".to_string(),
+                timeout_secs: 1,
+            })
+        }
+    }
+
+    // ── run_provider_process timeout (real subprocess) ────────────────────────
+
+    /// Verify that a process that runs longer than the timeout is killed and
+    /// `ProviderTimeout` is returned (non-streaming path).
+    ///
+    /// Uses `sleep` as a long-running process; skipped on platforms without it.
+    #[test]
+    #[cfg(unix)]
+    fn non_streaming_process_is_killed_on_timeout() {
+        // sleep for 60s, but timeout after 1s
+        let result = super::run_provider_process(
+            "sleep",
+            &["60"],
+            false,
+            None,
+            Some(1),
+        );
+        match result {
+            Err(LooperError::ProviderTimeout { timeout_secs, .. }) => {
+                assert_eq!(timeout_secs, 1);
+            }
+            other => panic!("expected ProviderTimeout, got: {:?}", other),
+        }
+    }
+
+    /// Verify that a fast process completes normally without triggering timeout.
+    #[test]
+    #[cfg(unix)]
+    fn non_streaming_fast_process_is_not_timed_out() {
+        let result = super::run_provider_process(
+            "echo",
+            &["hello"],
+            false,
+            None,
+            Some(5),
+        );
+        match result {
+            Ok(r) => assert!(r.succeeded(), "expected success, got: {:?}", r.exit_code),
+            Err(e) => panic!("expected Ok, got: {e}"),
+        }
     }
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -74,27 +74,35 @@ pub trait ProviderAdapter: Send + Sync {
 /// `timeout_secs` sets a per-invocation wall-clock deadline.  When the provider
 /// does not exit within `timeout_secs` seconds, the process is killed and
 /// `LooperError::ProviderTimeout` is returned.  `None` means no timeout.
+///
+/// `extra_args` are additional CLI arguments appended after the adapter's
+/// hardcoded flags but before the prompt argument.  These are passed verbatim
+/// via `Command::arg` (no shell expansion).
 pub fn build_adapter(
     kind: &ProviderKind,
     stream_output: bool,
     working_dir: Option<PathBuf>,
     timeout_secs: Option<u64>,
+    extra_args: Vec<String>,
 ) -> Box<dyn ProviderAdapter> {
     match kind {
         ProviderKind::Claude => Box::new(ClaudeAdapter {
             stream_output,
             working_dir,
             timeout_secs,
+            extra_args,
         }),
         ProviderKind::Copilot => Box::new(CopilotAdapter {
             stream_output,
             working_dir,
             timeout_secs,
+            extra_args,
         }),
         ProviderKind::Codex => Box::new(CodexAdapter {
             stream_output,
             working_dir,
             timeout_secs,
+            extra_args,
         }),
     }
 }
@@ -105,6 +113,7 @@ pub struct ClaudeAdapter {
     pub stream_output: bool,
     pub working_dir: Option<PathBuf>,
     pub timeout_secs: Option<u64>,
+    pub extra_args: Vec<String>,
 }
 
 impl ProviderAdapter for ClaudeAdapter {
@@ -113,9 +122,13 @@ impl ProviderAdapter for ClaudeAdapter {
     }
 
     fn execute(&self, prompt: &str) -> Result<ExecutionResult, LooperError> {
+        let mut args: Vec<&str> = vec!["-p", "--dangerously-skip-permissions"];
+        let extra: Vec<&str> = self.extra_args.iter().map(String::as_str).collect();
+        args.extend_from_slice(&extra);
+        args.push(prompt);
         run_provider_process(
             "claude",
-            &["-p", "--dangerously-skip-permissions", prompt],
+            &args,
             self.stream_output,
             self.working_dir.as_deref(),
             self.timeout_secs,
@@ -129,6 +142,7 @@ pub struct CopilotAdapter {
     pub stream_output: bool,
     pub working_dir: Option<PathBuf>,
     pub timeout_secs: Option<u64>,
+    pub extra_args: Vec<String>,
 }
 
 impl ProviderAdapter for CopilotAdapter {
@@ -137,9 +151,13 @@ impl ProviderAdapter for CopilotAdapter {
     }
 
     fn execute(&self, prompt: &str) -> Result<ExecutionResult, LooperError> {
+        let mut args: Vec<&str> = vec!["copilot", "suggest", "-t", "shell"];
+        let extra: Vec<&str> = self.extra_args.iter().map(String::as_str).collect();
+        args.extend_from_slice(&extra);
+        args.push(prompt);
         run_provider_process(
             "gh",
-            &["copilot", "suggest", "-t", "shell", prompt],
+            &args,
             self.stream_output,
             self.working_dir.as_deref(),
             self.timeout_secs,
@@ -153,6 +171,7 @@ pub struct CodexAdapter {
     pub stream_output: bool,
     pub working_dir: Option<PathBuf>,
     pub timeout_secs: Option<u64>,
+    pub extra_args: Vec<String>,
 }
 
 impl ProviderAdapter for CodexAdapter {
@@ -161,9 +180,13 @@ impl ProviderAdapter for CodexAdapter {
     }
 
     fn execute(&self, prompt: &str) -> Result<ExecutionResult, LooperError> {
+        let mut args: Vec<&str> = Vec::new();
+        let extra: Vec<&str> = self.extra_args.iter().map(String::as_str).collect();
+        args.extend_from_slice(&extra);
+        args.push(prompt);
         run_provider_process(
             "codex",
-            &[prompt],
+            &args,
             self.stream_output,
             self.working_dir.as_deref(),
             self.timeout_secs,
@@ -442,15 +465,15 @@ pub mod tests {
     #[test]
     fn build_adapter_returns_correct_names() {
         assert_eq!(
-            build_adapter(&ProviderKind::Claude, false, None, None).name(),
+            build_adapter(&ProviderKind::Claude, false, None, None, vec![]).name(),
             "claude"
         );
         assert_eq!(
-            build_adapter(&ProviderKind::Copilot, false, None, None).name(),
+            build_adapter(&ProviderKind::Copilot, false, None, None, vec![]).name(),
             "copilot"
         );
         assert_eq!(
-            build_adapter(&ProviderKind::Codex, false, None, None).name(),
+            build_adapter(&ProviderKind::Codex, false, None, None, vec![]).name(),
             "codex"
         );
     }
@@ -527,6 +550,55 @@ pub mod tests {
             super::check_allowed_binary("codex").is_ok(),
             "codex missing"
         );
+    }
+
+    // ── extra_args threading ──────────────────────────────────────────────────
+
+    /// Verify that extra_args are included in the subprocess invocation by
+    /// using `echo` to print all args and checking the output contains them.
+    #[test]
+    #[cfg(unix)]
+    fn claude_adapter_includes_extra_args_in_invocation() {
+        // Use `echo` to print args rather than spawning real `claude`.
+        // We construct the adapter and verify arg order by calling run_provider_process
+        // directly with the expected expanded arg list.
+        let extra = vec!["--extra-flag".to_string(), "extra-value".to_string()];
+        let expected_args = [
+            "-p",
+            "--dangerously-skip-permissions",
+            "--extra-flag",
+            "extra-value",
+            "my-prompt",
+        ];
+        let result =
+            super::run_provider_process("echo", &expected_args, false, None, None).unwrap();
+        let stdout = result.stdout.trim().to_string();
+        // echo prints all args space-separated; verify the extra args appear in order
+        assert!(
+            stdout.contains("--extra-flag extra-value"),
+            "extra args not found in echo output: {stdout}"
+        );
+        assert!(stdout.contains("my-prompt"), "prompt missing: {stdout}");
+        drop(extra); // suppress unused warning
+    }
+
+    #[test]
+    fn extra_args_empty_by_default_in_build_adapter() {
+        // Just verify build_adapter accepts an empty extra_args vec without panic.
+        let adapter = build_adapter(&ProviderKind::Claude, false, None, None, vec![]);
+        assert_eq!(adapter.name(), "claude");
+    }
+
+    #[test]
+    fn build_adapter_with_extra_args_returns_correct_name() {
+        let adapter = build_adapter(
+            &ProviderKind::Codex,
+            false,
+            None,
+            None,
+            vec!["--approval-mode".to_string(), "full-auto".to_string()],
+        );
+        assert_eq!(adapter.name(), "codex");
     }
 
     // ── run_provider_process timeout (real subprocess) ────────────────────────

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -116,16 +116,30 @@ pub struct ClaudeAdapter {
     pub extra_args: Vec<String>,
 }
 
+/// Build the argument vector passed to the `claude` binary.
+///
+/// Order is fixed: `-p`, `--dangerously-skip-permissions`, then any
+/// caller-supplied `extra_args`, then the prompt.  Extracted as a free
+/// function so unit tests can verify arg construction without spawning the
+/// real `claude` binary.
+pub(crate) fn build_claude_args(prompt: &str, extra_args: &[String]) -> Vec<String> {
+    let mut args: Vec<String> = vec![
+        "-p".to_string(),
+        "--dangerously-skip-permissions".to_string(),
+    ];
+    args.extend(extra_args.iter().cloned());
+    args.push(prompt.to_string());
+    args
+}
+
 impl ProviderAdapter for ClaudeAdapter {
     fn name(&self) -> &str {
         "claude"
     }
 
     fn execute(&self, prompt: &str) -> Result<ExecutionResult, LooperError> {
-        let mut args: Vec<&str> = vec!["-p", "--dangerously-skip-permissions"];
-        let extra: Vec<&str> = self.extra_args.iter().map(String::as_str).collect();
-        args.extend_from_slice(&extra);
-        args.push(prompt);
+        let owned = build_claude_args(prompt, &self.extra_args);
+        let args: Vec<&str> = owned.iter().map(String::as_str).collect();
         run_provider_process(
             "claude",
             &args,
@@ -330,9 +344,14 @@ fn run_provider_process(
             std::thread::spawn(move || {
                 std::thread::sleep(Duration::from_secs(secs));
                 if let Ok(mut c) = child_clone.lock() {
-                    let _ = c.kill();
+                    // Only mark as timed-out when kill() succeeds.  If the child
+                    // already exited and was reaped, kill() returns an error and
+                    // we leave `fired` false, avoiding a false-positive timeout
+                    // report when the process completed naturally at the deadline.
+                    if c.kill().is_ok() {
+                        fired.store(true, Ordering::Relaxed);
+                    }
                 }
-                fired.store(true, Ordering::Relaxed);
             });
         }
 
@@ -567,32 +586,39 @@ pub mod tests {
 
     // ── extra_args threading ──────────────────────────────────────────────────
 
-    /// Verify that extra_args are included in the subprocess invocation by
-    /// using `echo` to print all args and checking the output contains them.
+    /// Verify that `build_claude_args` threads `extra_args` through in the
+    /// required order: `-p`, `--dangerously-skip-permissions`, *extras*,
+    /// *prompt*.  Exercises the real arg-building helper used by
+    /// `ClaudeAdapter::execute`, without depending on the `claude` binary.
     #[test]
-    #[cfg(unix)]
     fn claude_adapter_includes_extra_args_in_invocation() {
-        // Use `echo` to print args rather than spawning real `claude`.
-        // We construct the adapter and verify arg order by calling run_provider_process
-        // directly with the expected expanded arg list.
         let extra = vec!["--extra-flag".to_string(), "extra-value".to_string()];
-        let expected_args = [
-            "-p",
-            "--dangerously-skip-permissions",
-            "--extra-flag",
-            "extra-value",
-            "my-prompt",
-        ];
-        let result =
-            super::run_provider_process("echo", &expected_args, false, None, None).unwrap();
-        let stdout = result.stdout.trim().to_string();
-        // echo prints all args space-separated; verify the extra args appear in order
-        assert!(
-            stdout.contains("--extra-flag extra-value"),
-            "extra args not found in echo output: {stdout}"
+        let args = super::build_claude_args("my-prompt", &extra);
+        assert_eq!(
+            args,
+            vec![
+                "-p".to_string(),
+                "--dangerously-skip-permissions".to_string(),
+                "--extra-flag".to_string(),
+                "extra-value".to_string(),
+                "my-prompt".to_string(),
+            ]
         );
-        assert!(stdout.contains("my-prompt"), "prompt missing: {stdout}");
-        drop(extra); // suppress unused warning
+    }
+
+    /// Empty `extra_args` collapses to the canonical Claude invocation:
+    /// `-p --dangerously-skip-permissions <prompt>`.
+    #[test]
+    fn claude_adapter_no_extra_args_uses_canonical_arg_order() {
+        let args = super::build_claude_args("hello", &[]);
+        assert_eq!(
+            args,
+            vec![
+                "-p".to_string(),
+                "--dangerously-skip-permissions".to_string(),
+                "hello".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -3,16 +3,18 @@ use crate::error::LooperError;
 use crate::security::redact_secrets;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{mpsc, Arc};
 use std::time::Duration;
-use tracing::trace;
+use tracing::{trace, warn};
 
 /// Approved provider executables.
 ///
-/// Only binaries in this list may be spawned by the loop engine.  This
-/// allowlist is enforced at runtime in non-test builds by
-/// [`check_allowed_binary`] to prevent arbitrary command injection in case of
-/// future refactors that relax the hardcoded binary names inside adapters.
+/// Defence-in-depth allowlist: today the binary name is a hardcoded string
+/// literal inside each adapter, so this check has no user-input surface to
+/// defend against.  It exists so that any future refactor which threads a
+/// caller-supplied binary name through [`run_provider_process`] (or a
+/// descendant of it) fails loudly at runtime rather than silently spawning an
+/// arbitrary command.  Enforcement lives in [`check_allowed_binary`].
 pub const ALLOWED_PROVIDER_BINARIES: &[&str] = &["claude", "gh", "codex"];
 
 /// Return `Ok(())` if `binary` is in [`ALLOWED_PROVIDER_BINARIES`], or a
@@ -146,6 +148,7 @@ impl ProviderAdapter for ClaudeAdapter {
             self.stream_output,
             self.working_dir.as_deref(),
             self.timeout_secs,
+            true,
         )
     }
 }
@@ -175,6 +178,7 @@ impl ProviderAdapter for CopilotAdapter {
             self.stream_output,
             self.working_dir.as_deref(),
             self.timeout_secs,
+            true,
         )
     }
 }
@@ -204,11 +208,59 @@ impl ProviderAdapter for CodexAdapter {
             self.stream_output,
             self.working_dir.as_deref(),
             self.timeout_secs,
+            true,
         )
     }
 }
 
 // ── Shared helper ─────────────────────────────────────────────────────────────
+
+/// Spawn a timeout watchdog that kills `child` after `secs` seconds, unless
+/// cancelled first via the returned [`mpsc::Sender`] (send `()` or drop it).
+///
+/// Using an mpsc channel with [`mpsc::Receiver::recv_timeout`] lets the
+/// caller cancel the watchdog as soon as `wait()` returns, instead of leaving
+/// a zombie thread sleeping for the full `secs` even though the child has
+/// already exited (see #66).
+///
+/// The `fired` flag is set only when the watchdog actually kills the child,
+/// so a natural exit that races with the deadline doesn't produce a
+/// false-positive `ProviderTimeout`.  A failing `kill()` is logged via
+/// `warn!` so the operator has something to debug if a timeout never fires
+/// (see #79).
+fn spawn_timeout_watchdog(
+    child: Arc<std::sync::Mutex<std::process::Child>>,
+    secs: u64,
+    fired: Arc<AtomicBool>,
+) -> mpsc::Sender<()> {
+    let (tx, rx) = mpsc::channel::<()>();
+    std::thread::spawn(move || {
+        match rx.recv_timeout(Duration::from_secs(secs)) {
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                // Deadline expired — kill the child.
+                if let Ok(mut c) = child.lock() {
+                    match c.kill() {
+                        Ok(()) => fired.store(true, Ordering::Relaxed),
+                        Err(e) => warn!(
+                            error = %e,
+                            "provider timeout watchdog: kill() failed; \
+                             ProviderTimeout will not fire"
+                        ),
+                    }
+                } else {
+                    warn!(
+                        "provider timeout watchdog: child mutex poisoned; \
+                         cannot attempt kill"
+                    );
+                }
+            }
+            // Either an explicit cancel message or sender dropped — the
+            // parent has observed wait() return, so the watchdog can exit.
+            Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => {}
+        }
+    });
+    tx
+}
 
 /// Run a provider process, optionally streaming stdout/stderr to the terminal
 /// as tagged lines (`[stdout]` / `[stderr]`).
@@ -219,22 +271,29 @@ impl ProviderAdapter for CodexAdapter {
 /// `timeout_secs` sets a maximum wall-clock duration for the provider.  When
 /// the timeout fires the process is killed and `LooperError::ProviderTimeout`
 /// is returned.  `None` means no timeout.
+///
+/// When `enforce_allowlist` is `true`, the caller `binary` must be in
+/// [`ALLOWED_PROVIDER_BINARIES`] or the call returns
+/// [`LooperError::DisallowedExecutable`] without spawning.  Production call
+/// sites (the three adapters) pass `true`; test helpers that need to spawn
+/// `sleep` / `echo` pass `false`.  Extracting the flag as a parameter (rather
+/// than `#[cfg(not(test))]`-gating the check) is what lets the integration be
+/// exercised by a real test — see issue #64.
 fn run_provider_process(
     binary: &str,
     args: &[&str],
     stream: bool,
     working_dir: Option<&std::path::Path>,
     timeout_secs: Option<u64>,
+    enforce_allowlist: bool,
 ) -> Result<ExecutionResult, LooperError> {
     use std::io::{BufRead, BufReader};
     use std::process::{Command, Stdio};
     use std::time::Instant;
 
-    // Enforce the executable allowlist in non-test builds.  Test builds bypass
-    // this so unit tests can spawn utilities like `sleep` or `echo` to exercise
-    // timeout/streaming behaviour without requiring real provider CLIs.
-    #[cfg(not(test))]
-    check_allowed_binary(binary)?;
+    if enforce_allowlist {
+        check_allowed_binary(binary)?;
+    }
 
     let start = Instant::now();
 
@@ -256,55 +315,85 @@ fn run_provider_process(
         let child = std::sync::Arc::new(std::sync::Mutex::new(child));
         let timeout_fired = Arc::new(AtomicBool::new(false));
 
-        if let Some(secs) = timeout_secs {
-            let child_clone = Arc::clone(&child);
-            let fired = Arc::clone(&timeout_fired);
-            std::thread::spawn(move || {
-                std::thread::sleep(Duration::from_secs(secs));
-                if let Ok(mut c) = child_clone.lock() {
-                    // Only mark as timed-out when kill() succeeds.  If the child
-                    // already exited and was reaped, kill() returns an error and we
-                    // leave `fired` false, avoiding a false-positive timeout report.
-                    if c.kill().is_ok() {
-                        fired.store(true, Ordering::Relaxed);
-                    }
-                }
-            });
-        }
+        let watchdog_tx = timeout_secs.map(|secs| {
+            spawn_timeout_watchdog(Arc::clone(&child), secs, Arc::clone(&timeout_fired))
+        });
 
         // Read stdout on a background thread so we don't deadlock on stderr.
         let stdout_handle = std::thread::spawn(move || {
             let reader = BufReader::new(stdout_pipe);
             let mut captured = String::new();
-            for line in reader.lines().map_while(Result::ok) {
-                let line = redact_secrets(&line);
-                println!("[stdout] {}", line);
-                trace!(stream = "stdout", "{}", line);
-                captured.push_str(&line);
-                captured.push('\n');
+            for line_result in reader.lines() {
+                match line_result {
+                    Ok(line) => {
+                        let line = redact_secrets(&line);
+                        println!("[stdout] {}", line);
+                        trace!(stream = "stdout", "{}", line);
+                        captured.push_str(&line);
+                        captured.push('\n');
+                    }
+                    Err(e) => {
+                        // Used to be `map_while(Result::ok)` which silently
+                        // truncated on the first read error — see #67.  A
+                        // truncated stdout silently broke shippable-marker
+                        // detection in pr_manager.
+                        warn!(
+                            error = %e,
+                            "stdout read error; capture may be truncated"
+                        );
+                        break;
+                    }
+                }
             }
             captured
         });
 
         let mut stderr_captured = String::new();
         let stderr_reader = BufReader::new(stderr_pipe);
-        for line in stderr_reader.lines().map_while(Result::ok) {
-            let line = redact_secrets(&line);
-            eprintln!("[stderr] {}", line);
-            trace!(stream = "stderr", "{}", line);
-            stderr_captured.push_str(&line);
-            stderr_captured.push('\n');
+        for line_result in stderr_reader.lines() {
+            match line_result {
+                Ok(line) => {
+                    let line = redact_secrets(&line);
+                    eprintln!("[stderr] {}", line);
+                    trace!(stream = "stderr", "{}", line);
+                    stderr_captured.push_str(&line);
+                    stderr_captured.push('\n');
+                }
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        "stderr read error; capture may be truncated"
+                    );
+                    break;
+                }
+            }
         }
 
-        let stdout_captured = stdout_handle.join().unwrap_or_default();
-        let status = child
-            .lock()
-            .unwrap()
-            .wait()
-            .map_err(|e| LooperError::ProviderSpawn {
+        let stdout_captured = match stdout_handle.join() {
+            Ok(s) => s,
+            Err(_) => {
+                warn!("stdout drain thread panicked; returning empty capture");
+                String::new()
+            }
+        };
+        let status = {
+            let mut guard = child.lock().map_err(|_| LooperError::ProviderSpawn {
+                binary: binary.to_string(),
+                source: std::io::Error::other("child mutex poisoned by watchdog"),
+            })?;
+            guard.wait().map_err(|e| LooperError::ProviderSpawn {
                 binary: binary.to_string(),
                 source: e,
-            })?;
+            })?
+        };
+
+        // Cancel the watchdog now that wait() has returned (no-op if there
+        // was no timeout).  See #66 — we used to leave the watchdog asleep
+        // for the full deadline even after early child exit.
+        if let Some(tx) = watchdog_tx {
+            let _ = tx.send(());
+        }
+
         let duration = start.elapsed();
 
         if timeout_fired.load(Ordering::Relaxed) {
@@ -338,42 +427,73 @@ fn run_provider_process(
         let child = Arc::new(std::sync::Mutex::new(child));
         let timeout_fired = Arc::new(AtomicBool::new(false));
 
-        if let Some(secs) = timeout_secs {
-            let child_clone = Arc::clone(&child);
-            let fired = Arc::clone(&timeout_fired);
-            std::thread::spawn(move || {
-                std::thread::sleep(Duration::from_secs(secs));
-                if let Ok(mut c) = child_clone.lock() {
-                    // Only mark as timed-out when kill() succeeds.  If the child
-                    // already exited and was reaped, kill() returns an error and
-                    // we leave `fired` false, avoiding a false-positive timeout
-                    // report when the process completed naturally at the deadline.
-                    if c.kill().is_ok() {
-                        fired.store(true, Ordering::Relaxed);
-                    }
-                }
-            });
-        }
+        let watchdog_tx = timeout_secs.map(|secs| {
+            spawn_timeout_watchdog(Arc::clone(&child), secs, Arc::clone(&timeout_fired))
+        });
 
         // Drain both pipes on background threads to prevent deadlock when the
         // child fills its pipe buffers.  The drain threads block until EOF,
         // which happens when the child exits or is killed by the watchdog.
+        // IO errors during drain are logged; we return whatever was read
+        // before the error so the caller still sees partial output, but the
+        // log line gives operators something to debug if marker detection
+        // downstream silently fails (see #67).
         let stdout_handle = std::thread::spawn(move || {
             use std::io::Read;
             let mut buf = Vec::new();
-            let _ = { stdout_pipe }.read_to_end(&mut buf);
+            if let Err(e) = { stdout_pipe }.read_to_end(&mut buf) {
+                warn!(
+                    error = %e,
+                    "non-streaming stdout drain error; capture may be truncated"
+                );
+            }
             buf
         });
         let stderr_handle = std::thread::spawn(move || {
             use std::io::Read;
             let mut buf = Vec::new();
-            let _ = { stderr_pipe }.read_to_end(&mut buf);
+            if let Err(e) = { stderr_pipe }.read_to_end(&mut buf) {
+                warn!(
+                    error = %e,
+                    "non-streaming stderr drain error; capture may be truncated"
+                );
+            }
             buf
         });
 
-        let stdout_bytes = stdout_handle.join().unwrap_or_default();
-        let stderr_bytes = stderr_handle.join().unwrap_or_default();
-        let exit_code = child.lock().unwrap().wait().ok().and_then(|s| s.code());
+        let stdout_bytes = match stdout_handle.join() {
+            Ok(b) => b,
+            Err(_) => {
+                warn!("non-streaming stdout drain thread panicked");
+                Vec::new()
+            }
+        };
+        let stderr_bytes = match stderr_handle.join() {
+            Ok(b) => b,
+            Err(_) => {
+                warn!("non-streaming stderr drain thread panicked");
+                Vec::new()
+            }
+        };
+
+        // Align with the streaming path: fail with ProviderSpawn on wait()
+        // error instead of collapsing it into `None` (which IterationOutcome
+        // would then misclassify as Signal and treat as non-retryable — see
+        // #67).
+        let status = {
+            let mut guard = child.lock().map_err(|_| LooperError::ProviderSpawn {
+                binary: binary.to_string(),
+                source: std::io::Error::other("child mutex poisoned by watchdog"),
+            })?;
+            guard.wait().map_err(|e| LooperError::ProviderSpawn {
+                binary: binary.to_string(),
+                source: e,
+            })?
+        };
+        if let Some(tx) = watchdog_tx {
+            let _ = tx.send(());
+        }
+        let exit_code = status.code();
         let duration = start.elapsed();
 
         if timeout_fired.load(Ordering::Relaxed) {
@@ -399,10 +519,19 @@ pub mod tests {
     use super::*;
     use std::time::Duration;
 
-    /// A deterministic test adapter that always returns a preset result.
+    /// A deterministic test adapter that returns either a fixed result or a
+    /// pre-scripted sequence of exit codes on successive calls.
+    ///
+    /// `result` is the fallback used when `sequence` is empty.  When
+    /// `sequence` is non-empty, each call to `execute` pops the next code,
+    /// wraps it in an `ExecutionResult`, and returns it.  See
+    /// [`Self::sequence`] for the retry-recovery test pattern (#70).
     pub struct FakeAdapter {
         pub name: String,
         pub result: Result<ExecutionResult, LooperError>,
+        /// Pre-scripted exit codes for successive calls to `execute`.
+        /// Popped from the front on each call; empty means "use `result`".
+        pub sequence: std::sync::Mutex<std::collections::VecDeque<i32>>,
     }
 
     impl FakeAdapter {
@@ -415,6 +544,7 @@ pub mod tests {
                     stderr: String::new(),
                     duration: Duration::from_millis(5),
                 }),
+                sequence: std::sync::Mutex::new(std::collections::VecDeque::new()),
             }
         }
 
@@ -427,6 +557,7 @@ pub mod tests {
                     stderr: "error".to_string(),
                     duration: Duration::from_millis(5),
                 }),
+                sequence: std::sync::Mutex::new(std::collections::VecDeque::new()),
             }
         }
 
@@ -440,6 +571,37 @@ pub mod tests {
                     stderr: format!("exit {code}"),
                     duration: Duration::from_millis(5),
                 }),
+                sequence: std::sync::Mutex::new(std::collections::VecDeque::new()),
+            }
+        }
+
+        /// Construct a fake adapter that returns each of the given exit
+        /// codes on successive calls to `execute`, in order.  Once the
+        /// sequence is exhausted the final code is returned for any
+        /// subsequent calls.
+        ///
+        /// Intended for retry-recovery tests (#70): a permanently-failing
+        /// adapter cannot distinguish "retried N times then gave up" from
+        /// "broken retry loop".  `sequence(vec![1, 0])` models a failure
+        /// followed by a successful retry.
+        pub fn sequence(name: &str, codes: Vec<i32>) -> Self {
+            assert!(
+                !codes.is_empty(),
+                "FakeAdapter::sequence requires at least one exit code"
+            );
+            let deque: std::collections::VecDeque<i32> = codes.into_iter().collect();
+            Self {
+                name: name.to_string(),
+                // `result` is only used when the sequence is drained — store
+                // a harmless placeholder; `execute` always consults the
+                // sequence first.
+                result: Ok(ExecutionResult {
+                    exit_code: Some(0),
+                    stdout: String::new(),
+                    stderr: String::new(),
+                    duration: Duration::from_millis(5),
+                }),
+                sequence: std::sync::Mutex::new(deque),
             }
         }
     }
@@ -450,6 +612,35 @@ pub mod tests {
         }
 
         fn execute(&self, _prompt: &str) -> Result<ExecutionResult, LooperError> {
+            // Pop the next scripted exit code if any; fall back to the
+            // fixed `result` otherwise.  When the sequence has a single
+            // element left, it's *kept* so later calls reuse it (matches
+            // the doc comment's "final code is returned for any subsequent
+            // calls" contract).
+            {
+                let mut seq = self.sequence.lock().expect("sequence mutex poisoned");
+                if !seq.is_empty() {
+                    let code = if seq.len() == 1 {
+                        *seq.front().unwrap()
+                    } else {
+                        seq.pop_front().unwrap()
+                    };
+                    return Ok(ExecutionResult {
+                        exit_code: Some(code),
+                        stdout: if code == 0 {
+                            "ok".to_string()
+                        } else {
+                            String::new()
+                        },
+                        stderr: if code == 0 {
+                            String::new()
+                        } else {
+                            format!("exit {code}")
+                        },
+                        duration: Duration::from_millis(5),
+                    });
+                }
+            }
             match &self.result {
                 Ok(r) => Ok(r.clone()),
                 Err(e) => Err(LooperError::InvalidArgument(e.to_string())),
@@ -650,7 +841,7 @@ pub mod tests {
     #[cfg(unix)]
     fn non_streaming_process_is_killed_on_timeout() {
         // sleep for 60s, but timeout after 1s
-        let result = super::run_provider_process("sleep", &["60"], false, None, Some(1));
+        let result = super::run_provider_process("sleep", &["60"], false, None, Some(1), false);
         match result {
             Err(LooperError::ProviderTimeout { timeout_secs, .. }) => {
                 assert_eq!(timeout_secs, 1);
@@ -663,9 +854,42 @@ pub mod tests {
     #[test]
     #[cfg(unix)]
     fn non_streaming_fast_process_is_not_timed_out() {
-        let result = super::run_provider_process("echo", &["hello"], false, None, Some(5));
+        let result = super::run_provider_process("echo", &["hello"], false, None, Some(5), false);
         match result {
             Ok(r) => assert!(r.succeeded(), "expected success, got: {:?}", r.exit_code),
+            Err(e) => panic!("expected Ok, got: {e}"),
+        }
+    }
+
+    /// Regression test for #64: the allowlist enforcement must be wired into
+    /// `run_provider_process` and reachable from the test build.  Passing
+    /// `enforce_allowlist = true` with a disallowed binary must fail with
+    /// `DisallowedExecutable` *before* spawning anything — so even a
+    /// nonexistent path like `not-a-real-binary` reliably returns the
+    /// allowlist error rather than a spawn error.
+    #[test]
+    fn run_provider_process_enforces_allowlist_when_requested() {
+        let err = super::run_provider_process("not-a-real-binary", &[], false, None, None, true)
+            .expect_err("should be rejected by allowlist");
+        match err {
+            LooperError::DisallowedExecutable { binary, .. } => {
+                assert_eq!(binary, "not-a-real-binary");
+            }
+            other => panic!("expected DisallowedExecutable, got: {other:?}"),
+        }
+    }
+
+    /// When `enforce_allowlist = false`, the allowlist check is skipped and
+    /// the usual spawn path runs.  Spawning `/bin/true` is a cheap way to
+    /// confirm the non-enforced path still works end-to-end without the
+    /// check short-circuiting it.
+    #[test]
+    #[cfg(unix)]
+    fn run_provider_process_skips_allowlist_when_not_enforced() {
+        // /bin/true exits 0 immediately — used as a minimal real subprocess.
+        let result = super::run_provider_process("true", &[], false, None, None, false);
+        match result {
+            Ok(r) => assert_eq!(r.exit_code, Some(0)),
             Err(e) => panic!("expected Ok, got: {e}"),
         }
     }

--- a/src/security.rs
+++ b/src/security.rs
@@ -94,18 +94,25 @@ fn redact_auth_headers(s: String) -> String {
 
 fn redact_header_value(s: &str, scheme: &str) -> String {
     // Pattern: "Authorization:" (optional whitespace) scheme (whitespace) <value>
-    // We scan case-insensitively by lower-casing a working copy for position
-    // finding, then apply redaction to the original.
-    let needle = "authorization:".to_string();
-    let lower = s.to_lowercase();
-    let scheme_lower = scheme.to_lowercase();
+    //
+    // Matching is case-insensitive for the header name and scheme keyword, but
+    // only for ASCII characters.  We use `to_ascii_lowercase()` (not
+    // `to_lowercase()`) because it preserves byte length — general Unicode case
+    // folding does not (e.g. `ß` → `ss`, Turkish dotted-I), and we index back
+    // into the original byte-for-byte.  All character-class checks below use
+    // `is_ascii_whitespace()` on *bytes*, which is safe because ASCII whitespace
+    // bytes cannot appear inside a multi-byte UTF-8 sequence, so byte positions
+    // are always on character boundaries.
+    let needle = "authorization:";
+    let lower = s.to_ascii_lowercase();
+    let scheme_lower = scheme.to_ascii_lowercase();
 
     let mut result = String::with_capacity(s.len());
     let mut remaining_lower = lower.as_str();
     let mut remaining_orig = s;
 
     loop {
-        let Some(pos) = remaining_lower.find(needle.as_str()) else {
+        let Some(pos) = remaining_lower.find(needle) else {
             result.push_str(remaining_orig);
             break;
         };
@@ -117,11 +124,8 @@ fn redact_header_value(s: &str, scheme: &str) -> String {
         let after_colon_lower = &remaining_lower[header_end..];
         let after_colon_orig = &remaining_orig[header_end..];
 
-        // Skip optional whitespace.
-        let ws_len = after_colon_lower
-            .chars()
-            .take_while(|c| c.is_ascii_whitespace() && *c != '\n' && *c != '\r')
-            .count();
+        // Skip optional inline whitespace (spaces/tabs, not newlines).
+        let ws_len = count_inline_ws_bytes(after_colon_lower);
 
         let scheme_start = ws_len;
         let scheme_end = scheme_start + scheme_lower.len();
@@ -136,20 +140,22 @@ fn redact_header_value(s: &str, scheme: &str) -> String {
             let after_scheme_orig = &after_colon_orig[scheme_end..];
 
             // Skip whitespace between scheme and value.
-            let inner_ws = after_scheme_lower
-                .chars()
-                .take_while(|c| c.is_ascii_whitespace() && *c != '\n' && *c != '\r')
-                .count();
+            let inner_ws = count_inline_ws_bytes(after_scheme_lower);
 
             if inner_ws > 0 {
                 result.push_str(&after_scheme_orig[..inner_ws]);
             }
 
-            let value_str = &after_scheme_lower[inner_ws..];
-            let value_len = value_str
-                .chars()
-                .take_while(|c| !c.is_ascii_whitespace())
-                .count();
+            // Byte length of the value, measured up to the first whitespace
+            // byte.  `is_ascii_whitespace()` on a byte is safe here: ASCII
+            // whitespace bytes (< 0x80) cannot appear inside a UTF-8 multi-byte
+            // sequence, so the count always lands on a char boundary even if
+            // the value contains multi-byte UTF-8.
+            let value_bytes = &after_scheme_orig.as_bytes()[inner_ws..];
+            let value_len = value_bytes
+                .iter()
+                .position(u8::is_ascii_whitespace)
+                .unwrap_or(value_bytes.len());
 
             if value_len > 0 {
                 result.push_str(REDACTED);
@@ -168,6 +174,19 @@ fn redact_header_value(s: &str, scheme: &str) -> String {
     }
 
     result
+}
+
+/// Count the number of leading inline-whitespace bytes (space / tab) in `s`.
+///
+/// Stops at the first newline, carriage return, or non-whitespace byte.  Returns
+/// a byte count that is guaranteed to be on a UTF-8 character boundary because
+/// inline-whitespace bytes are all in the ASCII range and cannot appear inside
+/// a multi-byte UTF-8 sequence.
+fn count_inline_ws_bytes(s: &str) -> usize {
+    s.as_bytes()
+        .iter()
+        .take_while(|&&b| b.is_ascii_whitespace() && b != b'\n' && b != b'\r')
+        .count()
 }
 
 // ── Environment variable assignments ─────────────────────────────────────────
@@ -189,11 +208,16 @@ fn redact_env_var_value(s: String, var_name: &str) -> String {
     while let Some(pos) = remaining.find(needle.as_str()) {
         result.push_str(&remaining[..pos + needle.len()]);
         let after_eq = &remaining[pos + needle.len()..];
-        // Value ends at whitespace or end of string.
-        let value_len = after_eq
-            .chars()
-            .take_while(|c| !c.is_ascii_whitespace())
-            .count();
+        // Value ends at the first whitespace byte or end-of-string.  We measure
+        // the length in *bytes* (not chars) so the resulting split is a valid
+        // UTF-8 boundary even when the value contains multi-byte characters —
+        // ASCII whitespace bytes cannot appear inside a multi-byte UTF-8
+        // sequence, so the first such byte is always on a char boundary.
+        let after_bytes = after_eq.as_bytes();
+        let value_len = after_bytes
+            .iter()
+            .position(u8::is_ascii_whitespace)
+            .unwrap_or(after_bytes.len());
         if value_len > 0 {
             result.push_str(REDACTED);
             remaining = &after_eq[value_len..];
@@ -370,5 +394,68 @@ mod tests {
     fn non_ascii_content_is_preserved() {
         let input = "result: OK — no token here";
         assert_eq!(redact_secrets(input), input);
+    }
+
+    // ── UTF-8 edge cases (regression: #60) ────────────────────────────────────
+    //
+    // These inputs used to panic because the old implementation counted
+    // characters and then used the char count as a byte index.  Any multi-byte
+    // character in (or right before) the value region would land mid-codepoint.
+
+    #[test]
+    fn bearer_header_with_multibyte_value_does_not_panic() {
+        // Value contains a multi-byte character (`é`, 2 bytes in UTF-8).
+        let input = "Authorization: Bearer tokén_with_multibyte";
+        let output = redact_secrets(input);
+        assert!(output.contains("Bearer [REDACTED]"), "{output}");
+        assert!(!output.contains("tokén"), "{output}");
+    }
+
+    #[test]
+    fn bearer_header_with_multibyte_before_value_does_not_panic() {
+        // Multi-byte character appears *before* the header, so all byte offsets
+        // within the scan are shifted relative to what a char count would say.
+        let input = "résumé\nAuthorization: Bearer abc123def";
+        let output = redact_secrets(input);
+        assert!(output.contains("Bearer [REDACTED]"), "{output}");
+        assert!(!output.contains("abc123def"), "{output}");
+        assert!(output.contains("résumé"), "{output}");
+    }
+
+    #[test]
+    fn env_var_with_multibyte_value_does_not_panic() {
+        let input = "GITHUB_TOKEN=tokén_value next";
+        let output = redact_secrets(input);
+        assert!(output.contains("GITHUB_TOKEN=[REDACTED]"), "{output}");
+        assert!(output.contains("next"), "{output}");
+        assert!(!output.contains("tokén_value"), "{output}");
+    }
+
+    #[test]
+    fn bearer_header_with_mixed_case_scheme() {
+        let input = "Authorization: BeArEr mytoken123";
+        let output = redact_secrets(input);
+        assert!(!output.contains("mytoken123"), "{output}");
+    }
+
+    #[test]
+    fn case_insensitive_header_scan_survives_german_sharp_s() {
+        // `ß` in `to_lowercase()` expands to `ss` (2 bytes → 2 bytes in this
+        // case, but the general-case-folding path is what broke the old
+        // implementation).  Use `to_ascii_lowercase()` internally, which
+        // leaves non-ASCII untouched and preserves byte length.
+        let input = "straße\nAuthorization: Bearer secret\nend";
+        let output = redact_secrets(input);
+        assert!(output.contains("Bearer [REDACTED]"), "{output}");
+        assert!(!output.contains("secret"), "{output}");
+    }
+
+    #[test]
+    fn empty_bearer_value_is_not_replaced() {
+        // "Bearer" with nothing after it — no value to redact, should pass
+        // through without inserting `[REDACTED]`.
+        let input = "Authorization: Bearer ";
+        let output = redact_secrets(input);
+        assert!(!output.contains("[REDACTED]"), "{output}");
     }
 }

--- a/src/security.rs
+++ b/src/security.rs
@@ -1,0 +1,371 @@
+/// Secret and token redaction for captured provider output.
+///
+/// Provider stdout/stderr is stored in run artifacts and structured logs.
+/// Any recognised credential pattern is replaced with `[REDACTED]` before
+/// the output leaves the capture boundary, so raw tokens never reach disk or
+/// tracing output.
+///
+/// # Patterns covered
+///
+/// | Pattern | Description |
+/// |---------|-------------|
+/// | `ghp_<36+chars>` | GitHub personal access token (new format) |
+/// | `gho_<36+chars>` | GitHub OAuth token |
+/// | `ghs_<36+chars>` | GitHub App installation token |
+/// | `ghr_<36+chars>` | GitHub refresh token |
+/// | `Authorization: Bearer <token>` | HTTP Authorization header (Bearer) |
+/// | `Authorization: token <token>` | HTTP Authorization header (token) |
+/// | `GITHUB_TOKEN=<value>` | Environment variable assignment |
+/// | `GH_TOKEN=<value>` | Alternative env var used by the `gh` CLI |
+
+const REDACTED: &str = "[REDACTED]";
+
+/// Replace all recognised secret patterns in `input` with `[REDACTED]`.
+///
+/// The function is designed to be cheap to call on every captured line; it
+/// performs a small number of simple string scans without requiring a regex
+/// engine.
+pub fn redact_secrets(input: &str) -> String {
+    let mut out = input.to_string();
+    out = redact_gh_tokens(out);
+    out = redact_auth_headers(out);
+    out = redact_env_vars(out);
+    out
+}
+
+// ── GitHub token prefixes ─────────────────────────────────────────────────────
+
+/// Prefixes used by GitHub-issued tokens.
+const GH_TOKEN_PREFIXES: &[&str] = &["ghp_", "gho_", "ghs_", "ghr_"];
+
+/// Minimum number of alphanumeric characters that must follow a prefix for it
+/// to be considered a real token (avoids redacting short test strings).
+const GH_TOKEN_MIN_SUFFIX: usize = 36;
+
+fn redact_gh_tokens(mut s: String) -> String {
+    for prefix in GH_TOKEN_PREFIXES {
+        s = redact_prefixed_token(&s, prefix, GH_TOKEN_MIN_SUFFIX);
+    }
+    s
+}
+
+/// Find every occurrence of `prefix` followed by at least `min_suffix`
+/// alphanumeric-or-underscore characters and replace them with
+/// `{prefix}[REDACTED]`.
+fn redact_prefixed_token(s: &str, prefix: &str, min_suffix: usize) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut remaining = s;
+
+    while let Some(pos) = remaining.find(prefix) {
+        // Append everything before the prefix.
+        result.push_str(&remaining[..pos]);
+
+        let after_prefix = &remaining[pos + prefix.len()..];
+        let suffix_len = after_prefix
+            .chars()
+            .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+            .count();
+
+        if suffix_len >= min_suffix {
+            // Redact: emit prefix + [REDACTED], skip the suffix chars.
+            result.push_str(prefix);
+            result.push_str(REDACTED);
+            // Advance past prefix + suffix (byte length, prefix is ASCII).
+            remaining = &remaining[pos + prefix.len() + suffix_len..];
+        } else {
+            // Not long enough — keep the prefix verbatim and advance past it.
+            result.push_str(prefix);
+            remaining = after_prefix;
+        }
+    }
+
+    result.push_str(remaining);
+    result
+}
+
+// ── Authorization headers ─────────────────────────────────────────────────────
+
+/// Redact `Authorization: Bearer <token>` and `Authorization: token <token>`.
+///
+/// Matching is case-insensitive for the header name and scheme keyword.
+fn redact_auth_headers(s: String) -> String {
+    redact_header_value(&s, "Bearer")
+        .pipe(|s| redact_header_value(&s, "token"))
+}
+
+fn redact_header_value(s: &str, scheme: &str) -> String {
+    // Pattern: "Authorization:" (optional whitespace) scheme (whitespace) <value>
+    // We scan case-insensitively by lower-casing a working copy for position
+    // finding, then apply redaction to the original.
+    let needle = format!("authorization:");
+    let lower = s.to_lowercase();
+    let scheme_lower = scheme.to_lowercase();
+
+    let mut result = String::with_capacity(s.len());
+    let mut remaining_lower = lower.as_str();
+    let mut remaining_orig = s;
+
+    loop {
+        let Some(pos) = remaining_lower.find(needle.as_str()) else {
+            result.push_str(remaining_orig);
+            break;
+        };
+
+        // Append everything up to and including "Authorization:"
+        let header_end = pos + needle.len();
+        result.push_str(&remaining_orig[..header_end]);
+
+        let after_colon_lower = &remaining_lower[header_end..];
+        let after_colon_orig = &remaining_orig[header_end..];
+
+        // Skip optional whitespace.
+        let ws_len = after_colon_lower
+            .chars()
+            .take_while(|c| c.is_ascii_whitespace() && *c != '\n' && *c != '\r')
+            .count();
+
+        let scheme_start = ws_len;
+        let scheme_end = scheme_start + scheme_lower.len();
+
+        if after_colon_lower.len() >= scheme_end
+            && &after_colon_lower[scheme_start..scheme_end] == scheme_lower.as_str()
+        {
+            // Emit the whitespace + scheme.
+            result.push_str(&after_colon_orig[..scheme_end]);
+
+            let after_scheme_lower = &after_colon_lower[scheme_end..];
+            let after_scheme_orig = &after_colon_orig[scheme_end..];
+
+            // Skip whitespace between scheme and value.
+            let inner_ws = after_scheme_lower
+                .chars()
+                .take_while(|c| c.is_ascii_whitespace() && *c != '\n' && *c != '\r')
+                .count();
+
+            if inner_ws > 0 {
+                result.push_str(&after_scheme_orig[..inner_ws]);
+            }
+
+            let value_str = &after_scheme_lower[inner_ws..];
+            let value_len = value_str
+                .chars()
+                .take_while(|c| !c.is_ascii_whitespace())
+                .count();
+
+            if value_len > 0 {
+                result.push_str(REDACTED);
+                let total_skip = scheme_end + inner_ws + value_len;
+                remaining_lower = &after_colon_lower[total_skip..];
+                remaining_orig = &after_colon_orig[total_skip..];
+            } else {
+                remaining_lower = after_scheme_lower;
+                remaining_orig = after_scheme_orig;
+            }
+        } else {
+            // Scheme not found after the colon — keep as-is and advance.
+            remaining_lower = after_colon_lower;
+            remaining_orig = after_colon_orig;
+        }
+    }
+
+    result
+}
+
+// ── Environment variable assignments ─────────────────────────────────────────
+
+const SENSITIVE_ENV_VARS: &[&str] = &["GITHUB_TOKEN", "GH_TOKEN"];
+
+fn redact_env_vars(mut s: String) -> String {
+    for var in SENSITIVE_ENV_VARS {
+        s = redact_env_var_value(s, var);
+    }
+    s
+}
+
+fn redact_env_var_value(s: String, var_name: &str) -> String {
+    let needle = format!("{var_name}=");
+    let mut result = String::with_capacity(s.len());
+    let mut remaining = s.as_str();
+
+    while let Some(pos) = remaining.find(needle.as_str()) {
+        result.push_str(&remaining[..pos + needle.len()]);
+        let after_eq = &remaining[pos + needle.len()..];
+        // Value ends at whitespace or end of string.
+        let value_len = after_eq
+            .chars()
+            .take_while(|c| !c.is_ascii_whitespace())
+            .count();
+        if value_len > 0 {
+            result.push_str(REDACTED);
+            remaining = &after_eq[value_len..];
+        } else {
+            remaining = after_eq;
+        }
+    }
+
+    result.push_str(remaining);
+    result
+}
+
+// ── Extension trait for method-chain style ────────────────────────────────────
+
+trait Pipe: Sized {
+    fn pipe<F: FnOnce(Self) -> Self>(self, f: F) -> Self {
+        f(self)
+    }
+}
+
+impl Pipe for String {}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── GitHub token patterns ─────────────────────────────────────────────────
+
+    // 40-character suffixes (well above the 36-char minimum).
+    const PAT: &str = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij";
+    const OAUTH: &str = "gho_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij";
+    const APP: &str = "ghs_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij";
+    const REFRESH: &str = "ghr_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij";
+
+    #[test]
+    fn redacts_github_pat() {
+        let input = format!("token is {PAT} end");
+        let output = redact_secrets(&input);
+        assert!(!output.contains("ghp_ABCDE"), "{output}");
+        assert!(output.contains("ghp_[REDACTED]"), "{output}");
+    }
+
+    #[test]
+    fn redacts_github_oauth_token() {
+        let output = redact_secrets(OAUTH);
+        assert!(output.contains("gho_[REDACTED]"), "{output}");
+        assert!(!output.contains("gho_ABCDE"), "{output}");
+    }
+
+    #[test]
+    fn redacts_github_app_token() {
+        let input = format!("value={APP}");
+        let output = redact_secrets(&input);
+        assert!(output.contains("ghs_[REDACTED]"), "{output}");
+    }
+
+    #[test]
+    fn redacts_github_refresh_token() {
+        let input = format!("refresh={REFRESH}");
+        let output = redact_secrets(&input);
+        assert!(output.contains("ghr_[REDACTED]"), "{output}");
+    }
+
+    #[test]
+    fn does_not_redact_short_gh_prefix() {
+        // Only 10 chars after prefix — below the 36-char minimum threshold.
+        let input = "ghp_short123";
+        let output = redact_secrets(input);
+        assert_eq!(output, input, "Short suffix should NOT be redacted");
+    }
+
+    #[test]
+    fn redacts_multiple_tokens_in_one_string() {
+        let input = format!("{PAT} and {OAUTH}");
+        let output = redact_secrets(&input);
+        assert!(output.contains("ghp_[REDACTED]"), "{output}");
+        assert!(output.contains("gho_[REDACTED]"), "{output}");
+    }
+
+    #[test]
+    fn redacts_token_at_end_of_string() {
+        let output = redact_secrets(PAT);
+        assert!(output.contains("ghp_[REDACTED]"), "{output}");
+    }
+
+    // ── Authorization headers ─────────────────────────────────────────────────
+
+    #[test]
+    fn redacts_bearer_header() {
+        let input = "Authorization: Bearer mysecrettoken123";
+        let output = redact_secrets(input);
+        assert!(output.contains("Bearer [REDACTED]"), "{output}");
+        assert!(!output.contains("mysecrettoken123"), "{output}");
+    }
+
+    #[test]
+    fn redacts_token_scheme_header() {
+        let input = "Authorization: token myapitoken456";
+        let output = redact_secrets(input);
+        assert!(output.contains("token [REDACTED]"), "{output}");
+        assert!(!output.contains("myapitoken456"), "{output}");
+    }
+
+    #[test]
+    fn auth_header_redaction_is_case_insensitive_for_header_name() {
+        let input = "authorization: Bearer mysecrettoken123";
+        let output = redact_secrets(input);
+        assert!(!output.contains("mysecrettoken123"), "{output}");
+    }
+
+    #[test]
+    fn auth_header_preserves_rest_of_line() {
+        let input = "GET /api HTTP/1.1\nAuthorization: Bearer abc123def\nContent-Type: application/json";
+        let output = redact_secrets(input);
+        assert!(!output.contains("abc123def"), "{output}");
+        assert!(output.contains("Content-Type: application/json"), "{output}");
+        assert!(output.contains("GET /api HTTP/1.1"), "{output}");
+    }
+
+    // ── Environment variable patterns ─────────────────────────────────────────
+
+    #[test]
+    fn redacts_github_token_env_var() {
+        let input = "GITHUB_TOKEN=ghp_somevalue123";
+        let output = redact_secrets(input);
+        assert!(output.starts_with("GITHUB_TOKEN=[REDACTED]"), "{output}");
+    }
+
+    #[test]
+    fn redacts_gh_token_env_var() {
+        let input = "GH_TOKEN=sometoken export OTHER=value";
+        let output = redact_secrets(input);
+        assert!(output.contains("GH_TOKEN=[REDACTED]"), "{output}");
+        assert!(output.contains("OTHER=value"), "{output}");
+    }
+
+    #[test]
+    fn env_var_redaction_stops_at_whitespace() {
+        let input = "GITHUB_TOKEN=abc123 OTHER=keep";
+        let output = redact_secrets(input);
+        assert!(output.contains("GITHUB_TOKEN=[REDACTED]"), "{output}");
+        assert!(output.contains("OTHER=keep"), "{output}");
+    }
+
+    // ── Edge cases ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn empty_string_returns_empty() {
+        assert_eq!(redact_secrets(""), "");
+    }
+
+    #[test]
+    fn string_with_no_secrets_is_unchanged() {
+        let input = "hello world, no secrets here";
+        assert_eq!(redact_secrets(input), input);
+    }
+
+    #[test]
+    fn multiline_input_handled_correctly() {
+        let input = format!("line1\n{PAT}\nline3");
+        let output = redact_secrets(&input);
+        assert!(output.contains("line1"), "{output}");
+        assert!(output.contains("ghp_[REDACTED]"), "{output}");
+        assert!(output.contains("line3"), "{output}");
+    }
+
+    #[test]
+    fn non_ascii_content_is_preserved() {
+        let input = "result: OK — no token here";
+        assert_eq!(redact_secrets(input), input);
+    }
+}

--- a/src/security.rs
+++ b/src/security.rs
@@ -458,4 +458,56 @@ mod tests {
         let output = redact_secrets(input);
         assert!(!output.contains("[REDACTED]"), "{output}");
     }
+
+    // ── Real-world edge cases (#70) ───────────────────────────────────────────
+
+    #[test]
+    fn bearer_header_with_tab_separator() {
+        // A tab between `Authorization:` and `Bearer`, and between scheme
+        // and value, is legal HTTP and must still trigger redaction.
+        let input = "Authorization:\tBearer\tmyapitoken789";
+        let output = redact_secrets(input);
+        assert!(!output.contains("myapitoken789"), "{output}");
+        assert!(output.contains("[REDACTED]"), "{output}");
+    }
+
+    #[test]
+    fn env_var_with_crlf_terminator_is_bounded_correctly() {
+        // Windows-written log files use CRLF; the redactor must stop the
+        // value at `\r` (or any whitespace byte) and not swallow the rest
+        // of the line.
+        let input = "GITHUB_TOKEN=ghp_somesecret_value\r\nnext-line";
+        let output = redact_secrets(input);
+        assert!(output.contains("GITHUB_TOKEN=[REDACTED]"), "{output}");
+        assert!(output.contains("next-line"), "{output}");
+        assert!(!output.contains("ghp_somesecret_value"), "{output}");
+    }
+
+    #[test]
+    fn token_immediately_preceded_by_alphanumeric_still_redacted() {
+        // The current prefix scanner matches `ghp_` wherever it appears, so
+        // `prefix-ghp_<40 chars>` should still redact.  Lock in the
+        // behaviour explicitly.
+        let input = format!("prefix-{PAT}");
+        let output = redact_secrets(&input);
+        assert!(output.contains("ghp_[REDACTED]"), "{output}");
+    }
+
+    #[test]
+    fn ansi_escape_wrapped_token_is_not_split_by_redaction() {
+        // ANSI color escapes often wrap log content.  The prefix scanner
+        // only stops at non-alphanumeric bytes, so an escape right after
+        // the prefix currently breaks redaction.  This test documents the
+        // limitation so a future fix has a clear before/after target.
+        //
+        // NOTE: the behaviour tested here is intentionally the *current*
+        // behaviour (redaction does NOT succeed across a raw `\x1b` byte).
+        // If you tighten the scanner later, flip the assertion.
+        let input = format!("\x1b[31m{PAT}\x1b[0m");
+        let output = redact_secrets(&input);
+        assert!(
+            output.contains("ghp_[REDACTED]"),
+            "expected redaction despite ANSI wrapping, got: {output}"
+        );
+    }
 }

--- a/src/security.rs
+++ b/src/security.rs
@@ -1,22 +1,22 @@
-/// Secret and token redaction for captured provider output.
-///
-/// Provider stdout/stderr is stored in run artifacts and structured logs.
-/// Any recognised credential pattern is replaced with `[REDACTED]` before
-/// the output leaves the capture boundary, so raw tokens never reach disk or
-/// tracing output.
-///
-/// # Patterns covered
-///
-/// | Pattern | Description |
-/// |---------|-------------|
-/// | `ghp_<36+chars>` | GitHub personal access token (new format) |
-/// | `gho_<36+chars>` | GitHub OAuth token |
-/// | `ghs_<36+chars>` | GitHub App installation token |
-/// | `ghr_<36+chars>` | GitHub refresh token |
-/// | `Authorization: Bearer <token>` | HTTP Authorization header (Bearer) |
-/// | `Authorization: token <token>` | HTTP Authorization header (token) |
-/// | `GITHUB_TOKEN=<value>` | Environment variable assignment |
-/// | `GH_TOKEN=<value>` | Alternative env var used by the `gh` CLI |
+//! Secret and token redaction for captured provider output.
+//!
+//! Provider stdout/stderr is stored in run artifacts and structured logs.
+//! Any recognised credential pattern is replaced with `[REDACTED]` before
+//! the output leaves the capture boundary, so raw tokens never reach disk or
+//! tracing output.
+//!
+//! # Patterns covered
+//!
+//! | Pattern | Description |
+//! |---------|-------------|
+//! | `ghp_<36+chars>` | GitHub personal access token (new format) |
+//! | `gho_<36+chars>` | GitHub OAuth token |
+//! | `ghs_<36+chars>` | GitHub App installation token |
+//! | `ghr_<36+chars>` | GitHub refresh token |
+//! | `Authorization: Bearer <token>` | HTTP Authorization header (Bearer) |
+//! | `Authorization: token <token>` | HTTP Authorization header (token) |
+//! | `GITHUB_TOKEN=<value>` | Environment variable assignment |
+//! | `GH_TOKEN=<value>` | Alternative env var used by the `gh` CLI |
 
 const REDACTED: &str = "[REDACTED]";
 
@@ -97,7 +97,7 @@ fn redact_header_value(s: &str, scheme: &str) -> String {
     // Pattern: "Authorization:" (optional whitespace) scheme (whitespace) <value>
     // We scan case-insensitively by lower-casing a working copy for position
     // finding, then apply redaction to the original.
-    let needle = format!("authorization:");
+    let needle = "authorization:".to_string();
     let lower = s.to_lowercase();
     let scheme_lower = scheme.to_lowercase();
 

--- a/src/security.rs
+++ b/src/security.rs
@@ -89,8 +89,7 @@ fn redact_prefixed_token(s: &str, prefix: &str, min_suffix: usize) -> String {
 ///
 /// Matching is case-insensitive for the header name and scheme keyword.
 fn redact_auth_headers(s: String) -> String {
-    redact_header_value(&s, "Bearer")
-        .pipe(|s| redact_header_value(&s, "token"))
+    redact_header_value(&s, "Bearer").pipe(|s| redact_header_value(&s, "token"))
 }
 
 fn redact_header_value(s: &str, scheme: &str) -> String {
@@ -309,10 +308,14 @@ mod tests {
 
     #[test]
     fn auth_header_preserves_rest_of_line() {
-        let input = "GET /api HTTP/1.1\nAuthorization: Bearer abc123def\nContent-Type: application/json";
+        let input =
+            "GET /api HTTP/1.1\nAuthorization: Bearer abc123def\nContent-Type: application/json";
         let output = redact_secrets(input);
         assert!(!output.contains("abc123def"), "{output}");
-        assert!(output.contains("Content-Type: application/json"), "{output}");
+        assert!(
+            output.contains("Content-Type: application/json"),
+            "{output}"
+        );
         assert!(output.contains("GET /api HTTP/1.1"), "{output}");
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::io::{BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
 use std::time::Instant;
-use tracing::{info, warn};
+use tracing::{info, warn, error};
 
 // ── Request / response types ──────────────────────────────────────────────────
 
@@ -224,22 +224,44 @@ impl ServiceMode {
 
                 match adapter.execute(&prompt) {
                     Ok(result) => {
-                        if result.succeeded() {
+                        let ok = result.succeeded();
+                        let duration_ms = result.duration.as_millis();
+                        if ok {
                             state.success_count += 1;
+                            info!(
+                                provider = adapter.name(),
+                                duration_ms,
+                                exit_code = result.exit_code,
+                                ok = true,
+                                "Service run completed"
+                            );
                         } else {
                             state.failure_count += 1;
+                            warn!(
+                                provider = adapter.name(),
+                                duration_ms,
+                                exit_code = result.exit_code,
+                                ok = false,
+                                "Service run failed"
+                            );
                         }
                         let data = serde_json::json!({
-                            "ok": result.succeeded(),
+                            "ok": ok,
                             "exit_code": result.exit_code,
                             "stdout": result.stdout,
                             "stderr": result.stderr,
-                            "duration_ms": result.duration.as_millis(),
+                            "duration_ms": duration_ms,
                         });
                         (ServiceResponse::success(data), false)
                     }
                     Err(e) => {
                         state.failure_count += 1;
+                        error!(
+                            provider = adapter.name(),
+                            error = %e,
+                            ok = false,
+                            "Service run error"
+                        );
                         (ServiceResponse::failure(e.to_string()), false)
                     }
                 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,0 +1,378 @@
+use crate::config::{LoopConfig, Provider as ProviderKind};
+use crate::provider::build_adapter;
+use serde::{Deserialize, Serialize};
+use std::io::{BufRead, BufReader, Write};
+use std::net::{TcpListener, TcpStream};
+use std::time::Instant;
+use tracing::{info, warn};
+
+// ── Request / response types ──────────────────────────────────────────────────
+
+/// A JSON-lines request from a service client.
+///
+/// Wire format: `{"cmd": "<name>", ...fields}` as a single newline-terminated
+/// JSON object.
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(tag = "cmd", rename_all = "lowercase")]
+pub enum ServiceRequest {
+    /// Execute one provider iteration with the given prompt.
+    ///
+    /// `provider` overrides the service-level default for this single request.
+    Run {
+        prompt: String,
+        #[serde(default)]
+        provider: Option<ProviderKind>,
+    },
+    /// Return service uptime and run statistics.
+    Status,
+    /// Gracefully stop the service after the current connection closes.
+    Shutdown,
+}
+
+/// A JSON-lines response returned to the client for each request.
+#[derive(Debug, Serialize)]
+pub struct ServiceResponse {
+    /// `true` when the request completed without error.
+    pub ok: bool,
+    /// Request-specific payload (present on success).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+    /// Human-readable error description (present on failure).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl ServiceResponse {
+    /// Build a successful response with an attached payload.
+    pub fn success(data: serde_json::Value) -> Self {
+        Self { ok: true, data: Some(data), error: None }
+    }
+
+    /// Build an error response with a description.
+    pub fn failure(msg: impl Into<String>) -> Self {
+        Self { ok: false, data: None, error: Some(msg.into()) }
+    }
+}
+
+// ── Service state ─────────────────────────────────────────────────────────────
+
+/// Accumulated statistics for the lifetime of one service session.
+struct ServiceState {
+    started_at: Instant,
+    run_count: u64,
+    success_count: u64,
+    failure_count: u64,
+}
+
+impl ServiceState {
+    fn new() -> Self {
+        Self { started_at: Instant::now(), run_count: 0, success_count: 0, failure_count: 0 }
+    }
+
+    fn uptime_secs(&self) -> u64 {
+        self.started_at.elapsed().as_secs()
+    }
+}
+
+// ── ServiceMode ───────────────────────────────────────────────────────────────
+
+/// Embedded service mode: accepts JSON-lines requests over a local TCP socket.
+///
+/// Each connection is processed sequentially.  The service shuts down cleanly
+/// when a `shutdown` command is received or when the process receives SIGINT.
+///
+/// # Protocol
+///
+/// Each request is a single newline-terminated JSON object.  The server
+/// responds with a single newline-terminated JSON object per request.
+///
+/// ```text
+/// Client → {"cmd":"run","prompt":"fix the tests"}
+/// Server ← {"ok":true,"data":{"exit_code":0,"stdout":"...","duration_ms":1200}}
+///
+/// Client → {"cmd":"status"}
+/// Server ← {"ok":true,"data":{"uptime_secs":42,"run_count":1,...}}
+///
+/// Client → {"cmd":"shutdown"}
+/// Server ← {"ok":true,"data":{"message":"shutting down"}}
+/// ```
+pub struct ServiceMode {
+    config: LoopConfig,
+    bind_addr: String,
+    port: u16,
+}
+
+impl ServiceMode {
+    /// Create a new service mode from an existing resolved config and binding
+    /// parameters.  `config.provider` is used as the default provider for `run`
+    /// requests that omit the `provider` field.
+    pub fn new(config: LoopConfig, bind_addr: String, port: u16) -> Self {
+        Self { config, bind_addr, port }
+    }
+
+    /// Start the TCP listener and process connections until a `shutdown` command
+    /// is received or the process is terminated.
+    pub fn run(&self) -> anyhow::Result<()> {
+        let addr = format!("{}:{}", self.bind_addr, self.port);
+        let listener = TcpListener::bind(&addr)?;
+        info!(addr = %addr, "Code Looper service listening");
+        println!("Code Looper service listening on {addr}");
+        println!("Send JSON-lines requests (one per line).  Ctrl-C to stop.");
+
+        let mut state = ServiceState::new();
+
+        for stream in listener.incoming() {
+            match stream {
+                Ok(stream) => {
+                    let peer = stream.peer_addr().map(|a| a.to_string()).unwrap_or_default();
+                    info!(peer = %peer, "Client connected");
+                    match self.handle_connection(stream, &mut state) {
+                        Ok(true) => {
+                            info!("Shutdown requested by client — stopping service");
+                            break;
+                        }
+                        Ok(false) => {}
+                        Err(e) => warn!(error = %e, "Connection error"),
+                    }
+                }
+                Err(e) => warn!(error = %e, "Accept error"),
+            }
+        }
+
+        info!(
+            runs = state.run_count,
+            successes = state.success_count,
+            failures = state.failure_count,
+            uptime_secs = state.uptime_secs(),
+            "Code Looper service stopped"
+        );
+        Ok(())
+    }
+
+    /// Process all requests from one TCP connection.
+    ///
+    /// Returns `Ok(true)` if the client sent a `shutdown` command.
+    fn handle_connection(
+        &self,
+        stream: TcpStream,
+        state: &mut ServiceState,
+    ) -> anyhow::Result<bool> {
+        let mut write_stream = stream.try_clone()?;
+        let reader = BufReader::new(stream);
+        let mut shutdown_requested = false;
+
+        for raw_line in reader.lines() {
+            let line = raw_line?;
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+
+            let (response, shutdown) = match serde_json::from_str::<ServiceRequest>(line) {
+                Ok(req) => self.process_request(req, state),
+                Err(e) => (ServiceResponse::failure(format!("parse error: {e}")), false),
+            };
+
+            let response_json = serde_json::to_string(&response)?;
+            writeln!(write_stream, "{response_json}")?;
+
+            if shutdown {
+                shutdown_requested = true;
+                break;
+            }
+        }
+
+        Ok(shutdown_requested)
+    }
+
+    /// Dispatch a parsed request to its handler and return (response, shutdown).
+    fn process_request(
+        &self,
+        req: ServiceRequest,
+        state: &mut ServiceState,
+    ) -> (ServiceResponse, bool) {
+        match req {
+            ServiceRequest::Run { prompt, provider } => {
+                let provider_kind = provider.as_ref().unwrap_or(&self.config.provider);
+                let adapter =
+                    build_adapter(provider_kind, false, self.config.workspace_dir.clone());
+                state.run_count += 1;
+
+                match adapter.execute(&prompt) {
+                    Ok(result) => {
+                        if result.succeeded() {
+                            state.success_count += 1;
+                        } else {
+                            state.failure_count += 1;
+                        }
+                        let data = serde_json::json!({
+                            "ok": result.succeeded(),
+                            "exit_code": result.exit_code,
+                            "stdout": result.stdout,
+                            "stderr": result.stderr,
+                            "duration_ms": result.duration.as_millis(),
+                        });
+                        (ServiceResponse::success(data), false)
+                    }
+                    Err(e) => {
+                        state.failure_count += 1;
+                        (ServiceResponse::failure(e.to_string()), false)
+                    }
+                }
+            }
+
+            ServiceRequest::Status => {
+                let data = serde_json::json!({
+                    "uptime_secs": state.uptime_secs(),
+                    "run_count": state.run_count,
+                    "success_count": state.success_count,
+                    "failure_count": state.failure_count,
+                    "provider": self.config.provider.to_string(),
+                });
+                (ServiceResponse::success(data), false)
+            }
+
+            ServiceRequest::Shutdown => {
+                let data = serde_json::json!({"message": "shutting down"});
+                (ServiceResponse::success(data), true)
+            }
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── ServiceRequest parsing ────────────────────────────────────────────────
+
+    #[test]
+    fn parse_run_request_with_default_provider() {
+        let json = r#"{"cmd":"run","prompt":"fix tests"}"#;
+        let req: ServiceRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            req,
+            ServiceRequest::Run { prompt: "fix tests".to_string(), provider: None }
+        );
+    }
+
+    #[test]
+    fn parse_run_request_with_explicit_provider() {
+        let json = r#"{"cmd":"run","prompt":"hello","provider":"codex"}"#;
+        let req: ServiceRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            req,
+            ServiceRequest::Run {
+                prompt: "hello".to_string(),
+                provider: Some(ProviderKind::Codex),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_status_request() {
+        let json = r#"{"cmd":"status"}"#;
+        let req: ServiceRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req, ServiceRequest::Status);
+    }
+
+    #[test]
+    fn parse_shutdown_request() {
+        let json = r#"{"cmd":"shutdown"}"#;
+        let req: ServiceRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req, ServiceRequest::Shutdown);
+    }
+
+    #[test]
+    fn parse_unknown_command_returns_error() {
+        let json = r#"{"cmd":"frobnicate"}"#;
+        let result: Result<ServiceRequest, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    // ── ServiceResponse serialization ─────────────────────────────────────────
+
+    #[test]
+    fn success_response_omits_error_field() {
+        let resp = ServiceResponse::success(serde_json::json!({"key": "value"}));
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"ok\":true"));
+        assert!(json.contains("\"key\":\"value\""));
+        assert!(!json.contains("\"error\""));
+    }
+
+    #[test]
+    fn failure_response_omits_data_field() {
+        let resp = ServiceResponse::failure("something went wrong");
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"ok\":false"));
+        assert!(json.contains("\"error\":\"something went wrong\""));
+        assert!(!json.contains("\"data\""));
+    }
+
+    // ── ServiceState ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn service_state_initial_counts_are_zero() {
+        let state = ServiceState::new();
+        assert_eq!(state.run_count, 0);
+        assert_eq!(state.success_count, 0);
+        assert_eq!(state.failure_count, 0);
+    }
+
+    #[test]
+    fn service_state_uptime_is_non_negative() {
+        let state = ServiceState::new();
+        // Uptime immediately after creation should be 0 or very small.
+        assert!(state.uptime_secs() < 5);
+    }
+
+    // ── process_request (status / shutdown via ServiceMode) ───────────────────
+
+    fn make_service() -> ServiceMode {
+        let config = crate::config::LoopConfig {
+            provider: ProviderKind::Claude,
+            ..Default::default()
+        };
+        ServiceMode::new(config, "127.0.0.1".to_string(), 7979)
+    }
+
+    #[test]
+    fn process_status_returns_correct_fields() {
+        let service = make_service();
+        let mut state = ServiceState::new();
+        state.run_count = 3;
+        state.success_count = 2;
+        state.failure_count = 1;
+
+        let (resp, shutdown) = service.process_request(ServiceRequest::Status, &mut state);
+        assert!(!shutdown);
+        assert!(resp.ok);
+        let data = resp.data.unwrap();
+        assert_eq!(data["run_count"], 3);
+        assert_eq!(data["success_count"], 2);
+        assert_eq!(data["failure_count"], 1);
+        assert_eq!(data["provider"], "claude");
+    }
+
+    #[test]
+    fn process_shutdown_sets_shutdown_flag() {
+        let service = make_service();
+        let mut state = ServiceState::new();
+        let (resp, shutdown) = service.process_request(ServiceRequest::Shutdown, &mut state);
+        assert!(shutdown);
+        assert!(resp.ok);
+        let data = resp.data.unwrap();
+        assert_eq!(data["message"], "shutting down");
+    }
+
+    #[test]
+    fn process_status_increments_uptime_field_exists() {
+        let service = make_service();
+        let mut state = ServiceState::new();
+        let (resp, _) = service.process_request(ServiceRequest::Status, &mut state);
+        assert!(resp.data.as_ref().and_then(|d| d.get("uptime_secs")).is_some());
+    }
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -219,6 +219,7 @@ impl ServiceMode {
                     false,
                     self.config.workspace_dir.clone(),
                     self.config.iteration_timeout_secs,
+                    self.config.provider_extra_args.clone(),
                 );
                 state.run_count += 1;
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -2,7 +2,7 @@ use crate::config::{LoopConfig, Provider as ProviderKind};
 use crate::provider::build_adapter;
 use serde::{Deserialize, Serialize};
 use std::io::{BufRead, BufReader, Write};
-use std::net::{TcpListener, TcpStream};
+use std::net::{IpAddr, TcpListener, TcpStream};
 use std::time::Instant;
 use tracing::{error, info, warn};
 
@@ -117,23 +117,63 @@ pub struct ServiceMode {
     config: LoopConfig,
     bind_addr: String,
     port: u16,
+    /// When `true`, `run()` will accept a non-loopback bind address.  See
+    /// `--unsafe-bind` in the CLI.  Defaults to `false`, in which case any
+    /// non-loopback bind is refused with an error.
+    unsafe_bind: bool,
 }
 
 impl ServiceMode {
     /// Create a new service mode from an existing resolved config and binding
     /// parameters.  `config.provider` is used as the default provider for `run`
     /// requests that omit the `provider` field.
-    pub fn new(config: LoopConfig, bind_addr: String, port: u16) -> Self {
+    ///
+    /// `unsafe_bind` controls whether `run()` will accept a non-loopback bind
+    /// address — see `Self::is_loopback_bind` and `--unsafe-bind` on the CLI.
+    pub fn new(config: LoopConfig, bind_addr: String, port: u16, unsafe_bind: bool) -> Self {
         Self {
             config,
             bind_addr,
             port,
+            unsafe_bind,
         }
     }
 
     /// Start the TCP listener and process connections until a `shutdown` command
     /// is received or the process is terminated.
     pub fn run(&self) -> anyhow::Result<()> {
+        // Safety gate: service mode has no built-in auth, no TLS, and no peer
+        // check, yet `run` executes arbitrary prompts with
+        // `--dangerously-skip-permissions`.  Refuse non-loopback binds unless
+        // the caller explicitly opts in via `--unsafe-bind`.  See #61.
+        match Self::is_loopback_bind(&self.bind_addr) {
+            Some(true) => {}
+            Some(false) => {
+                if !self.unsafe_bind {
+                    anyhow::bail!(
+                        "refusing to bind service mode to non-loopback address '{}': \
+                         the service has no built-in auth and exposes `run` with \
+                         --dangerously-skip-permissions.  Pass --unsafe-bind to \
+                         override (only when the deployment is already behind an \
+                         external auth/firewall boundary).",
+                        self.bind_addr
+                    );
+                }
+                warn!(
+                    bind_addr = %self.bind_addr,
+                    "⚠ Service mode bound to NON-LOOPBACK address with --unsafe-bind. \
+                     There is no built-in authentication; anyone who can reach this \
+                     port can execute provider prompts on the host."
+                );
+            }
+            None => {
+                anyhow::bail!(
+                    "could not parse bind address '{}' as an IP address",
+                    self.bind_addr
+                );
+            }
+        }
+
         let addr = format!("{}:{}", self.bind_addr, self.port);
         let listener = TcpListener::bind(&addr)?;
         info!(addr = %addr, "Code Looper service listening");
@@ -174,6 +214,26 @@ impl ServiceMode {
             "Code Looper service stopped"
         );
         Ok(())
+    }
+
+    /// Classify a bind address as loopback (`Some(true)`), routable
+    /// (`Some(false)`), or unparseable (`None`).
+    ///
+    /// - `127.0.0.0/8` matches via `Ipv4Addr::is_loopback`.
+    /// - `::1` matches via `Ipv6Addr::is_loopback`.
+    /// - The literal string `localhost` is treated as loopback.
+    /// - Anything else that parses as an IP is considered non-loopback.
+    ///
+    /// Returns `None` only when the address is not `localhost` and does not
+    /// parse as an IP.
+    fn is_loopback_bind(bind_addr: &str) -> Option<bool> {
+        if bind_addr.eq_ignore_ascii_case("localhost") {
+            return Some(true);
+        }
+        match bind_addr.parse::<IpAddr>() {
+            Ok(ip) => Some(ip.is_loopback()),
+            Err(_) => None,
+        }
     }
 
     /// Process all requests from one TCP connection.
@@ -393,7 +453,7 @@ mod tests {
             provider: ProviderKind::Claude,
             ..Default::default()
         };
-        ServiceMode::new(config, "127.0.0.1".to_string(), 7979)
+        ServiceMode::new(config, "127.0.0.1".to_string(), 7979, false)
     }
 
     #[test]
@@ -423,6 +483,57 @@ mod tests {
         assert!(resp.ok);
         let data = resp.data.unwrap();
         assert_eq!(data["message"], "shutting down");
+    }
+
+    // ── is_loopback_bind (safety gate for #61) ────────────────────────────────
+
+    #[test]
+    fn loopback_ipv4_is_loopback() {
+        assert_eq!(ServiceMode::is_loopback_bind("127.0.0.1"), Some(true));
+        assert_eq!(ServiceMode::is_loopback_bind("127.1.2.3"), Some(true));
+    }
+
+    #[test]
+    fn loopback_ipv6_is_loopback() {
+        assert_eq!(ServiceMode::is_loopback_bind("::1"), Some(true));
+    }
+
+    #[test]
+    fn localhost_string_is_loopback() {
+        assert_eq!(ServiceMode::is_loopback_bind("localhost"), Some(true));
+        assert_eq!(ServiceMode::is_loopback_bind("LOCALHOST"), Some(true));
+    }
+
+    #[test]
+    fn routable_ipv4_is_not_loopback() {
+        assert_eq!(ServiceMode::is_loopback_bind("0.0.0.0"), Some(false));
+        assert_eq!(ServiceMode::is_loopback_bind("192.168.1.10"), Some(false));
+        assert_eq!(ServiceMode::is_loopback_bind("10.0.0.1"), Some(false));
+    }
+
+    #[test]
+    fn routable_ipv6_is_not_loopback() {
+        assert_eq!(ServiceMode::is_loopback_bind("::"), Some(false));
+        assert_eq!(ServiceMode::is_loopback_bind("2001:db8::1"), Some(false));
+    }
+
+    #[test]
+    fn unparseable_bind_addr_returns_none() {
+        assert_eq!(ServiceMode::is_loopback_bind("not an ip"), None);
+        assert_eq!(ServiceMode::is_loopback_bind("example.com"), None);
+    }
+
+    #[test]
+    fn service_run_refuses_non_loopback_without_unsafe_flag() {
+        let config = crate::config::LoopConfig {
+            provider: ProviderKind::Claude,
+            ..Default::default()
+        };
+        let svc = ServiceMode::new(config, "0.0.0.0".to_string(), 0, false);
+        let err = svc.run().expect_err("bind should be refused");
+        let msg = err.to_string();
+        assert!(msg.contains("non-loopback"), "{msg}");
+        assert!(msg.contains("--unsafe-bind"), "{msg}");
     }
 
     #[test]

--- a/src/service.rs
+++ b/src/service.rs
@@ -195,7 +195,7 @@ impl ServiceMode {
             ServiceRequest::Run { prompt, provider } => {
                 let provider_kind = provider.as_ref().unwrap_or(&self.config.provider);
                 let adapter =
-                    build_adapter(provider_kind, false, self.config.workspace_dir.clone());
+                    build_adapter(provider_kind, false, self.config.workspace_dir.clone(), self.config.iteration_timeout_secs);
                 state.run_count += 1;
 
                 match adapter.execute(&prompt) {

--- a/src/service.rs
+++ b/src/service.rs
@@ -92,7 +92,11 @@ impl ServiceState {
 /// Embedded service mode: accepts JSON-lines requests over a local TCP socket.
 ///
 /// Each connection is processed sequentially.  The service shuts down cleanly
-/// when a `shutdown` command is received or when the process receives SIGINT.
+/// only when a client sends a `{"cmd":"shutdown"}` request.  SIGINT/Ctrl-C
+/// terminates the process via the default signal handler — there is currently
+/// no installed `ctrlc` handler in service mode, so any in-flight client
+/// connection is dropped without a closing reply.  Prefer the `shutdown`
+/// command for orderly stops.
 ///
 /// # Protocol
 ///
@@ -134,7 +138,10 @@ impl ServiceMode {
         let listener = TcpListener::bind(&addr)?;
         info!(addr = %addr, "Code Looper service listening");
         println!("Code Looper service listening on {addr}");
-        println!("Send JSON-lines requests (one per line).  Ctrl-C to stop.");
+        println!(
+            "Send JSON-lines requests (one per line).  \
+             Send {{\"cmd\":\"shutdown\"}} for a clean stop; Ctrl-C terminates the process."
+        );
 
         let mut state = ServiceState::new();
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -45,12 +45,20 @@ pub struct ServiceResponse {
 impl ServiceResponse {
     /// Build a successful response with an attached payload.
     pub fn success(data: serde_json::Value) -> Self {
-        Self { ok: true, data: Some(data), error: None }
+        Self {
+            ok: true,
+            data: Some(data),
+            error: None,
+        }
     }
 
     /// Build an error response with a description.
     pub fn failure(msg: impl Into<String>) -> Self {
-        Self { ok: false, data: None, error: Some(msg.into()) }
+        Self {
+            ok: false,
+            data: None,
+            error: Some(msg.into()),
+        }
     }
 }
 
@@ -66,7 +74,12 @@ struct ServiceState {
 
 impl ServiceState {
     fn new() -> Self {
-        Self { started_at: Instant::now(), run_count: 0, success_count: 0, failure_count: 0 }
+        Self {
+            started_at: Instant::now(),
+            run_count: 0,
+            success_count: 0,
+            failure_count: 0,
+        }
     }
 
     fn uptime_secs(&self) -> u64 {
@@ -107,7 +120,11 @@ impl ServiceMode {
     /// parameters.  `config.provider` is used as the default provider for `run`
     /// requests that omit the `provider` field.
     pub fn new(config: LoopConfig, bind_addr: String, port: u16) -> Self {
-        Self { config, bind_addr, port }
+        Self {
+            config,
+            bind_addr,
+            port,
+        }
     }
 
     /// Start the TCP listener and process connections until a `shutdown` command
@@ -124,7 +141,10 @@ impl ServiceMode {
         for stream in listener.incoming() {
             match stream {
                 Ok(stream) => {
-                    let peer = stream.peer_addr().map(|a| a.to_string()).unwrap_or_default();
+                    let peer = stream
+                        .peer_addr()
+                        .map(|a| a.to_string())
+                        .unwrap_or_default();
                     info!(peer = %peer, "Client connected");
                     match self.handle_connection(stream, &mut state) {
                         Ok(true) => {
@@ -194,8 +214,12 @@ impl ServiceMode {
         match req {
             ServiceRequest::Run { prompt, provider } => {
                 let provider_kind = provider.as_ref().unwrap_or(&self.config.provider);
-                let adapter =
-                    build_adapter(provider_kind, false, self.config.workspace_dir.clone(), self.config.iteration_timeout_secs);
+                let adapter = build_adapter(
+                    provider_kind,
+                    false,
+                    self.config.workspace_dir.clone(),
+                    self.config.iteration_timeout_secs,
+                );
                 state.run_count += 1;
 
                 match adapter.execute(&prompt) {
@@ -254,7 +278,10 @@ mod tests {
         let req: ServiceRequest = serde_json::from_str(json).unwrap();
         assert_eq!(
             req,
-            ServiceRequest::Run { prompt: "fix tests".to_string(), provider: None }
+            ServiceRequest::Run {
+                prompt: "fix tests".to_string(),
+                provider: None
+            }
         );
     }
 
@@ -373,6 +400,10 @@ mod tests {
         let service = make_service();
         let mut state = ServiceState::new();
         let (resp, _) = service.process_request(ServiceRequest::Status, &mut state);
-        assert!(resp.data.as_ref().and_then(|d| d.get("uptime_secs")).is_some());
+        assert!(resp
+            .data
+            .as_ref()
+            .and_then(|d| d.get("uptime_secs"))
+            .is_some());
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::io::{BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
 use std::time::Instant;
-use tracing::{info, warn, error};
+use tracing::{error, info, warn};
 
 // ── Request / response types ──────────────────────────────────────────────────
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -44,7 +44,10 @@ impl IterationOutcome {
     /// exit states, and policy guard blocks are treated as non-retryable
     /// because a retry is unlikely to change the outcome.
     pub fn is_retryable(&self) -> bool {
-        matches!(self, IterationOutcome::NonZeroExit { .. } | IterationOutcome::Timeout)
+        matches!(
+            self,
+            IterationOutcome::NonZeroExit { .. } | IterationOutcome::Timeout
+        )
     }
 
     /// Classify an exit code into an outcome.
@@ -120,7 +123,10 @@ pub struct IterationRecord {
 impl IterationRecord {
     /// Extract the first non-empty line from a stderr string for the log excerpt.
     pub fn stderr_first_line(stderr: &str) -> Option<String> {
-        stderr.lines().find(|l| !l.trim().is_empty()).map(|l| l.to_string())
+        stderr
+            .lines()
+            .find(|l| !l.trim().is_empty())
+            .map(|l| l.to_string())
     }
 }
 
@@ -159,28 +165,28 @@ impl RunArtifacts {
         let run_dir = artifacts_root.join(&run_id);
         if enabled {
             if let Err(e) = std::fs::create_dir_all(&run_dir) {
-                warn!("Could not create run artifacts dir {}: {e}", run_dir.display());
+                warn!(
+                    "Could not create run artifacts dir {}: {e}",
+                    run_dir.display()
+                );
             }
         }
-        Self { run_id, run_dir, enabled }
+        Self {
+            run_id,
+            run_dir,
+            enabled,
+        }
     }
 
     /// Write a transcript for iteration `n` (1-based).  Returns the path
     /// written (relative to the run dir), or `None` when disabled or on error.
-    pub fn write_transcript(
-        &self,
-        iteration: u64,
-        stdout: &str,
-        stderr: &str,
-    ) -> Option<String> {
+    pub fn write_transcript(&self, iteration: u64, stdout: &str, stderr: &str) -> Option<String> {
         if !self.enabled {
             return None;
         }
         let filename = format!("iteration-{iteration}.log");
         let path = self.run_dir.join(&filename);
-        let content = format!(
-            "=== STDOUT ===\n{stdout}\n=== STDERR ===\n{stderr}\n"
-        );
+        let content = format!("=== STDOUT ===\n{stdout}\n=== STDERR ===\n{stderr}\n");
         if let Err(e) = std::fs::write(&path, content) {
             warn!("Could not write transcript {}: {e}", path.display());
             return None;
@@ -205,11 +211,7 @@ impl RunArtifacts {
     }
 
     /// Write the human-readable `summary.md` and return its path.
-    pub fn write_summary(
-        &self,
-        manifest: &RunManifest,
-        no_summary: bool,
-    ) -> Option<PathBuf> {
+    pub fn write_summary(&self, manifest: &RunManifest, no_summary: bool) -> Option<PathBuf> {
         let summary = build_summary_markdown(manifest);
         if !no_summary {
             print_terminal_summary(&summary);
@@ -273,13 +275,14 @@ fn build_summary_markdown(manifest: &RunManifest) -> String {
     let ended = manifest.ended_at.unwrap_or(started);
     let total_secs = ended.saturating_sub(started);
     let iterations_executed = manifest.iterations.len();
-    let successes = manifest.iterations.iter().filter(|i| i.outcome.is_success()).count();
+    let successes = manifest
+        .iterations
+        .iter()
+        .filter(|i| i.outcome.is_success())
+        .count();
     let failures = iterations_executed - successes;
     let total_retries: u32 = manifest.iterations.iter().map(|i| i.retries).sum();
-    let term_reason = manifest
-        .termination_reason
-        .as_deref()
-        .unwrap_or("unknown");
+    let term_reason = manifest.termination_reason.as_deref().unwrap_or("unknown");
 
     let mut md = String::new();
     md.push_str("# Code Looper — Run Summary\n\n");
@@ -297,7 +300,10 @@ fn build_summary_markdown(manifest: &RunManifest) -> String {
         "| Iterations requested | {} |\n",
         manifest.iterations_requested
     ));
-    md.push_str(&format!("| Iterations executed | {} |\n", iterations_executed));
+    md.push_str(&format!(
+        "| Iterations executed | {} |\n",
+        iterations_executed
+    ));
     md.push_str(&format!("| Termination reason | {} |\n\n", term_reason));
 
     // Totals
@@ -307,7 +313,10 @@ fn build_summary_markdown(manifest: &RunManifest) -> String {
     md.push_str(&format!("| Successes | {} |\n", successes));
     md.push_str(&format!("| Failures | {} |\n", failures));
     md.push_str(&format!("| Retries | {} |\n", total_retries));
-    md.push_str(&format!("| Skipped decisions | {} |\n\n", manifest.skipped_decisions));
+    md.push_str(&format!(
+        "| Skipped decisions | {} |\n\n",
+        manifest.skipped_decisions
+    ));
 
     // Per-iteration table
     if !manifest.iterations.is_empty() {
@@ -387,7 +396,10 @@ mod tests {
 
     #[test]
     fn outcome_from_exit_code_zero_is_success() {
-        assert_eq!(IterationOutcome::from_exit_code(Some(0)), IterationOutcome::Success);
+        assert_eq!(
+            IterationOutcome::from_exit_code(Some(0)),
+            IterationOutcome::Success
+        );
         assert!(IterationOutcome::from_exit_code(Some(0)).is_success());
     }
 
@@ -400,12 +412,17 @@ mod tests {
 
     #[test]
     fn outcome_from_exit_code_none_is_signal() {
-        assert_eq!(IterationOutcome::from_exit_code(None), IterationOutcome::Signal);
+        assert_eq!(
+            IterationOutcome::from_exit_code(None),
+            IterationOutcome::Signal
+        );
     }
 
     #[test]
     fn spawn_failure_is_fatal() {
-        let o = IterationOutcome::SpawnFailure { message: "not found".to_string() };
+        let o = IterationOutcome::SpawnFailure {
+            message: "not found".to_string(),
+        };
         assert!(o.is_fatal());
         assert!(!o.is_success());
     }
@@ -421,10 +438,14 @@ mod tests {
         assert!(!IterationOutcome::Success.is_retryable());
         assert!(!IterationOutcome::Signal.is_retryable());
         assert!(!IterationOutcome::Unknown.is_retryable());
-        assert!(!IterationOutcome::SpawnFailure { message: String::new() }.is_retryable());
-        assert!(
-            !IterationOutcome::PolicyGuardBlock { message: String::new() }.is_retryable()
-        );
+        assert!(!IterationOutcome::SpawnFailure {
+            message: String::new()
+        }
+        .is_retryable());
+        assert!(!IterationOutcome::PolicyGuardBlock {
+            message: String::new()
+        }
+        .is_retryable());
     }
 
     #[test]
@@ -435,11 +456,17 @@ mod tests {
             "non_zero_exit"
         );
         assert_eq!(
-            IterationOutcome::SpawnFailure { message: String::new() }.label(),
+            IterationOutcome::SpawnFailure {
+                message: String::new()
+            }
+            .label(),
             "spawn_failure"
         );
         assert_eq!(
-            IterationOutcome::PolicyGuardBlock { message: String::new() }.label(),
+            IterationOutcome::PolicyGuardBlock {
+                message: String::new()
+            }
+            .label(),
             "policy_guard_block"
         );
         assert_eq!(IterationOutcome::Signal.label(), "signal");
@@ -523,20 +550,18 @@ mod tests {
             iterations_requested: 2,
             termination_reason: Some("completed".to_string()),
             skipped_decisions: 2,
-            iterations: vec![
-                IterationRecord {
-                    iteration: 1,
-                    provider: "claude".to_string(),
-                    prompt_source: "inline".to_string(),
-                    workflow_branch: None,
-                    outcome: IterationOutcome::Success,
-                    duration_ms: 500,
-                    retries: 0,
-                    stderr_excerpt: None,
-                    transcript_path: Some("iteration-1.log".to_string()),
-                    started_at: 1000,
-                },
-            ],
+            iterations: vec![IterationRecord {
+                iteration: 1,
+                provider: "claude".to_string(),
+                prompt_source: "inline".to_string(),
+                workflow_branch: None,
+                outcome: IterationOutcome::Success,
+                duration_ms: 500,
+                retries: 0,
+                stderr_excerpt: None,
+                transcript_path: Some("iteration-1.log".to_string()),
+                started_at: 1000,
+            }],
         };
         let md = build_summary_markdown(&manifest);
         assert!(md.contains("test-run"));

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -145,6 +145,16 @@ pub struct RunManifest {
     /// (e.g. PR blocked on human review, no actionable PR found).
     #[serde(default)]
     pub skipped_decisions: u64,
+    /// Operator identity: value of `$USER` (or `$USERNAME` on Windows) at run
+    /// start.  `None` when neither environment variable is set.
+    ///
+    /// Satisfies the PRD audit-provenance requirement: "who/when/provider/policy".
+    #[serde(default)]
+    pub run_by: Option<String>,
+    /// Filesystem path of the workspace directory in which the run executed.
+    /// `None` when the workspace dir was not resolved or not stored.
+    #[serde(default)]
+    pub workspace_dir: Option<String>,
     pub iterations: Vec<IterationRecord>,
 }
 
@@ -261,6 +271,17 @@ fn run_id_now() -> String {
     format!("{secs:020}")
 }
 
+/// Resolve the operator identity from the environment.
+///
+/// Checks `$USER` first (Unix convention), then `$USERNAME` (Windows
+/// convention).  Returns `None` when neither variable is set.
+pub fn resolve_operator() -> Option<String> {
+    std::env::var("USER")
+        .or_else(|_| std::env::var("USERNAME"))
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+
 /// Current Unix timestamp in seconds.
 pub fn unix_now() -> u64 {
     SystemTime::now()
@@ -293,6 +314,12 @@ fn build_summary_markdown(manifest: &RunManifest) -> String {
     md.push_str("|---|---|\n");
     md.push_str(&format!("| Run ID | `{}` |\n", manifest.run_id));
     md.push_str(&format!("| Provider | {} |\n", manifest.provider));
+    if let Some(ref who) = manifest.run_by {
+        md.push_str(&format!("| Run by | {} |\n", who));
+    }
+    if let Some(ref ws) = manifest.workspace_dir {
+        md.push_str(&format!("| Workspace | {} |\n", ws));
+    }
     md.push_str(&format!("| Started | {} |\n", started));
     md.push_str(&format!("| Ended | {} |\n", ended));
     md.push_str(&format!("| Duration | {}s |\n", total_secs));
@@ -515,6 +542,8 @@ mod tests {
             iterations_requested: 2,
             termination_reason: Some("completed".to_string()),
             skipped_decisions: 0,
+            run_by: None,
+            workspace_dir: None,
             iterations: vec![],
         };
         art.write_manifest(&manifest);
@@ -550,6 +579,8 @@ mod tests {
             iterations_requested: 2,
             termination_reason: Some("completed".to_string()),
             skipped_decisions: 2,
+            run_by: None,
+            workspace_dir: None,
             iterations: vec![IterationRecord {
                 iteration: 1,
                 provider: "claude".to_string(),
@@ -570,5 +601,100 @@ mod tests {
         assert!(md.contains("success"));
         assert!(md.contains("iteration-1.log"));
         assert!(md.contains("Skipped decisions"));
+    }
+
+    #[test]
+    fn summary_includes_run_by_when_set() {
+        let manifest = RunManifest {
+            run_id: "r1".to_string(),
+            started_at: 0,
+            ended_at: None,
+            provider: "claude".to_string(),
+            iterations_requested: 1,
+            termination_reason: None,
+            skipped_decisions: 0,
+            run_by: Some("alice".to_string()),
+            workspace_dir: None,
+            iterations: vec![],
+        };
+        let md = build_summary_markdown(&manifest);
+        assert!(md.contains("alice"));
+        assert!(md.contains("Run by"));
+    }
+
+    #[test]
+    fn summary_includes_workspace_dir_when_set() {
+        let manifest = RunManifest {
+            run_id: "r2".to_string(),
+            started_at: 0,
+            ended_at: None,
+            provider: "claude".to_string(),
+            iterations_requested: 1,
+            termination_reason: None,
+            skipped_decisions: 0,
+            run_by: None,
+            workspace_dir: Some("/home/alice/my-repo".to_string()),
+            iterations: vec![],
+        };
+        let md = build_summary_markdown(&manifest);
+        assert!(md.contains("/home/alice/my-repo"));
+        assert!(md.contains("Workspace"));
+    }
+
+    #[test]
+    fn summary_omits_run_by_when_none() {
+        let manifest = RunManifest {
+            run_id: "r3".to_string(),
+            started_at: 0,
+            ended_at: None,
+            provider: "claude".to_string(),
+            iterations_requested: 1,
+            termination_reason: None,
+            skipped_decisions: 0,
+            run_by: None,
+            workspace_dir: None,
+            iterations: vec![],
+        };
+        let md = build_summary_markdown(&manifest);
+        assert!(!md.contains("Run by"));
+        assert!(!md.contains("Workspace"));
+    }
+
+    #[test]
+    fn manifest_run_by_round_trips_through_json() {
+        let manifest = RunManifest {
+            run_id: "r4".to_string(),
+            started_at: 42,
+            ended_at: None,
+            provider: "codex".to_string(),
+            iterations_requested: 3,
+            termination_reason: None,
+            skipped_decisions: 0,
+            run_by: Some("bob".to_string()),
+            workspace_dir: Some("/tmp/proj".to_string()),
+            iterations: vec![],
+        };
+        let json = serde_json::to_string(&manifest).unwrap();
+        let restored: RunManifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.run_by.as_deref(), Some("bob"));
+        assert_eq!(restored.workspace_dir.as_deref(), Some("/tmp/proj"));
+    }
+
+    #[test]
+    fn manifest_missing_run_by_deserializes_to_none() {
+        // Simulates reading an old manifest.json that pre-dates the run_by field.
+        let json = r#"{
+            "run_id": "old",
+            "started_at": 0,
+            "ended_at": null,
+            "provider": "claude",
+            "iterations_requested": 1,
+            "termination_reason": null,
+            "skipped_decisions": 0,
+            "iterations": []
+        }"#;
+        let manifest: RunManifest = serde_json::from_str(json).unwrap();
+        assert!(manifest.run_by.is_none());
+        assert!(manifest.workspace_dir.is_none());
     }
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -31,18 +31,21 @@ impl IterationOutcome {
         matches!(self, IterationOutcome::Success)
     }
 
-    /// Returns `true` when the loop should abort immediately (spawn failure).
-    #[allow(dead_code)]
-    pub fn is_fatal(&self) -> bool {
-        matches!(self, IterationOutcome::SpawnFailure { .. })
-    }
-
-    /// Returns `true` when a retry attempt may recover from this failure.
+    /// Returns `true` when a retry attempt **could** recover from this
+    /// failure *in isolation*, ignoring any user-configured exit-code
+    /// overrides.
     ///
-    /// Non-zero exits are considered transient (e.g. API rate limit, flaky
-    /// network) and are retried by default.  Signal terminations, unknown
-    /// exit states, and policy guard blocks are treated as non-retryable
-    /// because a retry is unlikely to change the outcome.
+    /// Non-zero exits and timeouts are considered transient (API rate
+    /// limit, flaky network, one slow provider call).  Signal terminations,
+    /// unknown exit states, and policy-guard blocks are treated as
+    /// non-retryable because a retry is unlikely to change the outcome.
+    ///
+    /// **This is not the full retry decision.**  The loop engine also
+    /// consults [`crate::config::LoopConfig::non_retryable_exit_codes`],
+    /// which can override `NonZeroExit` back to non-retryable for specific
+    /// codes.  Use [`RetryPolicy::should_retry`] at the actual decision
+    /// point — it combines this method with the config-driven deny list so
+    /// the two sources of truth can't drift apart (see #76).
     pub fn is_retryable(&self) -> bool {
         matches!(
             self,
@@ -90,6 +93,54 @@ impl std::fmt::Display for IterationOutcome {
             IterationOutcome::Timeout => write!(f, "timeout"),
             IterationOutcome::Unknown => write!(f, "unknown"),
         }
+    }
+}
+
+// ── RetryPolicy ───────────────────────────────────────────────────────────────
+
+/// Single source of truth for "should this iteration be retried?".
+///
+/// Before #76 the decision lived in two places:
+/// - [`IterationOutcome::is_retryable`] (the type method), which always
+///   treated `NonZeroExit` as retryable.
+/// - Inlined config reads in `loop_engine::run` against
+///   [`crate::config::LoopConfig::non_retryable_exit_codes`].
+///
+/// A future change to `is_retryable` could silently disagree with the
+/// config-driven path.  `RetryPolicy::should_retry` combines both so the
+/// loop engine makes one call and there is exactly one place to change
+/// when the rule evolves.
+#[derive(Debug, Clone, Copy)]
+pub struct RetryPolicy<'a> {
+    /// Exit codes that must never be retried, even when
+    /// `IterationOutcome::is_retryable()` would otherwise say yes.  Borrowed
+    /// from `LoopConfig::non_retryable_exit_codes`.
+    non_retryable_exit_codes: &'a [i32],
+}
+
+impl<'a> RetryPolicy<'a> {
+    pub fn new(non_retryable_exit_codes: &'a [i32]) -> Self {
+        Self {
+            non_retryable_exit_codes,
+        }
+    }
+
+    /// Return `true` when the loop engine should schedule another attempt
+    /// for `outcome`.
+    ///
+    /// Rules, in order:
+    /// 1. `NonZeroExit { exit_code }` where `exit_code` is in the config's
+    ///    `non_retryable_exit_codes` → **no retry** (user said never).
+    /// 2. Otherwise defer to [`IterationOutcome::is_retryable`] — currently
+    ///    `true` for `NonZeroExit` and `Timeout`, `false` for everything
+    ///    else.
+    pub fn should_retry(&self, outcome: &IterationOutcome) -> bool {
+        if let IterationOutcome::NonZeroExit { exit_code } = outcome {
+            if self.non_retryable_exit_codes.contains(exit_code) {
+                return false;
+            }
+        }
+        outcome.is_retryable()
     }
 }
 
@@ -478,11 +529,10 @@ mod tests {
     }
 
     #[test]
-    fn spawn_failure_is_fatal() {
+    fn spawn_failure_is_not_success() {
         let o = IterationOutcome::SpawnFailure {
             message: "not found".to_string(),
         };
-        assert!(o.is_fatal());
         assert!(!o.is_success());
     }
 
@@ -505,6 +555,44 @@ mod tests {
             message: String::new()
         }
         .is_retryable());
+    }
+
+    // ── RetryPolicy (#76) ─────────────────────────────────────────────────────
+
+    #[test]
+    fn retry_policy_empty_denylist_matches_is_retryable() {
+        let policy = RetryPolicy::new(&[]);
+        assert!(policy.should_retry(&IterationOutcome::NonZeroExit { exit_code: 1 }));
+        assert!(policy.should_retry(&IterationOutcome::Timeout));
+        assert!(!policy.should_retry(&IterationOutcome::Success));
+        assert!(!policy.should_retry(&IterationOutcome::Signal));
+    }
+
+    #[test]
+    fn retry_policy_denylist_blocks_matching_exit_code() {
+        let policy = RetryPolicy::new(&[2, 127]);
+        assert!(
+            !policy.should_retry(&IterationOutcome::NonZeroExit { exit_code: 2 }),
+            "exit code 2 is denylisted"
+        );
+        assert!(
+            !policy.should_retry(&IterationOutcome::NonZeroExit { exit_code: 127 }),
+            "exit code 127 is denylisted"
+        );
+    }
+
+    #[test]
+    fn retry_policy_denylist_does_not_block_other_exit_codes() {
+        let policy = RetryPolicy::new(&[2]);
+        assert!(policy.should_retry(&IterationOutcome::NonZeroExit { exit_code: 1 }));
+        assert!(policy.should_retry(&IterationOutcome::NonZeroExit { exit_code: 3 }));
+    }
+
+    #[test]
+    fn retry_policy_denylist_only_affects_non_zero_exit() {
+        // A denylisted exit code does not suddenly make Timeout non-retryable.
+        let policy = RetryPolicy::new(&[2]);
+        assert!(policy.should_retry(&IterationOutcome::Timeout));
     }
 
     #[test]

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -36,6 +36,16 @@ impl IterationOutcome {
         matches!(self, IterationOutcome::SpawnFailure { .. })
     }
 
+    /// Returns `true` when a retry attempt may recover from this failure.
+    ///
+    /// Non-zero exits are considered transient (e.g. API rate limit, flaky
+    /// network) and are retried by default.  Signal terminations, unknown
+    /// exit states, and policy guard blocks are treated as non-retryable
+    /// because a retry is unlikely to change the outcome.
+    pub fn is_retryable(&self) -> bool {
+        matches!(self, IterationOutcome::NonZeroExit { .. } | IterationOutcome::Timeout)
+    }
+
     /// Classify an exit code into an outcome.
     pub fn from_exit_code(code: Option<i32>) -> Self {
         match code {
@@ -392,6 +402,23 @@ mod tests {
         let o = IterationOutcome::SpawnFailure { message: "not found".to_string() };
         assert!(o.is_fatal());
         assert!(!o.is_success());
+    }
+
+    #[test]
+    fn retryable_outcomes() {
+        assert!(IterationOutcome::NonZeroExit { exit_code: 1 }.is_retryable());
+        assert!(IterationOutcome::Timeout.is_retryable());
+    }
+
+    #[test]
+    fn non_retryable_outcomes() {
+        assert!(!IterationOutcome::Success.is_retryable());
+        assert!(!IterationOutcome::Signal.is_retryable());
+        assert!(!IterationOutcome::Unknown.is_retryable());
+        assert!(!IterationOutcome::SpawnFailure { message: String::new() }.is_retryable());
+        assert!(
+            !IterationOutcome::PolicyGuardBlock { message: String::new() }.is_retryable()
+        );
     }
 
     #[test]

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -263,12 +263,17 @@ impl RunArtifacts {
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /// Generate a run ID from the current timestamp (sortable, filesystem-safe).
+///
+/// Uses nanosecond precision so that two runs starting in the same wall-clock
+/// second do not collide and overwrite each other's artifacts directory.
+/// Padded to 20 digits so the IDs sort lexicographically as well as
+/// chronologically (epoch nanos currently fit in 19 digits, with headroom).
 fn run_id_now() -> String {
-    let secs = SystemTime::now()
+    let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or(Duration::ZERO)
-        .as_secs();
-    format!("{secs:020}")
+        .as_nanos();
+    format!("{nanos:020}")
 }
 
 /// Resolve the operator identity from the environment.
@@ -420,6 +425,33 @@ fn print_terminal_summary(markdown: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `run_id_now()` must produce distinct IDs for back-to-back calls so that
+    /// concurrent runs starting in the same second don't share an artifact
+    /// directory.  Verifies the nanosecond-precision fix for issue #58.
+    #[test]
+    fn run_id_now_is_unique_for_back_to_back_calls() {
+        let mut ids = std::collections::HashSet::new();
+        for _ in 0..1000 {
+            let id = run_id_now();
+            assert!(
+                ids.insert(id.clone()),
+                "duplicate run_id observed within a tight loop: {id}"
+            );
+        }
+    }
+
+    /// Run IDs must be 20-digit zero-padded strings so they sort
+    /// lexicographically as well as chronologically.
+    #[test]
+    fn run_id_now_is_20_digit_zero_padded() {
+        let id = run_id_now();
+        assert_eq!(id.len(), 20, "expected 20-digit ID, got {id}");
+        assert!(
+            id.chars().all(|c| c.is_ascii_digit()),
+            "expected all digits, got {id}"
+        );
+    }
 
     #[test]
     fn outcome_from_exit_code_zero_is_success() {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,513 @@
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tracing::warn;
+
+// ── IterationOutcome ──────────────────────────────────────────────────────────
+
+/// Classified outcome of a single iteration attempt.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IterationOutcome {
+    /// Provider exited with status 0.
+    Success,
+    /// Provider exited with a non-zero status code.
+    NonZeroExit { exit_code: i32 },
+    /// The provider binary could not be spawned.
+    SpawnFailure { message: String },
+    /// The policy guard blocked a disallowed operation.
+    PolicyGuardBlock { message: String },
+    /// Process was terminated by a signal (Unix only; exit_code is None).
+    Signal,
+    /// Provider invocation exceeded the configured timeout.
+    Timeout,
+    /// Exit status was not available (e.g. process exit status unknown).
+    Unknown,
+}
+
+impl IterationOutcome {
+    /// Returns `true` when the iteration is considered successful.
+    pub fn is_success(&self) -> bool {
+        matches!(self, IterationOutcome::Success)
+    }
+
+    /// Returns `true` when the loop should abort immediately (spawn failure).
+    pub fn is_fatal(&self) -> bool {
+        matches!(self, IterationOutcome::SpawnFailure { .. })
+    }
+
+    /// Classify an exit code into an outcome.
+    pub fn from_exit_code(code: Option<i32>) -> Self {
+        match code {
+            Some(0) => IterationOutcome::Success,
+            Some(c) => IterationOutcome::NonZeroExit { exit_code: c },
+            None => IterationOutcome::Signal,
+        }
+    }
+
+    /// Short label for display / logging.
+    pub fn label(&self) -> &'static str {
+        match self {
+            IterationOutcome::Success => "success",
+            IterationOutcome::NonZeroExit { .. } => "non_zero_exit",
+            IterationOutcome::SpawnFailure { .. } => "spawn_failure",
+            IterationOutcome::PolicyGuardBlock { .. } => "policy_guard_block",
+            IterationOutcome::Signal => "signal",
+            IterationOutcome::Timeout => "timeout",
+            IterationOutcome::Unknown => "unknown",
+        }
+    }
+}
+
+impl std::fmt::Display for IterationOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IterationOutcome::Success => write!(f, "success"),
+            IterationOutcome::NonZeroExit { exit_code } => {
+                write!(f, "non_zero_exit({})", exit_code)
+            }
+            IterationOutcome::SpawnFailure { message } => {
+                write!(f, "spawn_failure: {}", message)
+            }
+            IterationOutcome::PolicyGuardBlock { message } => {
+                write!(f, "policy_guard_block: {}", message)
+            }
+            IterationOutcome::Signal => write!(f, "signal"),
+            IterationOutcome::Timeout => write!(f, "timeout"),
+            IterationOutcome::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
+// ── IterationRecord ───────────────────────────────────────────────────────────
+
+/// Durable record for a single completed iteration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IterationRecord {
+    /// 1-based iteration number within this run.
+    pub iteration: u64,
+    /// Provider name (e.g. "claude", "copilot", "codex").
+    pub provider: String,
+    /// Prompt source: "inline", "file", or "none".
+    pub prompt_source: String,
+    /// Orchestration workflow branch selected (if orchestration is enabled).
+    pub workflow_branch: Option<String>,
+    /// Classified outcome.
+    pub outcome: IterationOutcome,
+    /// Wall-clock duration of the provider execution (excluding retries).
+    pub duration_ms: u128,
+    /// Total retry attempts consumed (0 = no retries).
+    pub retries: u32,
+    /// First line of stderr, if the iteration failed.
+    pub stderr_excerpt: Option<String>,
+    /// Path to the full transcript file, relative to the run directory.
+    pub transcript_path: Option<String>,
+    /// Unix timestamp (seconds) when this iteration started.
+    pub started_at: u64,
+}
+
+impl IterationRecord {
+    /// Extract the first non-empty line from a stderr string for the log excerpt.
+    pub fn stderr_first_line(stderr: &str) -> Option<String> {
+        stderr.lines().find(|l| !l.trim().is_empty()).map(|l| l.to_string())
+    }
+}
+
+// ── RunManifest ───────────────────────────────────────────────────────────────
+
+/// Index written to `manifest.json` inside the run directory.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RunManifest {
+    pub run_id: String,
+    pub started_at: u64,
+    pub ended_at: Option<u64>,
+    pub provider: String,
+    pub iterations_requested: i64,
+    pub termination_reason: Option<String>,
+    pub iterations: Vec<IterationRecord>,
+}
+
+// ── RunArtifacts ──────────────────────────────────────────────────────────────
+
+/// Manages the on-disk artifacts directory for a single run.
+pub struct RunArtifacts {
+    pub run_id: String,
+    pub run_dir: PathBuf,
+    pub enabled: bool,
+}
+
+impl RunArtifacts {
+    /// Create the run directory and return a `RunArtifacts` handle.
+    /// When `enabled` is false, all write operations are no-ops.
+    pub fn create(artifacts_root: &Path, enabled: bool) -> Self {
+        let run_id = run_id_now();
+        let run_dir = artifacts_root.join(&run_id);
+        if enabled {
+            if let Err(e) = std::fs::create_dir_all(&run_dir) {
+                warn!("Could not create run artifacts dir {}: {e}", run_dir.display());
+            }
+        }
+        Self { run_id, run_dir, enabled }
+    }
+
+    /// Write a transcript for iteration `n` (1-based).  Returns the path
+    /// written (relative to the run dir), or `None` when disabled or on error.
+    pub fn write_transcript(
+        &self,
+        iteration: u64,
+        stdout: &str,
+        stderr: &str,
+    ) -> Option<String> {
+        if !self.enabled {
+            return None;
+        }
+        let filename = format!("iteration-{iteration}.log");
+        let path = self.run_dir.join(&filename);
+        let content = format!(
+            "=== STDOUT ===\n{stdout}\n=== STDERR ===\n{stderr}\n"
+        );
+        if let Err(e) = std::fs::write(&path, content) {
+            warn!("Could not write transcript {}: {e}", path.display());
+            return None;
+        }
+        Some(filename)
+    }
+
+    /// Write `manifest.json` for the run.
+    pub fn write_manifest(&self, manifest: &RunManifest) {
+        if !self.enabled {
+            return;
+        }
+        let path = self.run_dir.join("manifest.json");
+        match serde_json::to_string_pretty(manifest) {
+            Ok(json) => {
+                if let Err(e) = std::fs::write(&path, json) {
+                    warn!("Could not write manifest {}: {e}", path.display());
+                }
+            }
+            Err(e) => warn!("Could not serialize manifest: {e}"),
+        }
+    }
+
+    /// Write the human-readable `summary.md` and return its path.
+    pub fn write_summary(
+        &self,
+        manifest: &RunManifest,
+        no_summary: bool,
+    ) -> Option<PathBuf> {
+        let summary = build_summary_markdown(manifest);
+        if !no_summary {
+            print_terminal_summary(&summary);
+        }
+        if !self.enabled {
+            return None;
+        }
+        let path = self.run_dir.join("summary.md");
+        if let Err(e) = std::fs::write(&path, &summary) {
+            warn!("Could not write summary {}: {e}", path.display());
+            return None;
+        }
+        Some(path)
+    }
+
+    /// Prune old run directories under `artifacts_root`, keeping only the
+    /// `keep_runs` most recent (by directory name, which is timestamp-ordered).
+    pub fn prune_old_runs(artifacts_root: &Path, keep_runs: usize) {
+        let entries = match std::fs::read_dir(artifacts_root) {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+        let mut dirs: Vec<PathBuf> = entries
+            .flatten()
+            .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+            .map(|e| e.path())
+            .collect();
+        dirs.sort();
+        if dirs.len() > keep_runs {
+            for old in dirs.iter().take(dirs.len() - keep_runs) {
+                if let Err(e) = std::fs::remove_dir_all(old) {
+                    warn!("Could not prune old run dir {}: {e}", old.display());
+                }
+            }
+        }
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Generate a run ID from the current timestamp (sortable, filesystem-safe).
+fn run_id_now() -> String {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs();
+    format!("{secs:020}")
+}
+
+/// Current Unix timestamp in seconds.
+pub fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs()
+}
+
+/// Build the full markdown summary string.
+fn build_summary_markdown(manifest: &RunManifest) -> String {
+    let started = manifest.started_at;
+    let ended = manifest.ended_at.unwrap_or(started);
+    let total_secs = ended.saturating_sub(started);
+    let iterations_executed = manifest.iterations.len();
+    let successes = manifest.iterations.iter().filter(|i| i.outcome.is_success()).count();
+    let failures = iterations_executed - successes;
+    let total_retries: u32 = manifest.iterations.iter().map(|i| i.retries).sum();
+    let term_reason = manifest
+        .termination_reason
+        .as_deref()
+        .unwrap_or("unknown");
+
+    let mut md = String::new();
+    md.push_str("# Code Looper — Run Summary\n\n");
+
+    // Metadata table
+    md.push_str("## Run Metadata\n\n");
+    md.push_str("| Field | Value |\n");
+    md.push_str("|---|---|\n");
+    md.push_str(&format!("| Run ID | `{}` |\n", manifest.run_id));
+    md.push_str(&format!("| Provider | {} |\n", manifest.provider));
+    md.push_str(&format!("| Started | {} |\n", started));
+    md.push_str(&format!("| Ended | {} |\n", ended));
+    md.push_str(&format!("| Duration | {}s |\n", total_secs));
+    md.push_str(&format!(
+        "| Iterations requested | {} |\n",
+        manifest.iterations_requested
+    ));
+    md.push_str(&format!("| Iterations executed | {} |\n", iterations_executed));
+    md.push_str(&format!("| Termination reason | {} |\n\n", term_reason));
+
+    // Totals
+    md.push_str("## Totals\n\n");
+    md.push_str("| Metric | Count |\n");
+    md.push_str("|---|---|\n");
+    md.push_str(&format!("| Successes | {} |\n", successes));
+    md.push_str(&format!("| Failures | {} |\n", failures));
+    md.push_str(&format!("| Retries | {} |\n\n", total_retries));
+
+    // Per-iteration table
+    if !manifest.iterations.is_empty() {
+        md.push_str("## Iterations\n\n");
+        md.push_str("| # | Branch | Status | Duration (ms) | Retries | Stderr excerpt |\n");
+        md.push_str("|---|---|---|---|---|---|\n");
+        for rec in &manifest.iterations {
+            let branch = rec.workflow_branch.as_deref().unwrap_or("-");
+            let excerpt = rec.stderr_excerpt.as_deref().unwrap_or("-");
+            md.push_str(&format!(
+                "| {} | {} | {} | {} | {} | {} |\n",
+                rec.iteration,
+                branch,
+                rec.outcome.label(),
+                rec.duration_ms,
+                rec.retries,
+                excerpt,
+            ));
+        }
+        md.push('\n');
+    }
+
+    // Transcript links
+    let with_transcripts: Vec<_> = manifest
+        .iterations
+        .iter()
+        .filter(|r| r.transcript_path.is_some())
+        .collect();
+    if !with_transcripts.is_empty() {
+        md.push_str("## Transcripts\n\n");
+        for rec in with_transcripts {
+            md.push_str(&format!(
+                "- Iteration {}: [{}]({})\n",
+                rec.iteration,
+                rec.transcript_path.as_deref().unwrap_or(""),
+                rec.transcript_path.as_deref().unwrap_or(""),
+            ));
+        }
+        md.push('\n');
+    }
+
+    md
+}
+
+/// Print a condensed run summary to stdout.
+fn print_terminal_summary(markdown: &str) {
+    // Extract the totals section for the condensed terminal view.
+    println!();
+    println!("─── Run Summary ─────────────────────────────────");
+    for line in markdown.lines() {
+        if line.starts_with("| Run ID")
+            || line.starts_with("| Provider")
+            || line.starts_with("| Duration")
+            || line.starts_with("| Iterations executed")
+            || line.starts_with("| Successes")
+            || line.starts_with("| Failures")
+            || line.starts_with("| Retries")
+            || line.starts_with("| Termination")
+        {
+            // Format: `| Key | Value |`
+            let parts: Vec<&str> = line.split('|').collect();
+            if parts.len() >= 4 {
+                let key = parts[1].trim();
+                let val = parts[2].trim();
+                println!("  {:<26}: {}", key, val);
+            }
+        }
+    }
+    println!("─────────────────────────────────────────────────");
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outcome_from_exit_code_zero_is_success() {
+        assert_eq!(IterationOutcome::from_exit_code(Some(0)), IterationOutcome::Success);
+        assert!(IterationOutcome::from_exit_code(Some(0)).is_success());
+    }
+
+    #[test]
+    fn outcome_from_exit_code_nonzero() {
+        let o = IterationOutcome::from_exit_code(Some(1));
+        assert_eq!(o, IterationOutcome::NonZeroExit { exit_code: 1 });
+        assert!(!o.is_success());
+    }
+
+    #[test]
+    fn outcome_from_exit_code_none_is_signal() {
+        assert_eq!(IterationOutcome::from_exit_code(None), IterationOutcome::Signal);
+    }
+
+    #[test]
+    fn spawn_failure_is_fatal() {
+        let o = IterationOutcome::SpawnFailure { message: "not found".to_string() };
+        assert!(o.is_fatal());
+        assert!(!o.is_success());
+    }
+
+    #[test]
+    fn outcome_labels_are_stable() {
+        assert_eq!(IterationOutcome::Success.label(), "success");
+        assert_eq!(
+            IterationOutcome::NonZeroExit { exit_code: 2 }.label(),
+            "non_zero_exit"
+        );
+        assert_eq!(
+            IterationOutcome::SpawnFailure { message: String::new() }.label(),
+            "spawn_failure"
+        );
+        assert_eq!(
+            IterationOutcome::PolicyGuardBlock { message: String::new() }.label(),
+            "policy_guard_block"
+        );
+        assert_eq!(IterationOutcome::Signal.label(), "signal");
+        assert_eq!(IterationOutcome::Timeout.label(), "timeout");
+        assert_eq!(IterationOutcome::Unknown.label(), "unknown");
+    }
+
+    #[test]
+    fn stderr_first_line_skips_empty_lines() {
+        assert_eq!(
+            IterationRecord::stderr_first_line("\n\nerror: thing failed\nmore"),
+            Some("error: thing failed".to_string())
+        );
+        assert_eq!(IterationRecord::stderr_first_line(""), None);
+    }
+
+    #[test]
+    fn run_artifacts_disabled_writes_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let art = RunArtifacts::create(dir.path(), false);
+        assert!(art.write_transcript(1, "out", "err").is_none());
+        // No directories should have been created under the root.
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
+    }
+
+    #[test]
+    fn run_artifacts_enabled_writes_transcript() {
+        let dir = tempfile::tempdir().unwrap();
+        let art = RunArtifacts::create(dir.path(), true);
+        let name = art.write_transcript(1, "hello", "world").unwrap();
+        assert_eq!(name, "iteration-1.log");
+        let content = std::fs::read_to_string(art.run_dir.join(&name)).unwrap();
+        assert!(content.contains("hello"));
+        assert!(content.contains("world"));
+    }
+
+    #[test]
+    fn run_artifacts_writes_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let art = RunArtifacts::create(dir.path(), true);
+        let manifest = RunManifest {
+            run_id: art.run_id.clone(),
+            started_at: 0,
+            ended_at: Some(10),
+            provider: "claude".to_string(),
+            iterations_requested: 2,
+            termination_reason: Some("completed".to_string()),
+            iterations: vec![],
+        };
+        art.write_manifest(&manifest);
+        let json_path = art.run_dir.join("manifest.json");
+        assert!(json_path.exists());
+        let raw = std::fs::read_to_string(json_path).unwrap();
+        assert!(raw.contains("completed"));
+    }
+
+    #[test]
+    fn prune_keeps_n_most_recent() {
+        let dir = tempfile::tempdir().unwrap();
+        // Create 5 fake run dirs with sortable names.
+        for i in 0..5u32 {
+            std::fs::create_dir(dir.path().join(format!("{:020}", i))).unwrap();
+        }
+        RunArtifacts::prune_old_runs(dir.path(), 3);
+        let remaining = std::fs::read_dir(dir.path())
+            .unwrap()
+            .flatten()
+            .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
+            .count();
+        assert_eq!(remaining, 3);
+    }
+
+    #[test]
+    fn summary_markdown_contains_key_fields() {
+        let manifest = RunManifest {
+            run_id: "test-run".to_string(),
+            started_at: 1000,
+            ended_at: Some(1060),
+            provider: "claude".to_string(),
+            iterations_requested: 2,
+            termination_reason: Some("completed".to_string()),
+            iterations: vec![
+                IterationRecord {
+                    iteration: 1,
+                    provider: "claude".to_string(),
+                    prompt_source: "inline".to_string(),
+                    workflow_branch: None,
+                    outcome: IterationOutcome::Success,
+                    duration_ms: 500,
+                    retries: 0,
+                    stderr_excerpt: None,
+                    transcript_path: Some("iteration-1.log".to_string()),
+                    started_at: 1000,
+                },
+            ],
+        };
+        let md = build_summary_markdown(&manifest);
+        assert!(md.contains("test-run"));
+        assert!(md.contains("claude"));
+        assert!(md.contains("completed"));
+        assert!(md.contains("success"));
+        assert!(md.contains("iteration-1.log"));
+    }
+}

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -32,6 +32,7 @@ impl IterationOutcome {
     }
 
     /// Returns `true` when the loop should abort immediately (spawn failure).
+    #[allow(dead_code)]
     pub fn is_fatal(&self) -> bool {
         matches!(self, IterationOutcome::SpawnFailure { .. })
     }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -135,6 +135,10 @@ pub struct RunManifest {
     pub provider: String,
     pub iterations_requested: i64,
     pub termination_reason: Option<String>,
+    /// Number of planned orchestration actions that were intentionally skipped
+    /// (e.g. PR blocked on human review, no actionable PR found).
+    #[serde(default)]
+    pub skipped_decisions: u64,
     pub iterations: Vec<IterationRecord>,
 }
 
@@ -302,7 +306,8 @@ fn build_summary_markdown(manifest: &RunManifest) -> String {
     md.push_str("|---|---|\n");
     md.push_str(&format!("| Successes | {} |\n", successes));
     md.push_str(&format!("| Failures | {} |\n", failures));
-    md.push_str(&format!("| Retries | {} |\n\n", total_retries));
+    md.push_str(&format!("| Retries | {} |\n", total_retries));
+    md.push_str(&format!("| Skipped decisions | {} |\n\n", manifest.skipped_decisions));
 
     // Per-iteration table
     if !manifest.iterations.is_empty() {
@@ -482,6 +487,7 @@ mod tests {
             provider: "claude".to_string(),
             iterations_requested: 2,
             termination_reason: Some("completed".to_string()),
+            skipped_decisions: 0,
             iterations: vec![],
         };
         art.write_manifest(&manifest);
@@ -516,6 +522,7 @@ mod tests {
             provider: "claude".to_string(),
             iterations_requested: 2,
             termination_reason: Some("completed".to_string()),
+            skipped_decisions: 2,
             iterations: vec![
                 IterationRecord {
                     iteration: 1,
@@ -537,5 +544,6 @@ mod tests {
         assert!(md.contains("completed"));
         assert!(md.contains("success"));
         assert!(md.contains("iteration-1.log"));
+        assert!(md.contains("Skipped decisions"));
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -396,7 +396,7 @@ mod tests {
     }
 
     #[test]
-    fn reports_three_failures_when_file_exists_without_section_and_no_mcp() {
+    fn reports_two_failures_when_file_exists_without_section_and_no_mcp() {
         let dir = setup_dir();
         // Instruction file exists but has no section; no .mcp.json
         write_file(&dir, "CLAUDE.md", "# instructions");

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -53,7 +53,9 @@ impl CheckResult {
 /// Validates:
 /// 1. An instruction file exists (`CLAUDE.md`, `AGENTS.md`, or
 ///    `.github/copilot-instructions.md`).
-/// 2. An MCP config file (`.mcp.json`) exists and contains a `"github"` key,
+/// 2. The instruction file contains the Code Looper section marker
+///    (`<!-- code-looper:begin -->`); skipped when check 1 fails.
+/// 3. An MCP config file (`.mcp.json`) exists and contains a `"github"` key,
 ///    indicating the GitHub MCP server is configured.
 pub struct PrerequisiteChecker {
     workspace_dir: PathBuf,

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -61,7 +61,9 @@ pub struct PrerequisiteChecker {
 
 impl PrerequisiteChecker {
     pub fn new(workspace_dir: impl Into<PathBuf>) -> Self {
-        Self { workspace_dir: workspace_dir.into() }
+        Self {
+            workspace_dir: workspace_dir.into(),
+        }
     }
 
     /// Run all prerequisite checks and return the aggregate result.
@@ -80,11 +82,7 @@ impl PrerequisiteChecker {
     /// Check that an instruction file exists and return its path when found.
     fn check_instruction_file(&self, result: &mut CheckResult) -> Option<PathBuf> {
         const CHECK: &str = "instruction-file";
-        let candidates = [
-            "CLAUDE.md",
-            "AGENTS.md",
-            ".github/copilot-instructions.md",
-        ];
+        let candidates = ["CLAUDE.md", "AGENTS.md", ".github/copilot-instructions.md"];
 
         let found_path = candidates
             .iter()
@@ -152,10 +150,7 @@ impl PrerequisiteChecker {
         if !mcp_path.is_file() {
             result.failed.push(DiagnosticError {
                 check: CHECK.to_string(),
-                message: format!(
-                    "No .mcp.json found in '{}'",
-                    self.workspace_dir.display()
-                ),
+                message: format!("No .mcp.json found in '{}'", self.workspace_dir.display()),
                 remediation: "Create a .mcp.json that includes a \"github\" MCP server entry. \
                               See https://docs.anthropic.com/en/docs/claude-code/mcp for details."
                     .to_string(),
@@ -273,7 +268,11 @@ mod tests {
     #[test]
     fn passes_when_copilot_instructions_exist() {
         let dir = setup_dir();
-        write_file(&dir, ".github/copilot-instructions.md", &valid_instruction_content());
+        write_file(
+            &dir,
+            ".github/copilot-instructions.md",
+            &valid_instruction_content(),
+        );
         write_file(&dir, ".mcp.json", valid_mcp_json());
 
         let result = PrerequisiteChecker::new(dir.path()).run();
@@ -289,7 +288,10 @@ mod tests {
         assert!(!result.is_ok());
         assert!(result.failed.iter().any(|d| d.check == "instruction-file"));
         // instruction-section is skipped when no file is found
-        assert!(!result.failed.iter().any(|d| d.check == "instruction-section"));
+        assert!(!result
+            .failed
+            .iter()
+            .any(|d| d.check == "instruction-section"));
     }
 
     // ── instruction-section checks ────────────────────────────────────────────
@@ -312,7 +314,11 @@ mod tests {
 
         let result = PrerequisiteChecker::new(dir.path()).run();
         assert!(!result.is_ok());
-        let diag = result.failed.iter().find(|d| d.check == "instruction-section").unwrap();
+        let diag = result
+            .failed
+            .iter()
+            .find(|d| d.check == "instruction-section")
+            .unwrap();
         assert!(diag.remediation.contains("bootstrap"));
     }
 
@@ -323,8 +329,13 @@ mod tests {
         write_file(&dir, ".mcp.json", valid_mcp_json());
 
         let result = PrerequisiteChecker::new(dir.path()).run();
-        assert!(!result.failed.iter().any(|d| d.check == "instruction-section"),
-            "instruction-section should be skipped when no instruction file exists");
+        assert!(
+            !result
+                .failed
+                .iter()
+                .any(|d| d.check == "instruction-section"),
+            "instruction-section should be skipped when no instruction file exists"
+        );
     }
 
     // ── mcp-github-server checks ──────────────────────────────────────────────
@@ -358,7 +369,11 @@ mod tests {
 
         let result = PrerequisiteChecker::new(dir.path()).run();
         assert!(!result.is_ok());
-        let diag = result.failed.iter().find(|d| d.check == "mcp-github-server").unwrap();
+        let diag = result
+            .failed
+            .iter()
+            .find(|d| d.check == "mcp-github-server")
+            .unwrap();
         assert!(!diag.remediation.is_empty());
     }
 
@@ -371,7 +386,12 @@ mod tests {
         // No instruction file → instruction-file fails, instruction-section skipped.
         // No .mcp.json → mcp-github-server fails.
         let result = PrerequisiteChecker::new(dir.path()).run();
-        assert_eq!(result.failed.len(), 2, "expected 2 failures, got: {:?}", result.failed);
+        assert_eq!(
+            result.failed.len(),
+            2,
+            "expected 2 failures, got: {:?}",
+            result.failed
+        );
         assert_eq!(result.passed.len(), 0);
     }
 
@@ -382,9 +402,16 @@ mod tests {
         write_file(&dir, "CLAUDE.md", "# instructions");
 
         let result = PrerequisiteChecker::new(dir.path()).run();
-        assert_eq!(result.failed.len(), 2,
-            "expected instruction-section + mcp-github-server failures, got: {:?}", result.failed);
-        assert!(result.failed.iter().any(|d| d.check == "instruction-section"));
+        assert_eq!(
+            result.failed.len(),
+            2,
+            "expected instruction-section + mcp-github-server failures, got: {:?}",
+            result.failed
+        );
+        assert!(result
+            .failed
+            .iter()
+            .any(|d| d.check == "instruction-section"));
         assert!(result.failed.iter().any(|d| d.check == "mcp-github-server"));
     }
 
@@ -422,6 +449,6 @@ mod tests {
     #[test]
     fn resolve_workspace_dir_falls_back_to_cwd_when_none() {
         let resolved = resolve_workspace_dir(None);
-        assert!(resolved.is_absolute() || resolved == PathBuf::from("."));
+        assert!(resolved.is_absolute() || resolved == std::path::Path::new("."));
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,3 +1,4 @@
+use crate::bootstrap::SECTION_BEGIN;
 use std::path::{Path, PathBuf};
 
 /// A single failed prerequisite check with actionable guidance.
@@ -66,14 +67,18 @@ impl PrerequisiteChecker {
     /// Run all prerequisite checks and return the aggregate result.
     pub fn run(&self) -> CheckResult {
         let mut result = CheckResult::default();
-        self.check_instruction_file(&mut result);
+        let instruction_path = self.check_instruction_file(&mut result);
+        if let Some(ref path) = instruction_path {
+            self.check_instruction_section(path, &mut result);
+        }
         self.check_mcp_config(&mut result);
         result
     }
 
     // ── Individual checks ─────────────────────────────────────────────────────
 
-    fn check_instruction_file(&self, result: &mut CheckResult) {
+    /// Check that an instruction file exists and return its path when found.
+    fn check_instruction_file(&self, result: &mut CheckResult) -> Option<PathBuf> {
         const CHECK: &str = "instruction-file";
         let candidates = [
             "CLAUDE.md",
@@ -81,11 +86,12 @@ impl PrerequisiteChecker {
             ".github/copilot-instructions.md",
         ];
 
-        let found = candidates
+        let found_path = candidates
             .iter()
-            .any(|name| self.workspace_dir.join(name).is_file());
+            .map(|name| self.workspace_dir.join(name))
+            .find(|p| p.is_file());
 
-        if found {
+        if found_path.is_some() {
             result.passed.push(CHECK.to_string());
         } else {
             result.failed.push(DiagnosticError {
@@ -99,6 +105,43 @@ impl PrerequisiteChecker {
                               with agent instructions for this project."
                     .to_string(),
             });
+        }
+
+        found_path
+    }
+
+    /// Check that the instruction file contains the Code Looper section marker.
+    ///
+    /// Skipped automatically when no instruction file was found (avoids a
+    /// double-failure for a single root cause).
+    fn check_instruction_section(&self, path: &Path, result: &mut CheckResult) {
+        const CHECK: &str = "instruction-section";
+
+        match std::fs::read_to_string(path) {
+            Err(e) => {
+                result.failed.push(DiagnosticError {
+                    check: CHECK.to_string(),
+                    message: format!("Failed to read {}: {e}", path.display()),
+                    remediation: "Ensure the instruction file is readable.".to_string(),
+                });
+            }
+            Ok(contents) => {
+                if contents.contains(SECTION_BEGIN) {
+                    result.passed.push(CHECK.to_string());
+                } else {
+                    result.failed.push(DiagnosticError {
+                        check: CHECK.to_string(),
+                        message: format!(
+                            "'{}' does not contain the Code Looper section \
+                             (expected marker: `{SECTION_BEGIN}`).",
+                            path.display()
+                        ),
+                        remediation: "Run `code-looper bootstrap` to inject the required \
+                                      Code Looper section into the instruction file."
+                            .to_string(),
+                    });
+                }
+            }
         }
     }
 
@@ -198,12 +241,18 @@ mod tests {
         r#"{"mcpServers":{"github":{"command":"npx","args":["@github/mcp"]}}}"#
     }
 
+    /// Minimal instruction file content that satisfies both the file-existence
+    /// and the instruction-section checks.
+    fn valid_instruction_content() -> String {
+        format!("# Project\n{SECTION_BEGIN}\nstuff\n<!-- code-looper end -->\n")
+    }
+
     // ── instruction-file checks ───────────────────────────────────────────────
 
     #[test]
     fn passes_when_claude_md_exists() {
         let dir = setup_dir();
-        write_file(&dir, "CLAUDE.md", "# instructions");
+        write_file(&dir, "CLAUDE.md", &valid_instruction_content());
         write_file(&dir, ".mcp.json", valid_mcp_json());
 
         let result = PrerequisiteChecker::new(dir.path()).run();
@@ -214,21 +263,21 @@ mod tests {
     #[test]
     fn passes_when_agents_md_exists() {
         let dir = setup_dir();
-        write_file(&dir, "AGENTS.md", "# instructions");
+        write_file(&dir, "AGENTS.md", &valid_instruction_content());
         write_file(&dir, ".mcp.json", valid_mcp_json());
 
         let result = PrerequisiteChecker::new(dir.path()).run();
-        assert!(result.is_ok());
+        assert!(result.is_ok(), "unexpected failures: {:?}", result.failed);
     }
 
     #[test]
     fn passes_when_copilot_instructions_exist() {
         let dir = setup_dir();
-        write_file(&dir, ".github/copilot-instructions.md", "# instructions");
+        write_file(&dir, ".github/copilot-instructions.md", &valid_instruction_content());
         write_file(&dir, ".mcp.json", valid_mcp_json());
 
         let result = PrerequisiteChecker::new(dir.path()).run();
-        assert!(result.is_ok());
+        assert!(result.is_ok(), "unexpected failures: {:?}", result.failed);
     }
 
     #[test]
@@ -239,6 +288,43 @@ mod tests {
         let result = PrerequisiteChecker::new(dir.path()).run();
         assert!(!result.is_ok());
         assert!(result.failed.iter().any(|d| d.check == "instruction-file"));
+        // instruction-section is skipped when no file is found
+        assert!(!result.failed.iter().any(|d| d.check == "instruction-section"));
+    }
+
+    // ── instruction-section checks ────────────────────────────────────────────
+
+    #[test]
+    fn passes_when_instruction_file_has_section_marker() {
+        let dir = setup_dir();
+        write_file(&dir, "CLAUDE.md", &valid_instruction_content());
+        write_file(&dir, ".mcp.json", valid_mcp_json());
+
+        let result = PrerequisiteChecker::new(dir.path()).run();
+        assert!(result.passed.contains(&"instruction-section".to_string()));
+    }
+
+    #[test]
+    fn fails_when_instruction_file_missing_section_marker() {
+        let dir = setup_dir();
+        write_file(&dir, "CLAUDE.md", "# instructions\nNo looper section here.");
+        write_file(&dir, ".mcp.json", valid_mcp_json());
+
+        let result = PrerequisiteChecker::new(dir.path()).run();
+        assert!(!result.is_ok());
+        let diag = result.failed.iter().find(|d| d.check == "instruction-section").unwrap();
+        assert!(diag.remediation.contains("bootstrap"));
+    }
+
+    #[test]
+    fn section_check_skipped_when_no_instruction_file() {
+        let dir = setup_dir();
+        // No instruction file at all — only 2 failures expected, not 3.
+        write_file(&dir, ".mcp.json", valid_mcp_json());
+
+        let result = PrerequisiteChecker::new(dir.path()).run();
+        assert!(!result.failed.iter().any(|d| d.check == "instruction-section"),
+            "instruction-section should be skipped when no instruction file exists");
     }
 
     // ── mcp-github-server checks ──────────────────────────────────────────────
@@ -246,18 +332,18 @@ mod tests {
     #[test]
     fn passes_when_mcp_json_has_github_key() {
         let dir = setup_dir();
-        write_file(&dir, "CLAUDE.md", "# instructions");
+        write_file(&dir, "CLAUDE.md", &valid_instruction_content());
         write_file(&dir, ".mcp.json", valid_mcp_json());
 
         let result = PrerequisiteChecker::new(dir.path()).run();
-        assert!(result.is_ok());
+        assert!(result.is_ok(), "unexpected failures: {:?}", result.failed);
         assert!(result.passed.contains(&"mcp-github-server".to_string()));
     }
 
     #[test]
     fn fails_when_mcp_json_missing() {
         let dir = setup_dir();
-        write_file(&dir, "CLAUDE.md", "# instructions");
+        write_file(&dir, "CLAUDE.md", &valid_instruction_content());
 
         let result = PrerequisiteChecker::new(dir.path()).run();
         assert!(!result.is_ok());
@@ -267,7 +353,7 @@ mod tests {
     #[test]
     fn fails_when_mcp_json_lacks_github_key() {
         let dir = setup_dir();
-        write_file(&dir, "CLAUDE.md", "# instructions");
+        write_file(&dir, "CLAUDE.md", &valid_instruction_content());
         write_file(&dir, ".mcp.json", r#"{"mcpServers":{"context7":{}}}"#);
 
         let result = PrerequisiteChecker::new(dir.path()).run();
@@ -282,9 +368,24 @@ mod tests {
     fn reports_all_failures_when_everything_missing() {
         let dir = setup_dir();
 
+        // No instruction file → instruction-file fails, instruction-section skipped.
+        // No .mcp.json → mcp-github-server fails.
         let result = PrerequisiteChecker::new(dir.path()).run();
-        assert_eq!(result.failed.len(), 2);
+        assert_eq!(result.failed.len(), 2, "expected 2 failures, got: {:?}", result.failed);
         assert_eq!(result.passed.len(), 0);
+    }
+
+    #[test]
+    fn reports_three_failures_when_file_exists_without_section_and_no_mcp() {
+        let dir = setup_dir();
+        // Instruction file exists but has no section; no .mcp.json
+        write_file(&dir, "CLAUDE.md", "# instructions");
+
+        let result = PrerequisiteChecker::new(dir.path()).run();
+        assert_eq!(result.failed.len(), 2,
+            "expected instruction-section + mcp-github-server failures, got: {:?}", result.failed);
+        assert!(result.failed.iter().any(|d| d.check == "instruction-section"));
+        assert!(result.failed.iter().any(|d| d.check == "mcp-github-server"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR lands the entire `iteration_2` working branch onto `main`. It bundles 35 commits produced by the Ralph Loop across issues #4–#44, covering loop-engine milestones M1–M5, multi-PR/multi-repo orchestration, service mode, observability, and a long tail of operational hardening.

The work was developed iteratively against per-issue scopes but never opened as individual PRs — see the linked issues for the per-change rationale, scope, and acceptance criteria. Issue comments were used as the canonical execution log throughout.

### Headline changes (newest first)

- **#44** — `least-conflicts` triage priority: PR triage now sorts open PRs by GitHub mergeable state (`MERGEABLE` → `UNKNOWN` → `CONFLICTING`) before evaluation
- **#43** — `non_retryable_exit_codes` config: skip retries for known-permanent failures
- **#42** — `provider_extra_args` config + `--provider-extra-arg` CLI flag
- **#41** — Validate `prompt_file` existence at startup; service-mode per-request logging
- **#40** — YAML config file support alongside TOML
- **#39** — `head_ref` on `PrInfo`; post-merge branch cleanup in multi-PR mode
- **#38** — Graceful SIGINT handling in multi-repo mode
- **#37** — Explicit allowlist for provider executables
- **#36** — `--retry-backoff-multiplier` and `--auto-close-owned-issues` CLI flags
- **#35** — `run_by` and `workspace_dir` on `RunManifest` for audit provenance
- **#34** — CI pipeline + clippy/fmt cleanup across the tree
- **#33** — Provider iteration timeout wired to `IterationOutcome::Timeout`
- **#32** — Workspace prerequisites doc fix
- **#31** — Multi-repo + `serve` subcommand docs; `.env.example`
- **#30** — Workspace validator: instruction file must contain Code Looper section
- **#29** — Track `skipped_decisions` in session summary (PRD acceptance criterion)
- **#28** — Single-PR branch name bug fix; `BranchManager` wired into loop engine
- **#27** — Service mode: embedded JSON-lines API surface
- **#26** — Clippy cleanup (45 warnings)
- **#25** — Multi-repo orchestration support
- **#24** — Token redaction in provider output capture
- **#4–#8** — Loop engine milestones M1–M5: scaffolding, provider adapters, orchestration policy engine, workspace validator, retry/backoff/stop-on-failure

All other commits in the range are smaller fixes, doc updates, and refactors tied to the issues above.

### Test status

```
cargo fmt -- --check    OK
cargo clippy --all-targets -- -D warnings    OK
cargo test    363 passed; 0 failed
```

## Test plan

- [ ] CI passes on the merge commit
- [ ] Spot-check `cargo run -- --help` reflects all new CLI flags (`--provider-extra-arg`, `--non-retryable-exit-code`, `--retry-backoff-multiplier`, `--auto-close-owned-issues`)
- [ ] Smoke test multi-PR mode against a fork with `triage_priority = "least-conflicts"` and at least one CONFLICTING PR to confirm ordering
- [ ] Smoke test `serve` subcommand JSON-lines protocol
- [ ] Confirm session summaries include `run_by`, `workspace_dir`, `skipped_decisions`

## Caveats

- This is a 35-commit bundle. Reviewing commit-by-commit will be more tractable than reviewing the diff as a whole; each commit message references its issue.
- Several of the closed issues (#34–#43) were closed when the loop committed locally, before this PR existed — they describe intent and acceptance criteria but have no merged PR linked. This PR is the first time any of that work appears on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)