### PR TITLE
CI/CD maturity: release pipeline, versioning, label conventions (v0.2.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 
@@ -11,7 +9,7 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
-  ci:
+  pr-check:
     name: fmt / clippy / test / release
     runs-on: ubuntu-latest
 
@@ -24,7 +22,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache cargo registry and build artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,146 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            cross: false
+            archive_ext: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            cross: true
+            archive_ext: tar.gz
+          - target: x86_64-apple-darwin
+            os: macos-13
+            cross: false
+            archive_ext: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            cross: false
+            archive_ext: tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            cross: false
+            archive_ext: zip
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo registry and build artifacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-
+
+      - name: Install cross (aarch64-linux only)
+        if: matrix.cross
+        run: cargo install cross --locked
+
+      - name: Build (native)
+        if: "!matrix.cross"
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Build (cross)
+        if: matrix.cross
+        run: cross build --release --target ${{ matrix.target }}
+
+      - name: Archive binary (Unix)
+        if: matrix.archive_ext == 'tar.gz'
+        shell: bash
+        run: |
+          VERSION=${{ github.ref_name }}
+          BINARY=code-looper-${VERSION}-${{ matrix.target }}
+          cp target/${{ matrix.target }}/release/code-looper "${BINARY}"
+          tar -czf "${BINARY}.tar.gz" "${BINARY}"
+
+      - name: Archive binary (Windows)
+        if: matrix.archive_ext == 'zip'
+        shell: pwsh
+        run: |
+          $VERSION = "${{ github.ref_name }}"
+          $BINARY = "code-looper-${VERSION}-${{ matrix.target }}"
+          Copy-Item "target/${{ matrix.target }}/release/code-looper.exe" "${BINARY}.exe"
+          Compress-Archive -Path "${BINARY}.exe" -DestinationPath "${BINARY}.zip"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.target }}
+          path: code-looper-${{ github.ref_name }}-${{ matrix.target }}.${{ matrix.archive_ext }}
+          if-no-files-found: error
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Detect pre-release
+        id: prerelease
+        shell: bash
+        run: |
+          if [[ "${{ github.ref_name }}" == *-* ]]; then
+            echo "flag=--prerelease" >> "$GITHUB_OUTPUT"
+          else
+            echo "flag=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            artifacts/* \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            ${{ steps.prerelease.outputs.flag }}
+
+      - name: Close milestone
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ github.ref_name }}"
+          MILESTONE=$(gh api "repos/${{ github.repository }}/milestones" \
+            --jq ".[] | select(.title == \"${VERSION}\") | .number")
+          if [ -n "$MILESTONE" ]; then
+            gh api "repos/${{ github.repository }}/milestones/${MILESTONE}" \
+              --method PATCH -f state=closed
+            echo "Closed milestone ${VERSION} (#${MILESTONE})"
+          else
+            echo "No open milestone titled ${VERSION} — skipping"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
+      - 'v[0-9]*.[0-9]*.[0-9]*'
 
 env:
   CARGO_TERM_COLOR: always
@@ -59,7 +59,7 @@ jobs:
 
       - name: Install cross (aarch64-linux only)
         if: matrix.cross
-        run: cargo install cross --locked
+        run: cargo install cross --version 0.2.5 --locked
 
       - name: Build (native)
         if: "!matrix.cross"
@@ -100,6 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
 
     steps:
       - uses: actions/checkout@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ Configured in `.mcp.json`:
 - `docs/PRD.md` — Full product requirements document with architecture, milestones, risks, and success criteria
 - `docs/ADRs/` — ADRs tracking significant architectural decisions
 - `docs/project-management.md` — Label taxonomy, milestone conventions, and lifecycle orchestration model
+- `docs/versioning.md` — SemVer scheme, bump rules, and step-by-step release process
 
 <!-- code-looper begin -->
 ## Code Looper

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ Configured in `.mcp.json`:
 
 - `docs/PRD.md` — Full product requirements document with architecture, milestones, risks, and success criteria
 - `docs/ADRs/` — ADRs tracking significant architectural decisions
+- `docs/project-management.md` — Label taxonomy, milestone conventions, and lifecycle orchestration model
 
 <!-- code-looper begin -->
 ## Code Looper

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "code-looper"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code-looper"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Pluggable loop engine for coding-agent CLIs"
 license = "MIT"

--- a/docs/ADRs/ADR-005-github-issues-milestones-as-pm-primitive.md
+++ b/docs/ADRs/ADR-005-github-issues-milestones-as-pm-primitive.md
@@ -1,0 +1,62 @@
+# ADR-005: GitHub Issues + Milestones as Project Management Primitive
+
+**Status:** Accepted
+**Date:** 2026-04-17
+**Deciders:** Code Looper project team
+**Related:** #190
+
+## Context
+
+Code Looper needs a project management system that:
+
+1. Is queryable by the orchestration engine at runtime — the engine must be able to ask "what should I work on next?" by reading state from an external source
+2. Is visible and editable by both human contributors and automated agents
+3. Does not require a separate SaaS subscription or significant setup overhead
+4. Can serve as the source of truth for release scope
+
+The candidates considered were:
+
+- **GitHub Projects v2** — Kanban-style board with custom fields and views. Rich UI, but GraphQL-only API; board state is not directly queryable via the `gh` CLI or REST API in a way that maps cleanly to orchestration decisions.
+- **JIRA** — Industry-standard issue tracker with deep workflow features. Requires a separate subscription and external service dependency; far more machinery than this project needs.
+- **GitHub Issues + Labels + Milestones** — Built into every GitHub repo. Fully queryable via REST API and `gh` CLI. Labels are first-class filter primitives. Milestones map naturally to releases.
+
+## Decision
+
+Use **GitHub Issues with labels and milestones** as the sole project management primitive for code-looper.
+
+- **Issues** are the unit of work
+- **Labels** encode lifecycle state (`ready-for-dev`, `in-progress`, `blocked`) and priority (`priority-high`, `priority-medium`, `priority-low`)
+- **Milestones** define release scope — one milestone = one release
+- No GitHub Projects board is used or required
+
+The full label taxonomy and milestone conventions are documented in `docs/project-management.md`.
+
+## Consequences
+
+**Positive:**
+- The orchestration engine can query issue state entirely via the GitHub MCP server tools already configured (no new integrations required)
+- Human contributors and automated agents use the same interface — no separate tracking system to sync
+- Milestones provide a natural, queryable release boundary: a milestone with zero open issues and zero open PRs is the condition that fires the release lifecycle
+- Zero additional cost or external service dependencies
+
+**Negative:**
+- No state machine enforcement — label discipline relies on the engine (and human contributors) applying labels consistently. A mislabeled issue can confuse orchestration queries.
+- No visual board unless GitHub Projects is layered on top later (which is explicitly not done here)
+- Labels are repo-global — the taxonomy must be documented and agreed upon; it cannot be enforced by schema
+
+## Tradeoffs Accepted
+
+- **No enforcement** of the label state machine. An issue can have both `ready-for-dev` and `blocked` applied simultaneously if someone makes a mistake. The convention document (`docs/project-management.md`) is the authority; enforcement lives in the agent's grooming logic.
+- **Implicit states** (backlog, done) are not represented by labels. "Backlog" is inferred from the absence of state labels; "done" is inferred from closed state. This keeps the label surface minimal but means you cannot filter for "backlog" as a label — you must filter for "open issues with no state label."
+
+## Alternatives Rejected
+
+- **GitHub Projects v2**: The GraphQL-only query model does not align with the MCP GitHub tools already in use. Adding a Projects integration would require either new MCP tools or raw GraphQL calls, neither of which is justified at this project scale.
+- **JIRA**: External dependency, cost, and operational overhead are not warranted for a single-repo project.
+
+## References
+
+- `docs/project-management.md` — Full label taxonomy and milestone conventions
+- ADR-006 — State label taxonomy (companion ADR)
+- #190 — Issue that introduced this system
+- #191 — Orchestration engine that consumes these labels as query signals

--- a/docs/ADRs/ADR-006-state-label-taxonomy.md
+++ b/docs/ADRs/ADR-006-state-label-taxonomy.md
@@ -1,0 +1,74 @@
+# ADR-006: State Label Taxonomy
+
+**Status:** Accepted
+**Date:** 2026-04-17
+**Deciders:** Code Looper project team
+**Related:** #190
+
+## Context
+
+The orchestration engine selects its active lifecycle by querying GitHub issue state. For this to work, issue state must be expressible as label-based predicates that the engine can evaluate:
+
+- "Are there issues ready to work?" → look for `ready-for-dev` label
+- "Is something blocked?" → look for `blocked` label
+- "Is anything actively in progress?" → look for `in-progress` label
+
+The label set must be:
+1. **Minimal** — the engine's query logic grows with every new label; fewer is better
+2. **Mutually exclusive in intent** — at any point in time, an issue should naturally sit in exactly one state
+3. **Gap-free** — every meaningful state in the lifecycle must be representable (even implicitly)
+
+Several label sets were considered during design.
+
+## Decision
+
+Use exactly **three** state labels:
+
+| Label | Meaning |
+|---|---|
+| `ready-for-dev` | Groomed, scoped, and actionable — safe for the execution lifecycle to pick up |
+| `in-progress` | Actively being worked by an agent or person |
+| `blocked` | Has an unresolved dependency (another issue, external decision, environment problem, etc.) |
+
+Two additional states are represented **implicitly** (no label):
+
+- **Backlog / needs grooming** — open issue with none of the three labels
+- **Done** — closed issue
+
+## Labels Explicitly Excluded
+
+The following labels were considered and rejected:
+
+| Candidate | Reason excluded |
+|---|---|
+| `selected` | Adds a "selected for sprint" state between backlog and ready-for-dev. Unnecessary — milestone assignment already encodes "selected for this release." A separate `selected` label would duplicate milestone semantics. |
+| `ready-for-pr` | Adds a state between in-progress and done. The PR itself is the signal that work is ready for review — a label is redundant with the open PR's existence. The `pr-review` lifecycle queries open PRs directly, not issue labels. |
+| `done` | GitHub's "closed" state is the canonical signal for done. A `done` label would duplicate it and risk getting out of sync (closed issues with no `done` label, open issues marked `done`). |
+| `needs-review` (issue level) | Code review state lives on the PR, not the issue. The PR-review lifecycle queries PR state directly. |
+| `in-review` | Same reasoning as `needs-review` — this is PR state, not issue state. |
+
+## Consequences
+
+**Positive:**
+- Three labels means three simple predicates in the orchestration engine's lifecycle selection logic
+- Implicit backlog state (no label) allows new issues to land without immediate label assignment — the grooming lifecycle handles them when ready
+- Closed = done is a natural GitHub convention that all contributors already understand
+
+**Negative:**
+- "Backlog" is not filterable as a label — you must query for "open issues with no state label," which requires a client-side filter step rather than a simple label search
+- Label discipline cannot be enforced by GitHub — it relies on the engine and contributors applying labels consistently
+
+## Invariants the Engine Must Maintain
+
+- An issue should have **at most one** state label at a time
+- When work starts: remove `ready-for-dev`, apply `in-progress`
+- When blocked: remove `in-progress`, apply `blocked`; add a comment explaining the blocker
+- When unblocked: remove `blocked`, apply appropriate state label
+- When work completes: remove `in-progress`, close the issue (no label needed)
+
+## References
+
+- `docs/project-management.md` — Full label taxonomy and workflow documentation
+- ADR-005 — GitHub Issues + milestones as PM primitive (companion ADR)
+- #190 — Issue that introduced this system
+- #191 — Orchestration engine that consumes these labels

--- a/docs/ADRs/ADR-007-tag-based-release-trigger.md
+++ b/docs/ADRs/ADR-007-tag-based-release-trigger.md
@@ -1,0 +1,57 @@
+# ADR-007: Tag-Based Release Trigger
+
+**Status:** Accepted
+**Date:** 2026-04-17
+**Deciders:** Code Looper project team
+**Related:** #185, #188
+
+## Context
+
+The release pipeline needs a trigger condition — the event that causes `release.yml` to fire and binaries to be built and published. The candidates were:
+
+1. **Every merge to `main`** — release on every mainline commit
+2. **Automated version bump** — a bot or workflow increments the version and commits a tagged release automatically
+3. **Manual `vX.Y.Z` tag push** — a human (or orchestration lifecycle) pushes a tag to signal intent to release
+
+## Decision
+
+Releases are triggered by manually pushing a `vX.Y.Z` git tag.
+
+```yaml
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+```
+
+The `*` suffix allows pre-release tags (`v0.2.0-beta.1`, `v0.2.0-rc.1`). The `release.yml` workflow detects hyphens in the tag name and marks those releases as pre-releases on GitHub.
+
+The full release sequence (per #185 and `docs/versioning.md`):
+1. Milestone reaches zero open issues and zero open PRs
+2. Bump `version` in `Cargo.toml`, commit, push `vX.Y.Z` tag
+3. `release.yml` fires on the tag push
+4. Workflow builds binaries, creates GitHub Release, closes milestone
+
+## Consequences
+
+**Positive:**
+- Release is an explicit, intentional act — no accidental releases from routine commits
+- Tag serves as a durable, named anchor point in git history for every release
+- Easy to automate: the orchestration release lifecycle pushes the tag when it determines the milestone is complete
+- Pre-release support is natural: append a suffix to the tag name
+
+**Negative:**
+- Slightly more process than push-to-main; the release author must remember to bump `Cargo.toml` and push both the commit and the tag
+- No automated version bump — risk of forgetting to increment the version before tagging. Mitigated by `docs/versioning.md` documenting the exact steps.
+
+## Alternatives Rejected
+
+- **Every merge to `main`**: Appropriate for continuous delivery products with fast feedback cycles. This project's release unit is a milestone, not a commit. Shipping on every merge would produce dozens of releases per milestone with no meaningful versioning signal.
+- **Automated version bump bot**: Adds a dependency on a GitHub App or custom action. Adds complexity without clear benefit at this project's scale. The orchestration release lifecycle can push a tag without needing a bot.
+
+## References
+
+- `.github/workflows/release.yml` — the workflow triggered by this pattern
+- `docs/versioning.md` — step-by-step release process
+- ADR-008 — milestone as release boundary (companion ADR)
+- #185 — CI/CD maturity umbrella issue

--- a/docs/ADRs/ADR-007-tag-based-release-trigger.md
+++ b/docs/ADRs/ADR-007-tag-based-release-trigger.md
@@ -21,10 +21,10 @@ Releases are triggered by manually pushing a `vX.Y.Z` git tag.
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
+      - 'v[0-9]*.[0-9]*.[0-9]*'
 ```
 
-The `*` suffix allows pre-release tags (`v0.2.0-beta.1`, `v0.2.0-rc.1`). The `release.yml` workflow detects hyphens in the tag name and marks those releases as pre-releases on GitHub.
+GitHub Actions tag filters use glob syntax, not regex — `*` matches any sequence of characters. The pattern above matches `v0.2.0`, `v1.0.0`, and also pre-release tags like `v0.2.0-beta.1`. The `release.yml` workflow detects hyphens in the tag name and marks those releases as pre-releases on GitHub.
 
 The full release sequence (per #185 and `docs/versioning.md`):
 1. Milestone reaches zero open issues and zero open PRs

--- a/docs/ADRs/ADR-008-milestone-as-release-boundary.md
+++ b/docs/ADRs/ADR-008-milestone-as-release-boundary.md
@@ -1,0 +1,64 @@
+# ADR-008: Milestone as Release Boundary
+
+**Status:** Accepted
+**Date:** 2026-04-17
+**Deciders:** Code Looper project team
+**Related:** #185, #190, #191
+
+## Context
+
+Code Looper needs a clear answer to: "what gets shipped in a release, and when is a release ready?" Without a defined release boundary, releases can be vague ("everything since last time") or premature (shipping with known open issues).
+
+The options considered were:
+
+1. **Time-based releases** — ship on a cadence (weekly, monthly) regardless of what's done
+2. **Feature-flag gating** — ship when specific features are enabled, regardless of issue state
+3. **Milestone completion** — ship when a defined set of issues is closed and all PRs merged
+
+## Decision
+
+A GitHub milestone defines both the **scope** (what gets worked) and the **release unit** (what gets shipped). A release is ready when its milestone has zero open issues and zero open PRs.
+
+The milestone lifecycle:
+- **Open milestone with open issues** → execution and PR-review lifecycles are active
+- **Open milestone with zero open issues/PRs** → release lifecycle fires
+- **Closed milestone** → release is complete; this is the final state
+
+The release workflow (`release.yml`) automatically closes the milestone as its last step, after the GitHub Release is created. This closure is the canonical signal that the release is complete.
+
+## Consequences
+
+**Positive:**
+- Release scope is explicit and visible before work begins — anyone can see what's in a milestone
+- "Ready to release" has a mechanical definition: `milestone.open_issues == 0 && open_prs_on_milestone == 0`
+- The orchestration engine can query this condition without ambiguity
+- Milestone closure is a permanent, auditable event in GitHub's history
+- Discovered work during execution (bugs, regressions) blocks the release by default — quality gate is enforced automatically
+
+**Negative:**
+- Milestone scope must be set deliberately before execution begins; an empty milestone immediately triggers the release lifecycle
+- Discovery of significant new work mid-milestone forces a scope decision: add to current milestone (blocks release) or defer to next milestone. This is intentional but requires judgment.
+- If a tag is pushed before the milestone is clean, the milestone closes automatically regardless of remaining issues. The release sequence in `docs/versioning.md` documents that checking milestone state is the first step.
+
+## Closing Milestone as Final Release Step
+
+The decision to close the milestone *after* the GitHub Release is created (not before) is deliberate:
+
+- The GitHub Release URL is the artifact the world sees; it should exist before the milestone is declared complete
+- Closing the milestone before publishing the release would make the milestone appear done while the actual deliverable is still in flight
+- The `release.yml` workflow handles this sequencing automatically
+
+## Alternatives Rejected
+
+- **Time-based releases**: Works well for products with many users who need predictable update cycles. Code Looper's release cadence is milestone-driven; shipping half-finished milestones on a calendar schedule would reduce release quality without meaningful user benefit.
+- **Feature-flag gating**: Adds runtime complexity for no benefit at this scale. The milestone is a simpler, visible mechanism that maps directly to the project's planning model.
+
+## References
+
+- `docs/project-management.md` — milestone conventions and the lifecycle query model
+- `docs/versioning.md` — step-by-step release process that starts with milestone verification
+- `.github/workflows/release.yml` — the workflow that closes the milestone after publishing the release
+- ADR-005 — GitHub Issues + milestones as PM primitive
+- ADR-007 — tag-based release trigger (companion ADR)
+- #185 — CI/CD maturity umbrella issue
+- #191 — orchestration engine that uses milestone state as a lifecycle signal

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -1,0 +1,95 @@
+# Project Management Conventions
+
+This document describes the label system, milestone conventions, and lifecycle model used to manage work in this repository. These conventions give the orchestration engine (see [#191](https://github.com/jamesbrayton/code-looper/issues/191)) queryable state signals to drive lifecycle decisions without requiring JIRA or GitHub Projects.
+
+## Label System
+
+### State Labels
+
+State labels reflect where an issue is in the development lifecycle. They drive orchestration queries — the engine checks for these labels to select the active lifecycle.
+
+| Label | Color | Meaning |
+|---|---|---|
+| `ready-for-dev` | green | Groomed, scoped, and actionable — safe to pick up for execution |
+| `in-progress` | blue | Actively being worked by an agent or person |
+| `blocked` | red | Has an unresolved dependency (another issue, external decision, etc.) |
+
+**Implicit states (no label required):**
+
+- **Backlog / needs grooming** — open issue with none of the state labels above
+- **Done** — closed issue
+
+An issue without a state label is in the backlog and may or may not be ready for work. The absence of a state label is a signal to the grooming lifecycle that the issue needs attention before execution.
+
+### Priority Labels
+
+Priority labels indicate importance relative to the current milestone. They are assigned during grooming.
+
+| Label | Color | Meaning |
+|---|---|---|
+| `priority-high` | red-orange | Must be in the current milestone; blocks release if incomplete |
+| `priority-medium` | yellow | Should be in the current milestone; deferrable if needed |
+| `priority-low` | light blue | Nice to have; default candidate for deferral to next milestone |
+
+### Type Labels (Retain As-Is)
+
+These labels describe issue *type*, not lifecycle state. They complement the above and are not replaced by them.
+
+| Label | Meaning |
+|---|---|
+| `bug` | Something isn't working correctly |
+| `enhancement` | New feature or improvement |
+| `tech-debt` | Internal quality or maintainability improvement |
+| `discovered-during-loop` | Surfaced by an automated loop run |
+
+## Milestone Conventions
+
+Each milestone corresponds to one release. Milestones are the primary scope boundary for execution.
+
+- A milestone is **complete** when it has zero open issues and zero open PRs
+- Milestone completion triggers the release lifecycle: tag push → `release.yml` → GitHub Release → milestone closed
+- Issues **not** assigned to any milestone are **backlog** — visible to grooming, invisible to execution
+- Issues assigned to a **future** milestone (e.g., `v0.3.0`) are **deferred** — explicitly out of scope for the current release
+
+### Release Sequence
+
+1. All issues in the current milestone are closed; all PRs merged
+2. Release lifecycle fires: bump `Cargo.toml` version, commit, push `vX.Y.Z` tag
+3. `release.yml` triggers on the tag — builds cross-platform binaries, creates GitHub Release with auto-generated notes
+4. Release lifecycle closes the milestone
+
+See `docs/versioning.md` (issue [#186](https://github.com/jamesbrayton/code-looper/issues/186)) for the full versioning and release process.
+
+## Orchestration Lifecycles
+
+The engine selects the active lifecycle by querying GitHub state at the start of each iteration:
+
+| Condition | Lifecycle |
+|---|---|
+| Current milestone has open `ready-for-dev` issues | `execution` |
+| Open PRs on milestone issues, no `ready-for-dev` issues | `pr-review` |
+| Milestone fully closed (zero open issues + PRs) | `release` |
+| Ungroomed open issues exist (no state label) | `grooming` |
+| `ready-for-dev` issues exist with no milestone | `planning` |
+
+See [#191](https://github.com/jamesbrayton/code-looper/issues/191) for full orchestration design and ADRs.
+
+## Workflow for New Issues
+
+1. Issue is created — no state label (enters backlog implicitly)
+2. **Grooming lifecycle** reviews the issue: clarifies scope, writes acceptance criteria, adds type/priority labels
+3. **Planning lifecycle** assigns the issue to a milestone
+4. Issue receives `ready-for-dev` label — now visible to the execution lifecycle
+5. **Execution lifecycle** picks up the issue, sets `in-progress`
+6. Work is done and PR is merged — issue is closed (enters Done implicitly)
+
+## Applying Labels
+
+When updating issue state:
+
+- Set `in-progress` when an agent or person begins active work on the issue
+- Remove `in-progress`, close the issue when work is committed
+- Set `blocked` if a dependency arises mid-work; add a comment explaining the blocker
+- Remove `blocked` and re-set to the appropriate state when the dependency resolves
+
+Only one state label should be active at a time.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -20,8 +20,8 @@ The project is currently pre-1.0 (`0.x.y`). Minor version bumps may include brea
 4. Commit: `git commit -am "chore: bump version to vX.Y.Z (#<issue>)"`
 5. Tag: `git tag vX.Y.Z`
 6. Push commit and tag: `git push && git push --tags`
-7. The `release.yml` workflow fires automatically on the tag push, builds cross-platform binaries, and creates the GitHub Release
-8. After the release is published, close the milestone
+7. The `release.yml` workflow fires automatically on the tag push, builds cross-platform binaries, creates the GitHub Release, and closes the milestone
+8. Confirm the milestone was closed by the workflow (close it manually only if the automation failed)
 
 ## Tag Format
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,37 @@
+# Versioning
+
+code-looper uses [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`). The `version` field in `Cargo.toml` is the single source of truth. The corresponding git tag is always `vX.Y.Z` (with the `v` prefix).
+
+## Bump Rules
+
+| Component | Bump when |
+|---|---|
+| `PATCH` | Bug fixes, doc updates, dependency bumps, internal refactors with no behavioral change |
+| `MINOR` | New features, new CLI flags, new provider adapters — backwards compatible |
+| `MAJOR` | Breaking changes to the CLI interface, config schema, or public API |
+
+The project is currently pre-1.0 (`0.x.y`). Minor version bumps may include breaking changes during this phase; this will be noted explicitly in release notes when it occurs.
+
+## How to Cut a Release
+
+1. Ensure the current milestone has zero open issues and zero open PRs
+2. Bump `version` in `Cargo.toml` to the new version (e.g., `0.2.0`)
+3. Run `cargo build` to update `Cargo.lock`
+4. Commit: `git commit -am "chore: bump version to vX.Y.Z (#<issue>)"`
+5. Tag: `git tag vX.Y.Z`
+6. Push commit and tag: `git push && git push --tags`
+7. The `release.yml` workflow fires automatically on the tag push, builds cross-platform binaries, and creates the GitHub Release
+8. After the release is published, close the milestone
+
+## Tag Format
+
+Tags must always use the `v` prefix: `v0.2.0`, `v1.0.0`, etc. Never tag without the prefix (`0.2.0` is not a valid release tag).
+
+## Pre-Release Versions
+
+Use SemVer pre-release suffixes when testing a release candidate before tagging the final version:
+
+- `v0.2.0-beta.1` — early beta, may have known issues
+- `v0.2.0-rc.1` — release candidate, feature-complete
+
+The `release.yml` workflow detects pre-release suffixes (any tag matching `v*-*`) and marks the GitHub Release as a pre-release automatically. Pre-release binaries are published the same way as stable releases but are not shown as the "latest" release.


### PR DESCRIPTION
## Summary

- Establishes label/milestone conventions and project management doc (`docs/project-management.md`) with ADR-005/006
- Adds versioning strategy (`docs/versioning.md`) with SemVer scheme, bump rules, and step-by-step release process
- Refactors `ci.yml` to PR-only trigger, upgrades to `checkout@v6` + `cache@v5` (node24), renames job to `pr-check` — resolves #184
- Adds `release.yml`: tag-triggered 5-target cross-platform build matrix (Linux x86_64/arm64, macOS x86_64/arm64, Windows x86_64), GitHub Release publishing with auto-generated notes, pre-release detection, and automatic milestone closure
- Writes ADR-007 (tag-based release trigger) and ADR-008 (milestone as release boundary)
- Bumps `Cargo.toml` version to `0.2.0`

## Closes

Closes #185, #186, #187, #188, #190. Resolves #184.

## Test plan

- [ ] CI (`pr-check`) passes on this PR with no Node.js 20 deprecation warnings
- [ ] After merge: push `v0.2.0` tag → confirm `release.yml` fires, builds all 5 targets, creates GitHub Release, closes `v0.2.0` milestone
- [ ] Confirm `aarch64-apple-darwin` binary runs on M2 MacBook Air
- [ ] Confirm `x86_64-unknown-linux-gnu` binary runs on Ubuntu x86_64 homelab

🤖 Generated with [Claude Code](https://claude.com/claude-code)