### PR TITLE
chore: bump version to v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "code-looper"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code-looper"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Pluggable loop engine for coding-agent CLIs"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bumps `version` in `Cargo.toml` from `0.2.0` → `0.2.1`
- Regenerates `Cargo.lock` via `cargo build`

Closes #197

## Test plan

- [x] `cargo build` — compiled cleanly at `v0.2.1`
- [ ] CI passes on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)