### PR TITLE
fix(install/ci): harden install.sh, fix release.yml milestone step, add shellcheck CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,6 @@ jobs:
 
       - name: Build release binary
         run: cargo build --release
+
+      - name: Lint install.sh
+        run: shellcheck install.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,11 +138,12 @@ jobs:
             ${{ steps.prerelease.outputs.flag }}
 
       - name: Close milestone
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ github.ref_name }}"
-          MILESTONE=$(gh api "repos/${{ github.repository }}/milestones" \
+          MILESTONE=$(gh api --paginate "repos/${{ github.repository }}/milestones" \
             --jq ".[] | select(.title == \"${VERSION}\") | .number")
           if [ -n "$MILESTONE" ]; then
             gh api "repos/${{ github.repository }}/milestones/${MILESTONE}" \

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,7 @@ REPO="jamesbrayton/code-looper"
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
 INSTALL_DIR="${INSTALL_DIR%/}"
 
+# Detect OS and architecture
 OS="${OS:-$(uname -s)}"
 ARCH="${ARCH:-$(uname -m)}"
 
@@ -24,6 +25,7 @@ case "${OS}/${ARCH}" in
     ;;
 esac
 
+# Resolve latest release version from GitHub API
 API_URL="https://api.github.com/repos/${REPO}/releases/latest"
 if [ -n "${GITHUB_TOKEN}" ]; then
   VERSION=$(curl -fsSL -H "Authorization: Bearer ${GITHUB_TOKEN}" "$API_URL" \
@@ -46,6 +48,13 @@ BINARY_NAME="code-looper-${VERSION}-${TARGET}"
 DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARCHIVE}"
 CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${VERSION}/checksums.txt"
 
+# Fail fast if the install directory cannot be created before downloading
+if ! mkdir -p "$INSTALL_DIR" 2>/dev/null; then
+  printf 'Cannot create install directory: %s\n' "$INSTALL_DIR" >&2
+  printf 'Try: INSTALL_DIR=~/.local/bin sh install.sh\n' >&2
+  exit 1
+fi
+
 TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t code-looper 2>/dev/null || printf '')
 if [ -z "$TMP_DIR" ] || [ ! -d "$TMP_DIR" ]; then
   printf 'Failed to create a temporary directory for installation.\n' >&2
@@ -53,10 +62,12 @@ if [ -z "$TMP_DIR" ] || [ ! -d "$TMP_DIR" ]; then
 fi
 trap 'rm -rf "$TMP_DIR"' EXIT
 
-curl -fsSL "$DOWNLOAD_URL" -o "${TMP_DIR}/${ARCHIVE}"
-curl -fsSL "$CHECKSUMS_URL" -o "${TMP_DIR}/checksums.txt"
+# Download archive and checksums to temp directory
+curl -fSL "$DOWNLOAD_URL" -o "${TMP_DIR}/${ARCHIVE}"
+curl -fSL "$CHECKSUMS_URL" -o "${TMP_DIR}/checksums.txt"
 
-EXPECTED_CHECKSUM=$(grep "  ${ARCHIVE}$" "${TMP_DIR}/checksums.txt" | awk '{print $1}' || true)
+# Verify archive integrity before extraction
+EXPECTED_CHECKSUM=$(grep "  ${ARCHIVE}$" "${TMP_DIR}/checksums.txt" | awk '{print $1}')
 if [ -z "$EXPECTED_CHECKSUM" ]; then
   printf 'Failed to find checksum for %s in checksums.txt.\n' "$ARCHIVE" >&2
   exit 1
@@ -76,12 +87,16 @@ if [ "$ACTUAL_CHECKSUM" != "$EXPECTED_CHECKSUM" ]; then
   exit 1
 fi
 
+# Extract binary and install
 tar -xzf "${TMP_DIR}/${ARCHIVE}" -C "$TMP_DIR"
-
-mkdir -p "$INSTALL_DIR"
+if [ ! -f "${TMP_DIR}/${BINARY_NAME}" ]; then
+  printf 'Extraction succeeded but expected binary %s was not found in the archive.\n' "$BINARY_NAME" >&2
+  exit 1
+fi
 mv "${TMP_DIR}/${BINARY_NAME}" "${INSTALL_DIR}/code-looper"
 chmod +x "${INSTALL_DIR}/code-looper"
 
+# Verify installation succeeded
 if ! INSTALLED_VERSION=$("${INSTALL_DIR}/code-looper" --version 2>&1); then
   printf 'Binary was installed to %s/code-looper but failed to execute:\n%s\n' "$INSTALL_DIR" "$INSTALLED_VERSION" >&2
   printf 'The binary may be incompatible with this system (wrong architecture, noexec mount, etc.).\n' >&2
@@ -89,6 +104,7 @@ if ! INSTALLED_VERSION=$("${INSTALL_DIR}/code-looper" --version 2>&1); then
 fi
 printf 'Installed: %s/code-looper (%s)\n' "$INSTALL_DIR" "$INSTALLED_VERSION"
 
+# Warn if install directory is not on PATH
 case ":${PATH}:" in
   *":${INSTALL_DIR}:"*) ;;
   *)

--- a/src/branch.rs
+++ b/src/branch.rs
@@ -815,7 +815,7 @@ mod tests {
         // temp repo and causing racy "unable to stat" failures in git add.
         std::fs::write(clone.path().join(".gitignore"), ".code-looper/\nloop.log\n").unwrap();
         std::fs::write(clone.path().join("README.md"), "init").unwrap();
-        git_in(clone.path(), &["add", "."]);
+        git_in(clone.path(), &["add", ".gitignore", "README.md"]);
         git_in(clone.path(), &["commit", "-m", "initial"]);
         git_in(clone.path(), &["push", "origin", "main"]);
 


### PR DESCRIPTION
## Summary

- **#211** Remove `|| true` from checksum `grep` — unexpected I/O failures now abort via `set -e` instead of collapsing into a misleading empty-checksum message
- **#212** Add post-extraction binary existence check before `mv` — gives an actionable error if the archive layout ever changes
- **#213** `release.yml` Close milestone step: add `--paginate` (handles > 30 milestones) and `continue-on-error: true` (milestone closure is housekeeping, not a release gate)
- **#214** `ci.yml`: new `shellcheck install.sh` lint step to enforce shell hygiene on every PR
- **#215** `branch.rs` test fixture: stage `.gitignore` and `README.md` explicitly instead of `git add .` to avoid racy staging of transient files
- **#216** `install.sh`: move `mkdir -p $INSTALL_DIR` before downloads (fail fast) and change download curl flags from `-fsSL` to `-fSL` so errors are visible to the user
- **#218** `install.sh`: add inline section comments at all seven logical boundaries for maintainability

## Test plan

- [x] `cargo test` — 561 tests pass
- [x] `shellcheck install.sh` — passes cleanly
- [x] `cargo fmt -- --check` / `cargo clippy` — no issues
- [ ] Verify release CI milestone close step no longer fails the job on transient errors
- [ ] Confirm shellcheck step appears in CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)