### PR TITLE
feat: milestone-aware lifecycle orchestration engine (#191)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ curl -fsSL https://raw.githubusercontent.com/jamesbrayton/code-looper/main/insta
 
 Detects your OS and architecture, downloads the correct binary from [GitHub Releases](https://github.com/jamesbrayton/code-looper/releases/latest), and installs to `~/.local/bin`. Override with `curl -fsSL https://raw.githubusercontent.com/jamesbrayton/code-looper/main/install.sh | INSTALL_DIR=/custom/path sh -s --`.
 
+If the GitHub API rate limit is hit during install, export `GITHUB_TOKEN` to a personal access token and re-run.
+
 **Supported platforms:** macOS ARM64 (Apple Silicon), Linux x86\_64, Linux ARM64.
 
 **macOS x86\_64 (Intel):** No pre-built binary — build from source (see below).

--- a/docs/ADRs/ADR-009-lifecycle-orchestration-model.md
+++ b/docs/ADRs/ADR-009-lifecycle-orchestration-model.md
@@ -19,7 +19,7 @@ Define **five named lifecycles** selected by querying GitHub state at the start 
 |-----------|--------------|
 | `execution` | Current milestone has ≥1 open issue with `ready-for-dev` label |
 | `pr-review` | Open PRs exist and no `ready-for-dev` issues in milestone |
-| `release` | Milestone has 0 open issues and 0 open PRs |
+| `release` | Milestone has 0 open issues (all issues closed, regardless of label) and 0 open PRs |
 | `grooming` | Open issues in milestone have no state label (ungroomed backlog) |
 | `planning` | `ready-for-dev` issues exist with no milestone assignment |
 

--- a/docs/ADRs/ADR-009-lifecycle-orchestration-model.md
+++ b/docs/ADRs/ADR-009-lifecycle-orchestration-model.md
@@ -30,6 +30,6 @@ The existing three-branch policy engine is retained for backward compatibility w
 ## Consequences
 
 - More granular repository context is required: label-filtered issue counts per milestone, not just total counts.
-- The `gh` CLI must be called with `--milestone` and `--label` flags; this adds two extra shell invocations per iteration.
+- The `gh` CLI is called with `--milestone` to fetch milestone issues; label filtering is applied in-process. A third `gh api` call fetches backlog issues with no milestone assignment. This adds one extra shell invocation per iteration compared to the legacy resolver (3 total vs 2).
 - The `release` lifecycle fires as a soft signal: the orchestration engine selects it and generates a prompt instructing the agent to create and push a release tag, which in turn triggers `release.yml`. No direct CI invocation from the engine.
 - Grooming and planning lifecycles are restricted by autonomy mode (see ADR-010).

--- a/docs/ADRs/ADR-009-lifecycle-orchestration-model.md
+++ b/docs/ADRs/ADR-009-lifecycle-orchestration-model.md
@@ -1,0 +1,35 @@
+# ADR-009: Lifecycle Orchestration Model
+
+**Status:** Accepted
+**Date:** 2026-05-02
+**Deciders:** Code Looper project team
+**Related:** #191
+
+## Context
+
+The existing policy engine selects one of three workflow branches (pr-review, issue-execution, backlog-discovery) using user-configurable condition rules evaluated against total open PR and issue counts. This is flexible but not milestone-aware: the engine cannot distinguish between "issues ready for the agent to work" and "issues that need grooming first", and it has no concept of a release trigger.
+
+The milestone-as-release-boundary pattern (ADR-008) and the state label taxonomy (ADR-006) established that GitHub milestone + `ready-for-dev` label is the queryable signal for "work that is ready for the agent." A richer lifecycle model should exploit these signals.
+
+## Decision
+
+Define **five named lifecycles** selected by querying GitHub state at the start of each iteration:
+
+| Lifecycle | Selected when |
+|-----------|--------------|
+| `execution` | Current milestone has ≥1 open issue with `ready-for-dev` label |
+| `pr-review` | Open PRs exist and no `ready-for-dev` issues in milestone |
+| `release` | Milestone has 0 open issues and 0 open PRs |
+| `grooming` | Open issues in milestone have no state label (ungroomed backlog) |
+| `planning` | `ready-for-dev` issues exist with no milestone assignment |
+
+Selection is evaluated in priority order: execution → pr-review → release → grooming → planning. The first matching condition wins.
+
+The existing three-branch policy engine is retained for backward compatibility when `orchestration.mode` is not set. When `mode` is set, the new `LifecycleEngine` replaces it.
+
+## Consequences
+
+- More granular repository context is required: label-filtered issue counts per milestone, not just total counts.
+- The `gh` CLI must be called with `--milestone` and `--label` flags; this adds two extra shell invocations per iteration.
+- The `release` lifecycle fires as a soft signal: the orchestration engine selects it and generates a prompt instructing the agent to create and push a release tag, which in turn triggers `release.yml`. No direct CI invocation from the engine.
+- Grooming and planning lifecycles are restricted by autonomy mode (see ADR-010).

--- a/docs/ADRs/ADR-010-orchestration-autonomy-modes.md
+++ b/docs/ADRs/ADR-010-orchestration-autonomy-modes.md
@@ -21,7 +21,7 @@ Three autonomy modes are defined at launch time via `orchestration.mode`:
 
 Mode is a **launch-time configuration**, not a runtime toggle. Changing mode mid-run would create unpredictable behavior: an autonomous run might create issues that an execution-only run then refuses to groom.
 
-`execution-only` is the **default** when `mode` is set, so users who forget to specify a mode get the safest option.
+If `mode` is omitted from `[orchestration]`, the lifecycle engine is not activated and the legacy policy engine is used instead. Users must explicitly set `mode = "execution-only"` (or another level) to enable the lifecycle engine.
 
 ## Consequences
 

--- a/docs/ADRs/ADR-010-orchestration-autonomy-modes.md
+++ b/docs/ADRs/ADR-010-orchestration-autonomy-modes.md
@@ -1,0 +1,30 @@
+# ADR-010: Orchestration Autonomy Modes
+
+**Status:** Accepted
+**Date:** 2026-05-02
+**Deciders:** Code Looper project team
+**Related:** #191
+
+## Context
+
+The five-lifecycle model (ADR-009) gives the engine the ability to perform grooming (scoping issues) and planning (creating new milestones) in addition to execution and PR review. Not all users want the engine to operate at that autonomy level — some want to retain human control over scope decisions.
+
+## Decision
+
+Three autonomy modes are defined at launch time via `orchestration.mode`:
+
+| Mode | Available lifecycles | Human responsibility |
+|------|---------------------|---------------------|
+| `execution-only` | execution, pr-review | Issue grooming, milestone assignment, release tagging |
+| `assisted` | execution, pr-review, grooming | Milestone assignment, release tagging |
+| `autonomous` | all five | Launch config, feedback review |
+
+Mode is a **launch-time configuration**, not a runtime toggle. Changing mode mid-run would create unpredictable behavior: an autonomous run might create issues that an execution-only run then refuses to groom.
+
+`execution-only` is the **default** when `mode` is set, so users who forget to specify a mode get the safest option.
+
+## Consequences
+
+- `LifecycleEngine::select()` checks the configured mode before returning a lifecycle; an unavailable lifecycle causes a clear error rather than silent fallback.
+- Users running in `execution-only` mode must set up issues with `ready-for-dev` labels and milestone assignments before launching. This setup requirement is documented in `docs/orchestration.md`.
+- Future autonomy levels (e.g., `supervised` with human-approval gates) can be added without breaking existing mode values.

--- a/docs/ADRs/ADR-011-depth-vs-breadth-iteration-patterns.md
+++ b/docs/ADRs/ADR-011-depth-vs-breadth-iteration-patterns.md
@@ -1,6 +1,6 @@
 # ADR-011: Depth vs Breadth Iteration Patterns
 
-**Status:** Accepted
+**Status:** Accepted (partially implemented)
 **Date:** 2026-05-02
 **Deciders:** Code Looper project team
 **Related:** #191
@@ -31,6 +31,8 @@ Two iteration patterns:
 `breadth` is appropriate when the user trusts the agent's planning judgment and wants fully autonomous velocity. It requires `autonomous` mode.
 
 ## Consequences
+
+> **Implementation note (2026-05-02):** `IterationPattern` is parsed and stored but the depth/breadth stop-condition and breadth-continuation logic are not yet wired into the engine. The consequences below describe the intended behaviour when that work is complete. Currently, both `depth` and `breadth` produce identical engine behaviour.
 
 - In `depth` mode, the engine stops when the `release` lifecycle fires (or raises an error if no more work exists in the milestone).
 - In `breadth` mode, the engine transitions from `release` → `planning` automatically. This requires `autonomous` mode; attempting `breadth` with `execution-only` or `assisted` is a startup validation error.

--- a/docs/ADRs/ADR-011-depth-vs-breadth-iteration-patterns.md
+++ b/docs/ADRs/ADR-011-depth-vs-breadth-iteration-patterns.md
@@ -1,0 +1,37 @@
+# ADR-011: Depth vs Breadth Iteration Patterns
+
+**Status:** Accepted
+**Date:** 2026-05-02
+**Deciders:** Code Looper project team
+**Related:** #191
+
+## Context
+
+After a release fires (milestone complete), the engine must decide what to do next. Two plausible behaviors emerged:
+
+1. **Stop** — the milestone is done; the run ends after the release lifecycle.
+2. **Continue to the next milestone** — plan new work, start execution again.
+
+These behaviors suit different workflows and user risk tolerances.
+
+## Decision
+
+Two iteration patterns:
+
+| Pattern | Post-release behavior | Best for |
+|---------|-----------------------|---------|
+| `depth` | Stop after release; milestone scope is locked to the launch prompt goal | Quality-first, deliberate release cycles |
+| `breadth` | After release, enter planning lifecycle to set up the next milestone; repeat | High-velocity, MVP phases with frequent user feedback |
+
+`depth` is the **default** because:
+- It matches the mental model of most users who launch a loop for a specific goal.
+- It is safer: the user retains control over what comes next after a release.
+- It is easier to reason about: the run has a defined end state.
+
+`breadth` is appropriate when the user trusts the agent's planning judgment and wants fully autonomous velocity. It requires `autonomous` mode.
+
+## Consequences
+
+- In `depth` mode, the engine stops when the `release` lifecycle fires (or raises an error if no more work exists in the milestone).
+- In `breadth` mode, the engine transitions from `release` → `planning` automatically. This requires `autonomous` mode; attempting `breadth` with `execution-only` or `assisted` is a startup validation error.
+- `breadth` cross-milestone behavior is implemented as a follow-on iteration: after release, the next `select()` call naturally falls through to `planning` because the old milestone is closed and a new one does not yet exist.

--- a/docs/ADRs/ADR-011-depth-vs-breadth-iteration-patterns.md
+++ b/docs/ADRs/ADR-011-depth-vs-breadth-iteration-patterns.md
@@ -36,4 +36,4 @@ Two iteration patterns:
 
 - In `depth` mode, the engine stops when the `release` lifecycle fires (or raises an error if no more work exists in the milestone).
 - In `breadth` mode, the engine transitions from `release` → `planning` automatically. This requires `autonomous` mode; attempting `breadth` with `execution-only` or `assisted` is a startup validation error.
-- `breadth` cross-milestone behavior is implemented as a follow-on iteration: after release, the next `select()` call naturally falls through to `planning` because the old milestone is closed and a new one does not yet exist.
+- `breadth` cross-milestone behavior is implemented as a follow-on iteration: after release, the next `select()` call falls through to `planning` — provided `ready-for-dev` issues with no milestone assignment already exist. If the backlog is empty at that point, the engine errors even in `autonomous` mode until issues are seeded.

--- a/docs/ADRs/ADR-012-prompt-as-scope-contract.md
+++ b/docs/ADRs/ADR-012-prompt-as-scope-contract.md
@@ -15,7 +15,7 @@ The **launch prompt** (either `--prompt-inline` text or the content of `--prompt
 
 - Issues are the *work decomposition* for achieving the goal — they can grow as the agent refines its understanding.
 - Milestones define what gets shipped — scope is anchored to the original prompt.
-- The engine passes the launch prompt to every lifecycle, not just execution. Grooming and planning lifecycles receive it as context for scoping decisions.
+- The engine will pass the launch prompt to every lifecycle, not just execution, as a planned enhancement (not yet implemented — see Consequences). Grooming and planning lifecycles will receive it as context for scoping decisions.
 
 ## Consequences
 

--- a/docs/ADRs/ADR-012-prompt-as-scope-contract.md
+++ b/docs/ADRs/ADR-012-prompt-as-scope-contract.md
@@ -19,7 +19,7 @@ The **launch prompt** (either `--prompt-inline` text or the content of `--prompt
 
 ## Consequences
 
-- The launch prompt must be stored on `LoopEngine` and passed through to every lifecycle prompt template.
+- The launch prompt is the intended scope anchor for grooming and planning lifecycles; passing it to lifecycle prompt templates is a planned enhancement. Currently `Lifecycle::default_prompt` does not accept a launch-prompt parameter; scope anchoring via prompt text is not yet implemented.
 - Agents must be instructed (via the lifecycle prompt) to compare discovered work against the launch prompt goal before adding it to the current milestone.
 - Users who want the agent to expand scope freely should use a broad launch prompt ("improve this repository") rather than a specific one.
 - This is enforced by convention (prompt text), not by hard code; the engine cannot mechanically verify that an issue "serves the goal."

--- a/docs/ADRs/ADR-012-prompt-as-scope-contract.md
+++ b/docs/ADRs/ADR-012-prompt-as-scope-contract.md
@@ -1,0 +1,25 @@
+# ADR-012: Prompt as Scope Contract
+
+**Status:** Accepted
+**Date:** 2026-05-02
+**Deciders:** Code Looper project team
+**Related:** #191
+
+## Context
+
+When the orchestration engine runs in `autonomous` mode with the grooming and planning lifecycles active, it can create and assign issues to milestones. Without a scope anchor, the engine might expand scope indefinitely — creating issues for any improvement it notices regardless of the original intent.
+
+## Decision
+
+The **launch prompt** (either `--prompt-inline` text or the content of `--prompt-file`) is the **scope contract** for the entire run. The agent must use the prompt goal to judge whether discovered work belongs in the current milestone or should be deferred.
+
+- Issues are the *work decomposition* for achieving the goal — they can grow as the agent refines its understanding.
+- Milestones define what gets shipped — scope is anchored to the original prompt.
+- The engine passes the launch prompt to every lifecycle, not just execution. Grooming and planning lifecycles receive it as context for scoping decisions.
+
+## Consequences
+
+- The launch prompt must be stored on `LoopEngine` and passed through to every lifecycle prompt template.
+- Agents must be instructed (via the lifecycle prompt) to compare discovered work against the launch prompt goal before adding it to the current milestone.
+- Users who want the agent to expand scope freely should use a broad launch prompt ("improve this repository") rather than a specific one.
+- This is enforced by convention (prompt text), not by hard code; the engine cannot mechanically verify that an issue "serves the goal."

--- a/docs/ADRs/ADR-013-discovery-policy.md
+++ b/docs/ADRs/ADR-013-discovery-policy.md
@@ -1,0 +1,40 @@
+# ADR-013: Discovery Policy
+
+**Status:** Accepted
+**Date:** 2026-05-02
+**Deciders:** Code Looper project team
+**Related:** #191
+
+## Context
+
+During execution, the agent often discovers work that was not anticipated when the milestone was set up — bugs found while implementing, missed dependencies, scope gaps. The orchestration engine must define a policy for where this discovered work lands.
+
+Two competing concerns:
+1. **Quality first:** Shipping with known open issues is worse than a delayed release. Discovered work should block the current milestone.
+2. **Velocity first:** Scope creep delays releases. Discovered work should never block the current milestone.
+
+## Decision
+
+Three discovery policies, configurable via `orchestration.discovery.policy`:
+
+| Policy | Behavior |
+|--------|---------|
+| `add-to-milestone` | Discovered work is added to the current milestone (default) |
+| `defer` | Discovered work is always pushed to the next milestone |
+| `prompt` | The agent must ask the user before adding or deferring |
+
+`add-to-milestone` is the **default** because:
+- For an automation tool, release quality is more important than release date.
+- A milestone that closes with known open bugs provides false confidence.
+- Users who need velocity can override to `defer`.
+
+`defer` is the escape valve for teams in a deliberate sprint/velocity mode where scope changes require human decision.
+
+`prompt` is available but not recommended for long-running autonomous loops, as it would block the loop waiting for user input.
+
+## Consequences
+
+- The discovery policy is injected into the execution lifecycle prompt so agents know where to create discovered issues.
+- `add-to-milestone` requires the agent to know the current milestone number; this is passed via the prompt template.
+- `defer` requires the agent to know a "next milestone" target; if none exists, the agent should create one or leave the issue without a milestone.
+- The engine does not mechanically enforce the policy; it communicates it via prompt and relies on agent compliance.

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -42,7 +42,7 @@ condition wins.
 enabled = true
 mode = "assisted"             # execution-only | assisted | autonomous
 current_milestone = 3         # GitHub milestone number to query
-iteration_pattern = "depth"   # depth | breadth (autonomous only)
+iteration_pattern = "depth"   # depth | breadth (breadth requires autonomous mode — not yet enforced)
 
 [orchestration.discovery]
 policy = "add-to-milestone"   # add-to-milestone | defer | prompt
@@ -59,8 +59,10 @@ issues before launching:
 4. Set `orchestration.current_milestone` in `looper.toml` to the milestone number.
 5. Launch `code-looper` — the engine picks up `ready-for-dev` issues automatically.
 
-The engine stops and reports an error if no `ready-for-dev` issues exist and
-the milestone is not yet complete.
+The engine returns an error if the milestone contains open issues but none carry
+the `ready-for-dev` label and no PRs are open — there is no lifecycle available
+in `execution-only` mode for this state. Ensure all actionable issues are
+labelled `ready-for-dev` before launching.
 
 ## Issue lifecycle
 

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -16,6 +16,52 @@ Each iteration the orchestration policy engine evaluates the current repository 
 
 The engine resolves repository context once per iteration before selecting a branch.
 
+## Milestone-aware lifecycle engine
+
+When `orchestration.mode` is set in `looper.toml`, the engine switches to a
+**five-lifecycle model** that queries GitHub state (milestone labels, PR count)
+to select the active lifecycle each iteration.
+
+### Lifecycle selection
+
+| Lifecycle | Fires when | Autonomy mode required |
+|-----------|-----------|----------------------|
+| `execution` | Current milestone has ≥1 issue with `ready-for-dev` label | Any |
+| `pr-review` | Open PRs exist; no `ready-for-dev` in milestone | Any |
+| `release` | Milestone has 0 open issues and 0 open PRs | Any |
+| `grooming` | Issues in milestone have no state label | `assisted` or `autonomous` |
+| `planning` | `ready-for-dev` issues exist with no milestone | `autonomous` only |
+
+Lifecycles are evaluated in priority order top-to-bottom; the first matching
+condition wins.
+
+### Configuration
+
+```toml
+[orchestration]
+enabled = true
+mode = "assisted"             # execution-only | assisted | autonomous
+current_milestone = 3         # GitHub milestone number to query
+iteration_pattern = "depth"   # depth | breadth (autonomous only)
+
+[orchestration.discovery]
+policy = "add-to-milestone"   # add-to-milestone | defer | prompt
+```
+
+### Execution-only mode setup
+
+In `execution-only` mode the engine cannot groom or plan — you must set up
+issues before launching:
+
+1. Open issues for all planned work (`gh issue create ...`).
+2. Add the `ready-for-dev` label to issues that are ready to start (`gh issue edit <n> --add-label ready-for-dev`).
+3. Assign issues to the current milestone (`gh issue edit <n> --milestone <title>`).
+4. Set `orchestration.current_milestone` in `looper.toml` to the milestone number.
+5. Launch `code-looper` — the engine picks up `ready-for-dev` issues automatically.
+
+The engine stops and reports an error if no `ready-for-dev` issues exist and
+the milestone is not yet complete.
+
 ## Issue lifecycle
 
 When orchestration is enabled, the engine expects agents to actively manage GitHub Issues throughout the run.

--- a/src/config.rs
+++ b/src/config.rs
@@ -511,7 +511,10 @@ pub enum OrchestrationMode {
     Autonomous,
 }
 
-/// Iteration pattern for the lifecycle engine (used in autonomous mode).
+/// Iteration pattern for the lifecycle engine.
+/// NOTE: This field is parsed and stored but the depth/breadth stop-condition
+/// logic is not yet implemented in the engine. Setting this to `breadth` has
+/// no effect until that feature is wired in.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum IterationPattern {

--- a/src/config.rs
+++ b/src/config.rs
@@ -485,6 +485,69 @@ pub struct OrchestrationConfig {
     /// rule chain (pr-review → issue-execution → backlog-discovery).
     #[serde(default = "default_policy_rules")]
     pub policies: Vec<PolicyRule>,
+    /// Milestone-aware mode. When set, the LifecycleEngine is used instead of PolicyEngine.
+    pub mode: Option<OrchestrationMode>,
+    /// Current milestone number for label-filtered lifecycle queries.
+    pub current_milestone: Option<u32>,
+    /// Iteration pattern (depth or breadth).
+    #[serde(default)]
+    pub iteration_pattern: IterationPattern,
+    /// Discovery policy configuration.
+    #[serde(default)]
+    pub discovery: DiscoveryConfig,
+}
+
+/// Autonomy mode for the milestone-aware lifecycle engine.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OrchestrationMode {
+    /// Only execution and pr-review lifecycles are available.
+    ExecutionOnly,
+    /// execution, pr-review, and grooming lifecycles are available.
+    Assisted,
+    /// All five lifecycles are available.
+    Autonomous,
+}
+
+/// Iteration pattern for the lifecycle engine (used in autonomous mode).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum IterationPattern {
+    /// Stop after the current milestone releases; scope is locked to launch prompt.
+    #[default]
+    Depth,
+    /// After release, move to planning the next milestone and repeat.
+    Breadth,
+}
+
+/// Policy for handling work discovered during execution.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum DiscoveryPolicy {
+    /// Add discovered work to the current milestone (default).
+    #[default]
+    AddToMilestone,
+    /// Always push discovered work to the next milestone.
+    Defer,
+    /// Ask the user before adding or deferring.
+    Prompt,
+}
+
+impl std::fmt::Display for DiscoveryPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DiscoveryPolicy::AddToMilestone => write!(f, "add-to-milestone"),
+            DiscoveryPolicy::Defer => write!(f, "defer"),
+            DiscoveryPolicy::Prompt => write!(f, "prompt"),
+        }
+    }
+}
+
+/// Discovery policy configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct DiscoveryConfig {
+    #[serde(default)]
+    pub policy: DiscoveryPolicy,
 }
 
 impl Default for OrchestrationConfig {
@@ -494,6 +557,10 @@ impl Default for OrchestrationConfig {
             repo_owner: None,
             repo_name: None,
             policies: default_policy_rules(),
+            mode: None,
+            current_milestone: None,
+            iteration_pattern: IterationPattern::default(),
+            discovery: DiscoveryConfig::default(),
         }
     }
 }
@@ -3044,5 +3111,38 @@ global = ".code-looper/rules/global.md"
         assert!(rules
             .workflows
             .contains_key(&PolicyWorkflow::IssueExecution));
+    }
+
+    #[test]
+    fn orchestration_mode_default_is_none() {
+        let cfg = OrchestrationConfig::default();
+        assert!(cfg.mode.is_none());
+    }
+
+    #[test]
+    fn orchestration_mode_deserializes_from_toml() {
+        let toml_str = r#"
+            enabled = true
+            mode = "assisted"
+            current_milestone = 3
+            [discovery]
+            policy = "defer"
+        "#;
+        let cfg: OrchestrationConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.mode, Some(OrchestrationMode::Assisted));
+        assert_eq!(cfg.current_milestone, Some(3));
+        assert_eq!(cfg.discovery.policy, DiscoveryPolicy::Defer);
+    }
+
+    #[test]
+    fn iteration_pattern_default_is_depth() {
+        let cfg = OrchestrationConfig::default();
+        assert_eq!(cfg.iteration_pattern, IterationPattern::Depth);
+    }
+
+    #[test]
+    fn discovery_policy_default_is_add_to_milestone() {
+        let cfg = OrchestrationConfig::default();
+        assert_eq!(cfg.discovery.policy, DiscoveryPolicy::AddToMilestone);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3160,6 +3160,28 @@ global = ".code-looper/rules/global.md"
     }
 
     #[test]
+    fn orchestration_mode_deserializes_execution_only() {
+        let toml_str = r#"
+            enabled = true
+            mode = "execution-only"
+            current_milestone = 1
+        "#;
+        let cfg: OrchestrationConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.mode, Some(OrchestrationMode::ExecutionOnly));
+    }
+
+    #[test]
+    fn orchestration_mode_deserializes_autonomous() {
+        let toml_str = r#"
+            enabled = true
+            mode = "autonomous"
+            current_milestone = 1
+        "#;
+        let cfg: OrchestrationConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.mode, Some(OrchestrationMode::Autonomous));
+    }
+
+    #[test]
     fn iteration_pattern_default_is_depth() {
         let cfg = OrchestrationConfig::default();
         assert_eq!(cfg.iteration_pattern, IterationPattern::Depth);

--- a/src/config.rs
+++ b/src/config.rs
@@ -486,8 +486,10 @@ pub struct OrchestrationConfig {
     #[serde(default = "default_policy_rules")]
     pub policies: Vec<PolicyRule>,
     /// Milestone-aware mode. When set, the LifecycleEngine is used instead of PolicyEngine.
+    #[serde(default)]
     pub mode: Option<OrchestrationMode>,
     /// Current milestone number for label-filtered lifecycle queries.
+    #[serde(default)]
     pub current_milestone: Option<u32>,
     /// Iteration pattern (depth or breadth).
     #[serde(default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1198,6 +1198,26 @@ impl LoopConfig {
             }
         }
 
+        // When mode is set, the three lifecycle-engine fields are required.
+        if self.orchestration.mode.is_some() {
+            if self.orchestration.repo_owner.is_none() {
+                return Err(LooperError::InvalidArgument(
+                    "orchestration.mode is set but orchestration.repo_owner is missing".to_string(),
+                ));
+            }
+            if self.orchestration.repo_name.is_none() {
+                return Err(LooperError::InvalidArgument(
+                    "orchestration.mode is set but orchestration.repo_name is missing".to_string(),
+                ));
+            }
+            if self.orchestration.current_milestone.is_none() {
+                return Err(LooperError::InvalidArgument(
+                    "orchestration.mode is set but orchestration.current_milestone is missing"
+                        .to_string(),
+                ));
+            }
+        }
+
         // ── on_complete ─────────────────────────────────────────────────
         if let Some(cmd) = &self.on_complete {
             if cmd.trim().is_empty() {
@@ -3146,5 +3166,39 @@ global = ".code-looper/rules/global.md"
     fn discovery_policy_default_is_add_to_milestone() {
         let cfg = OrchestrationConfig::default();
         assert_eq!(cfg.discovery.policy, DiscoveryPolicy::AddToMilestone);
+    }
+
+    #[test]
+    fn validate_rejects_mode_without_repo_fields() {
+        let cfg = LoopConfig {
+            orchestration: OrchestrationConfig {
+                mode: Some(OrchestrationMode::ExecutionOnly),
+                ..OrchestrationConfig::default()
+            },
+            ..Default::default()
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn validate_accepts_mode_with_all_required_fields() {
+        let cfg = LoopConfig {
+            orchestration: OrchestrationConfig {
+                mode: Some(OrchestrationMode::ExecutionOnly),
+                repo_owner: Some("owner".to_string()),
+                repo_name: Some("repo".to_string()),
+                current_milestone: Some(1),
+                ..OrchestrationConfig::default()
+            },
+            ..Default::default()
+        };
+        // validate() may fail for other reasons (prompt source); just confirm it doesn't
+        // fail on the orchestration fields. Check the error message if it fails.
+        if let Err(e) = cfg.validate() {
+            assert!(
+                !e.to_string().contains("orchestration.mode"),
+                "validate should not fail on orchestration.mode fields, got: {e}"
+            );
+        }
     }
 }

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -761,12 +761,8 @@ impl LoopEngine {
                     match engine.select() {
                         Ok(LifecycleSelection { lifecycle, context }) => {
                             let lc_name = lifecycle.to_string();
-                            let discovery_policy = self
-                                .config
-                                .orchestration
-                                .discovery
-                                .policy
-                                .to_string();
+                            let discovery_policy =
+                                self.config.orchestration.discovery.policy.to_string();
                             let milestone = self.config.orchestration.current_milestone;
                             info!(
                                 iteration = i,
@@ -2007,14 +2003,15 @@ mod tests {
     #[test]
     fn lifecycle_engine_selects_lifecycle_and_succeeds() {
         use crate::config::{OrchestrationConfig, OrchestrationMode};
-        use crate::orchestration::{
-            LifecycleEngine, MilestoneContext, MilestoneContextResolver,
-        };
+        use crate::orchestration::{LifecycleEngine, MilestoneContext, MilestoneContextResolver};
 
         struct StubLifecycleResolver;
         impl MilestoneContextResolver for StubLifecycleResolver {
             fn resolve(&self) -> Result<MilestoneContext, crate::error::LooperError> {
-                Ok(MilestoneContext { milestone_ready_for_dev: 1, ..Default::default() })
+                Ok(MilestoneContext {
+                    milestone_ready_for_dev: 1,
+                    ..Default::default()
+                })
             }
         }
 
@@ -2033,10 +2030,13 @@ mod tests {
         .validate()
         .unwrap();
         let adapter = FakeAdapter::success("fake");
-        let lifecycle_engine =
-            LifecycleEngine::new(Box::new(StubLifecycleResolver), OrchestrationMode::ExecutionOnly);
+        let lifecycle_engine = LifecycleEngine::new(
+            Box::new(StubLifecycleResolver),
+            OrchestrationMode::ExecutionOnly,
+        );
 
-        let engine = LoopEngine::with_adapter_and_lifecycle(config, Box::new(adapter), lifecycle_engine);
+        let engine =
+            LoopEngine::with_adapter_and_lifecycle(config, Box::new(adapter), lifecycle_engine);
         let summary = engine.run();
         assert_eq!(summary.iterations_run, 1);
         assert_eq!(summary.failures, 0);

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -2043,6 +2043,46 @@ mod tests {
         assert_eq!(summary.failures, 0);
     }
 
+    #[test]
+    fn lifecycle_engine_failure_terminates_loop() {
+        use crate::config::{OrchestrationConfig, OrchestrationMode};
+        use crate::orchestration::{LifecycleEngine, MilestoneContext, MilestoneContextResolver};
+
+        struct FailingLifecycleResolver;
+        impl MilestoneContextResolver for FailingLifecycleResolver {
+            fn resolve(&self) -> Result<MilestoneContext, crate::error::LooperError> {
+                Err(crate::error::LooperError::InvalidArgument(
+                    "simulated resolver failure".to_string(),
+                ))
+            }
+        }
+
+        let config = LoopConfig {
+            iterations: 3,
+            provider: Provider::Claude,
+            orchestration: OrchestrationConfig {
+                enabled: true,
+                mode: Some(OrchestrationMode::ExecutionOnly),
+                repo_owner: Some("owner".to_string()),
+                repo_name: Some("repo".to_string()),
+                current_milestone: Some(1),
+                ..OrchestrationConfig::default()
+            },
+            ..Default::default()
+        }
+        .validate()
+        .unwrap();
+        let adapter = FakeAdapter::success("fake");
+        let lifecycle_engine =
+            LifecycleEngine::new(Box::new(FailingLifecycleResolver), OrchestrationMode::ExecutionOnly);
+
+        let engine =
+            LoopEngine::with_adapter_and_lifecycle(config, Box::new(adapter), lifecycle_engine);
+        let summary = engine.run();
+        assert_eq!(summary.iterations_run, 1);
+        assert_eq!(summary.failures, 1);
+    }
+
     // ── Engine-driven issue comment tests ────────────────────────────────────
 
     use crate::config::{CommentCadence, IssueTrackingConfig, IssueTrackingMode};

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -184,25 +184,30 @@ impl LoopEngine {
             config.provider_extra_args.clone(),
         );
         let policy_engine = if config.orchestration.enabled {
-            let owner = config.orchestration.repo_owner.clone().unwrap_or_else(|| {
-                warn!(
-                    "PolicyEngine constructed with no repo_owner — \
-                     orchestration context resolution will fail"
-                );
-                String::new()
-            });
-            let repo = config.orchestration.repo_name.clone().unwrap_or_else(|| {
-                warn!(
-                    "PolicyEngine constructed with no repo_name — \
-                     orchestration context resolution will fail"
-                );
-                String::new()
-            });
-            let rules = config.orchestration.policies.clone();
-            Some(PolicyEngine::with_rules(
-                Box::new(GhCliContextResolver { owner, repo }),
-                rules,
-            ))
+            match (
+                config.orchestration.repo_owner.clone(),
+                config.orchestration.repo_name.clone(),
+            ) {
+                (Some(owner), Some(repo)) => Some(PolicyEngine::with_rules(
+                    Box::new(GhCliContextResolver { owner, repo }),
+                    config.orchestration.policies.clone(),
+                )),
+                (owner, repo) => {
+                    let missing: Vec<&str> = [
+                        owner.is_none().then_some("orchestration.repo_owner"),
+                        repo.is_none().then_some("orchestration.repo_name"),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .collect();
+                    warn!(
+                        "orchestration.enabled is true but required fields are missing: {}. \
+                         Policy engine disabled.",
+                        missing.join(", ")
+                    );
+                    None
+                }
+            }
         } else {
             None
         };

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -2023,6 +2023,7 @@ mod tests {
                 mode: Some(OrchestrationMode::ExecutionOnly),
                 repo_owner: Some("owner".to_string()),
                 repo_name: Some("repo".to_string()),
+                current_milestone: Some(1),
                 ..OrchestrationConfig::default()
             },
             ..Default::default()

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -762,7 +762,7 @@ impl LoopEngine {
                         Ok(LifecycleSelection { lifecycle, context }) => {
                             let lc_name = lifecycle.to_string();
                             let discovery_policy =
-                                self.config.orchestration.discovery.policy.to_string();
+                                &self.config.orchestration.discovery.policy;
                             let milestone = self.config.orchestration.current_milestone;
                             info!(
                                 iteration = i,
@@ -772,7 +772,7 @@ impl LoopEngine {
                                 open_pr_count = context.open_pr_count,
                                 "Iteration start (lifecycle engine)"
                             );
-                            let p = lifecycle.default_prompt(&discovery_policy, milestone);
+                            let p = lifecycle.default_prompt(discovery_policy, milestone);
                             (p, Some(lc_name), None)
                         }
                         Err(e) => {

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -4,7 +4,9 @@ use crate::config::{
     CommentCadence, IssueTrackingMode, LoopConfig, PrMode, PromptInput, ValidatedLoopConfig,
 };
 use crate::issue_tracker::{GitHubIssueTracker, IssueTracker, LocalPromiseTracker};
-use crate::orchestration::{BranchSelection, GhCliContextResolver, PolicyEngine};
+use crate::orchestration::{
+    BranchSelection, GhCliContextResolver, LifecycleEngine, LifecycleSelection, PolicyEngine,
+};
 use crate::policy_guard::PolicyGuard;
 use crate::pr_manager::{build_pr_manager, GhPrLifecycle, PrError, PrManager, TriageAction};
 use crate::pr_strategy::{build_strategy, PrStrategy};
@@ -143,6 +145,8 @@ pub struct LoopEngine {
     adapter: Box<dyn ProviderAdapter>,
     /// Optional orchestration policy engine (present when orchestration is enabled).
     policy_engine: Option<PolicyEngine>,
+    /// Milestone-aware lifecycle engine (present when orchestration.mode is set).
+    lifecycle_engine: Option<LifecycleEngine>,
     /// Policy guard used to augment prompts with the GitHub policy preamble.
     guard: PolicyGuard,
     /// Issue tracker for this run.
@@ -202,6 +206,40 @@ impl LoopEngine {
         } else {
             None
         };
+        let lifecycle_engine = if let Some(mode) = config.orchestration.mode.clone() {
+            let owner = config.orchestration.repo_owner.clone().unwrap_or_else(|| {
+                warn!(
+                    "LifecycleEngine constructed with no repo_owner — \
+                     context resolution will fail"
+                );
+                String::new()
+            });
+            let repo = config.orchestration.repo_name.clone().unwrap_or_else(|| {
+                warn!(
+                    "LifecycleEngine constructed with no repo_name — \
+                     context resolution will fail"
+                );
+                String::new()
+            });
+            if let Some(milestone) = config.orchestration.current_milestone {
+                Some(LifecycleEngine::new(
+                    Box::new(crate::orchestration::GhCliLifecycleContextResolver {
+                        owner,
+                        repo,
+                        milestone,
+                    }),
+                    mode,
+                ))
+            } else {
+                warn!(
+                    "orchestration.mode is set but orchestration.current_milestone is not; \
+                     lifecycle engine disabled"
+                );
+                None
+            }
+        } else {
+            None
+        };
         let tracker = build_tracker(&config);
         let pr_strategy =
             build_strategy(config.pr_management.clone(), config.workspace_dir.clone());
@@ -224,6 +262,7 @@ impl LoopEngine {
             config,
             adapter,
             policy_engine,
+            lifecycle_engine,
             guard,
             tracker,
             pr_strategy,
@@ -254,6 +293,7 @@ impl LoopEngine {
             config,
             adapter,
             policy_engine: None,
+            lifecycle_engine: None,
             guard,
             tracker,
             pr_strategy,
@@ -278,6 +318,7 @@ impl LoopEngine {
             config,
             adapter,
             policy_engine: None,
+            lifecycle_engine: None,
             guard,
             tracker,
             pr_strategy,
@@ -303,6 +344,7 @@ impl LoopEngine {
             config,
             adapter,
             policy_engine: Some(policy_engine),
+            lifecycle_engine: None,
             guard,
             tracker,
             pr_strategy,
@@ -326,6 +368,33 @@ impl LoopEngine {
             config,
             adapter,
             policy_engine: None,
+            lifecycle_engine: None,
+            guard,
+            tracker,
+            pr_strategy,
+            pr_manager: None,
+            branch_manager: None,
+            interrupted,
+        }
+    }
+
+    /// Constructor that accepts a custom adapter and lifecycle engine (useful for testing).
+    #[cfg(test)]
+    pub fn with_adapter_and_lifecycle(
+        config: ValidatedLoopConfig,
+        adapter: Box<dyn ProviderAdapter>,
+        lifecycle_engine: LifecycleEngine,
+    ) -> Self {
+        let interrupted = Arc::new(AtomicBool::new(false));
+        let guard = PolicyGuard::new(crate::policy_guard::UnsafeOverrides::default());
+        let tracker = build_tracker(&config);
+        let pr_strategy =
+            build_strategy(config.pr_management.clone(), config.workspace_dir.clone());
+        Self {
+            config,
+            adapter,
+            policy_engine: None,
+            lifecycle_engine: Some(lifecycle_engine),
             guard,
             tracker,
             pr_strategy,
@@ -686,9 +755,53 @@ impl LoopEngine {
                 }
             }
 
-            // If orchestration is enabled, select a workflow branch and use its prompt.
+            // Prefer lifecycle engine (milestone-aware) over policy engine (legacy).
             let (raw_prompt, workflow_branch, workflow_policy) =
-                if let Some(ref engine) = self.policy_engine {
+                if let Some(ref engine) = self.lifecycle_engine {
+                    match engine.select() {
+                        Ok(LifecycleSelection { lifecycle, .. }) => {
+                            let lc_name = lifecycle.to_string();
+                            let discovery_policy = self
+                                .config
+                                .orchestration
+                                .discovery
+                                .policy
+                                .to_string();
+                            let milestone = self.config.orchestration.current_milestone;
+                            info!(
+                                iteration = i,
+                                provider = self.adapter.name(),
+                                lifecycle = %lc_name,
+                                "Iteration start (lifecycle engine)"
+                            );
+                            let p = lifecycle.default_prompt(&discovery_policy, milestone);
+                            (p, Some(lc_name), None)
+                        }
+                        Err(e) => {
+                            error!(iteration = i, "Lifecycle engine failed: {e}");
+                            let outcome = IterationOutcome::PolicyGuardBlock {
+                                message: e.to_string(),
+                            };
+                            iteration_records.push(IterationRecord {
+                                iteration: i,
+                                provider: self.config.provider.clone(),
+                                prompt_source: prompt_source.clone(),
+                                workflow_branch: None,
+                                outcome: outcome.clone(),
+                                duration_ms: iter_start.elapsed().as_millis(),
+                                retries: 0,
+                                stderr_excerpt: Some(e.to_string()),
+                                transcript_path: None,
+                                started_at: iter_started_at,
+                            });
+                            summary.iterations_run += 1;
+                            summary.failures += 1;
+                            summary.termination_reason =
+                                Some(TerminationReason::ProviderError(e.to_string()));
+                            break;
+                        }
+                    }
+                } else if let Some(ref engine) = self.policy_engine {
                     match engine.select_branch() {
                         Ok(BranchSelection {
                             branch,
@@ -1887,6 +2000,44 @@ mod tests {
             summary.termination_reason,
             Some(TerminationReason::ProviderError(_))
         ));
+    }
+
+    #[test]
+    fn lifecycle_engine_selects_lifecycle_and_succeeds() {
+        use crate::config::{OrchestrationConfig, OrchestrationMode};
+        use crate::orchestration::{
+            LifecycleEngine, MilestoneContext, MilestoneContextResolver,
+        };
+
+        struct StubLifecycleResolver;
+        impl MilestoneContextResolver for StubLifecycleResolver {
+            fn resolve(&self) -> Result<MilestoneContext, crate::error::LooperError> {
+                Ok(MilestoneContext { milestone_ready_for_dev: 1, ..Default::default() })
+            }
+        }
+
+        let config = LoopConfig {
+            iterations: 1,
+            provider: Provider::Claude,
+            orchestration: OrchestrationConfig {
+                enabled: true,
+                mode: Some(OrchestrationMode::ExecutionOnly),
+                repo_owner: Some("owner".to_string()),
+                repo_name: Some("repo".to_string()),
+                ..OrchestrationConfig::default()
+            },
+            ..Default::default()
+        }
+        .validate()
+        .unwrap();
+        let adapter = FakeAdapter::success("fake");
+        let lifecycle_engine =
+            LifecycleEngine::new(Box::new(StubLifecycleResolver), OrchestrationMode::ExecutionOnly);
+
+        let engine = LoopEngine::with_adapter_and_lifecycle(config, Box::new(adapter), lifecycle_engine);
+        let summary = engine.run();
+        assert_eq!(summary.iterations_run, 1);
+        assert_eq!(summary.failures, 0);
     }
 
     // ── Engine-driven issue comment tests ────────────────────────────────────

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -224,7 +224,9 @@ impl LoopEngine {
                     let missing: Vec<&str> = [
                         owner.is_none().then_some("orchestration.repo_owner"),
                         repo.is_none().then_some("orchestration.repo_name"),
-                        milestone.is_none().then_some("orchestration.current_milestone"),
+                        milestone
+                            .is_none()
+                            .then_some("orchestration.current_milestone"),
                     ]
                     .into_iter()
                     .flatten()
@@ -761,8 +763,7 @@ impl LoopEngine {
                     match engine.select() {
                         Ok(LifecycleSelection { lifecycle, context }) => {
                             let lc_name = lifecycle.to_string();
-                            let discovery_policy =
-                                &self.config.orchestration.discovery.policy;
+                            let discovery_policy = &self.config.orchestration.discovery.policy;
                             let milestone = self.config.orchestration.current_milestone;
                             info!(
                                 iteration = i,
@@ -2073,8 +2074,10 @@ mod tests {
         .validate()
         .unwrap();
         let adapter = FakeAdapter::success("fake");
-        let lifecycle_engine =
-            LifecycleEngine::new(Box::new(FailingLifecycleResolver), OrchestrationMode::ExecutionOnly);
+        let lifecycle_engine = LifecycleEngine::new(
+            Box::new(FailingLifecycleResolver),
+            OrchestrationMode::ExecutionOnly,
+        );
 
         let engine =
             LoopEngine::with_adapter_and_lifecycle(config, Box::new(adapter), lifecycle_engine);

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -2089,6 +2089,10 @@ mod tests {
         let summary = engine.run();
         assert_eq!(summary.iterations_run, 1);
         assert_eq!(summary.failures, 1);
+        assert!(
+            summary.termination_reason.is_some(),
+            "termination_reason should be set after lifecycle engine failure"
+        );
     }
 
     // ── Engine-driven issue comment tests ────────────────────────────────────

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -759,7 +759,7 @@ impl LoopEngine {
             let (raw_prompt, workflow_branch, workflow_policy) =
                 if let Some(ref engine) = self.lifecycle_engine {
                     match engine.select() {
-                        Ok(LifecycleSelection { lifecycle, .. }) => {
+                        Ok(LifecycleSelection { lifecycle, context }) => {
                             let lc_name = lifecycle.to_string();
                             let discovery_policy = self
                                 .config
@@ -772,6 +772,8 @@ impl LoopEngine {
                                 iteration = i,
                                 provider = self.adapter.name(),
                                 lifecycle = %lc_name,
+                                milestone_ready_for_dev = context.milestone_ready_for_dev,
+                                open_pr_count = context.open_pr_count,
                                 "Iteration start (lifecycle engine)"
                             );
                             let p = lifecycle.default_prompt(&discovery_policy, milestone);

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -207,35 +207,35 @@ impl LoopEngine {
             None
         };
         let lifecycle_engine = if let Some(mode) = config.orchestration.mode.clone() {
-            let owner = config.orchestration.repo_owner.clone().unwrap_or_else(|| {
-                warn!(
-                    "LifecycleEngine constructed with no repo_owner — \
-                     context resolution will fail"
-                );
-                String::new()
-            });
-            let repo = config.orchestration.repo_name.clone().unwrap_or_else(|| {
-                warn!(
-                    "LifecycleEngine constructed with no repo_name — \
-                     context resolution will fail"
-                );
-                String::new()
-            });
-            if let Some(milestone) = config.orchestration.current_milestone {
-                Some(LifecycleEngine::new(
+            match (
+                config.orchestration.repo_owner.clone(),
+                config.orchestration.repo_name.clone(),
+                config.orchestration.current_milestone,
+            ) {
+                (Some(owner), Some(repo), Some(milestone)) => Some(LifecycleEngine::new(
                     Box::new(crate::orchestration::GhCliLifecycleContextResolver {
                         owner,
                         repo,
                         milestone,
                     }),
                     mode,
-                ))
-            } else {
-                warn!(
-                    "orchestration.mode is set but orchestration.current_milestone is not; \
-                     lifecycle engine disabled"
-                );
-                None
+                )),
+                (owner, repo, milestone) => {
+                    let missing: Vec<&str> = [
+                        owner.is_none().then_some("orchestration.repo_owner"),
+                        repo.is_none().then_some("orchestration.repo_name"),
+                        milestone.is_none().then_some("orchestration.current_milestone"),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .collect();
+                    warn!(
+                        "orchestration.mode is set but required fields are missing: {}. \
+                         Lifecycle engine disabled.",
+                        missing.join(", ")
+                    );
+                    None
+                }
             }
         } else {
             None

--- a/src/loop_engine.rs
+++ b/src/loop_engine.rs
@@ -1280,7 +1280,7 @@ impl LoopEngine {
 
         info!(
             total_duration_ms = total_ms,
-            termination_reason = %summary.termination_reason.as_ref().unwrap(),
+            termination_reason = %summary.termination_reason.as_ref().map(|r| r.to_string()).unwrap_or_else(|| "unknown".to_string()),
             "Loop finished"
         );
 

--- a/src/orchestration.rs
+++ b/src/orchestration.rs
@@ -64,6 +64,73 @@ pub enum Lifecycle {
     Planning,
 }
 
+impl Lifecycle {
+    /// Return the default prompt payload for this lifecycle.
+    #[allow(dead_code)]
+    pub fn default_prompt(&self, discovery_policy: &str, milestone: Option<u32>) -> String {
+        let milestone_ref = milestone
+            .map(|n| format!("milestone #{n}"))
+            .unwrap_or_else(|| "the current milestone".to_string());
+
+        match self {
+            Lifecycle::Execution => {
+                let discovery_note = match discovery_policy {
+                    "defer" => "create a new issue and leave it without a milestone (defer to next release)".to_string(),
+                    "prompt" => "pause and ask the user whether to add it to the current milestone or defer".to_string(),
+                    _ => format!("create a new issue and add it to {milestone_ref}"),
+                };
+                format!(
+                    "Work on open GitHub issues in {milestone_ref} that have the `ready-for-dev` label. \
+                     Pick the highest-priority unassigned issue, understand the requirements, \
+                     implement the changes, and update the issue when done.\n\n\
+                     **Issue lifecycle rules:**\n\
+                     - Comment at meaningful milestones (plan finalised, first pass done, tests added, blocker found).\n\
+                     - If you discover out-of-scope work, {discovery_note}.\n\
+                     - When the issue checklist is fully checked and changes are committed, close the issue."
+                )
+            }
+            Lifecycle::PrReview => {
+                "Review open pull requests in this repository. For each open PR, \
+                 check the diff, verify tests pass, and leave a constructive review comment \
+                 using the `gh` CLI or MCP GitHub tools. Do not merge without explicit approval \
+                 or unless the PR is from an automated process with a green CI run."
+                    .to_string()
+            }
+            Lifecycle::Release => format!(
+                "{milestone_ref} is complete — all issues are closed and there are no open PRs. \
+                 Create and push a release tag to trigger the release workflow:\n\n\
+                 1. Determine the next version by reading `Cargo.toml` and the latest git tag.\n\
+                 2. Run `git tag v<VERSION> && git push origin v<VERSION>`.\n\
+                 3. Verify that the `release.yml` CI workflow starts on GitHub Actions.\n\
+                 4. Comment on the milestone with the release tag and close it if it is not already closed."
+            ),
+            Lifecycle::Grooming => format!(
+                "Groom open issues in {milestone_ref} that have no state label \
+                 (`ready-for-dev`, `in-progress`, or `blocked`).\n\n\
+                 For each ungroomed issue:\n\
+                 - Read the issue body and comments.\n\
+                 - If the issue is actionable as written, add the `ready-for-dev` label.\n\
+                 - If the issue is blocked on another issue or external decision, add the `blocked` label \
+                   and add a comment explaining the blocker.\n\
+                 - If the issue is out of scope for the current milestone (compare against the launch goal), \
+                   remove the milestone assignment and add a comment explaining the deferral.\n\
+                 - If the issue needs more information before it can be started, leave a comment asking \
+                   for the missing details."
+            ),
+            Lifecycle::Planning => {
+                "Issues with the `ready-for-dev` label exist without a milestone assignment. \
+                 Plan the next milestone:\n\n\
+                 1. List all `ready-for-dev` issues without a milestone using `gh issue list --label ready-for-dev`.\n\
+                 2. Group them by theme or dependency order.\n\
+                 3. If no open milestone exists, create one: `gh api repos/:owner/:repo/milestones --method POST -f title='vX.Y.Z'`.\n\
+                 4. Assign the highest-priority issues to the milestone using `gh issue edit <number> --milestone <title>`.\n\
+                 5. Leave a planning comment on the milestone (via `gh api`) summarising the scope."
+                    .to_string()
+            }
+        }
+    }
+}
+
 impl std::fmt::Display for Lifecycle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -838,5 +905,28 @@ pub mod tests {
         assert_eq!(Lifecycle::Release.to_string(), "release");
         assert_eq!(Lifecycle::Grooming.to_string(), "grooming");
         assert_eq!(Lifecycle::Planning.to_string(), "planning");
+    }
+
+    #[test]
+    fn lifecycle_prompts_are_nonempty() {
+        assert!(!Lifecycle::Execution.default_prompt("add-to-milestone", Some(1)).is_empty());
+        assert!(!Lifecycle::PrReview.default_prompt("add-to-milestone", None).is_empty());
+        assert!(!Lifecycle::Release.default_prompt("add-to-milestone", Some(1)).is_empty());
+        assert!(!Lifecycle::Grooming.default_prompt("add-to-milestone", Some(1)).is_empty());
+        assert!(!Lifecycle::Planning.default_prompt("add-to-milestone", None).is_empty());
+    }
+
+    #[test]
+    fn execution_prompt_injects_discovery_policy() {
+        let defer_prompt = Lifecycle::Execution.default_prompt("defer", Some(2));
+        assert!(
+            defer_prompt.contains("defer to next release"),
+            "expected defer text in: {defer_prompt}"
+        );
+        let add_prompt = Lifecycle::Execution.default_prompt("add-to-milestone", Some(2));
+        assert!(
+            add_prompt.contains("milestone #2"),
+            "expected milestone ref in: {add_prompt}"
+        );
     }
 }

--- a/src/orchestration.rs
+++ b/src/orchestration.rs
@@ -449,6 +449,15 @@ impl MilestoneContextResolver for GhCliLifecycleContextResolver {
         // 2. All open issues in the milestone with their labels
         let milestone_issues = list_milestone_issues(&repo_slug, self.milestone)?;
 
+        if milestone_issues.len() == 200 {
+            tracing::warn!(
+                repo = %repo_slug,
+                milestone = self.milestone,
+                "Milestone issue query returned exactly 200 results (the limit); \
+                 some issues may have been omitted and counts may be inaccurate."
+            );
+        }
+
         let milestone_open_issues = milestone_issues.len() as u32;
 
         // 3. Partition by state label
@@ -516,10 +525,16 @@ fn list_milestone_issues(
 }
 
 fn has_label(issue: &serde_json::Value, label: &str) -> bool {
-    issue["labels"]
-        .as_array()
-        .map(|labels| labels.iter().any(|l| l["name"].as_str() == Some(label)))
-        .unwrap_or(false)
+    match issue["labels"].as_array() {
+        Some(labels) => labels.iter().any(|l| l["name"].as_str() == Some(label)),
+        None => {
+            tracing::warn!(
+                issue_number = issue["number"].as_u64(),
+                "Issue JSON missing or malformed 'labels' field; treating as unlabelled"
+            );
+            false
+        }
+    }
 }
 
 fn count_gh_issues_no_milestone(repo_slug: &str) -> Result<u32, LooperError> {
@@ -556,10 +571,23 @@ fn count_gh_issues_no_milestone(repo_slug: &str) -> Result<u32, LooperError> {
 
     // --paginate + --jq "length" outputs one count per page; sum them.
     let text = String::from_utf8_lossy(&output.stdout);
-    let total: u32 = text
-        .lines()
-        .filter_map(|l| l.trim().parse::<u32>().ok())
-        .sum();
+    let mut total: u32 = 0;
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match trimmed.parse::<u32>() {
+            Ok(n) => total += n,
+            Err(e) => {
+                return Err(LooperError::InvalidArgument(format!(
+                    "gh api issues (no-milestone) returned unparseable output for {repo_slug}: \
+                     {e} (line: {trimmed:?})"
+                )));
+            }
+        }
+    }
+    tracing::debug!(repo = %repo_slug, backlog_ready_for_dev = total, "Counted backlog ready-for-dev issues (no milestone)");
     Ok(total)
 }
 

--- a/src/orchestration.rs
+++ b/src/orchestration.rs
@@ -102,7 +102,8 @@ impl Lifecycle {
                  1. Determine the next version by reading `Cargo.toml` and the latest git tag.\n\
                  2. Run `git tag v<VERSION> && git push origin v<VERSION>`.\n\
                  3. Verify that the `release.yml` CI workflow starts on GitHub Actions.\n\
-                 4. Comment on the milestone with the release tag and close it if it is not already closed."
+                 4. Close the milestone once the tag is pushed: \
+ `gh api repos/:owner/:repo/milestones/<MILESTONE_NUMBER> --method PATCH -f state=closed`."
             ),
             Lifecycle::Grooming => format!(
                 "Groom open issues in {milestone_ref} that have no state label \
@@ -120,11 +121,13 @@ impl Lifecycle {
             Lifecycle::Planning => {
                 "Issues with the `ready-for-dev` label exist without a milestone assignment. \
                  Plan the next milestone:\n\n\
-                 1. List all `ready-for-dev` issues without a milestone using `gh issue list --label ready-for-dev`.\n\
+                 1. List all `ready-for-dev` issues without a milestone using \
+   `gh issue list --no-milestone --label ready-for-dev`.\n\
                  2. Group them by theme or dependency order.\n\
                  3. If no open milestone exists, create one: `gh api repos/:owner/:repo/milestones --method POST -f title='vX.Y.Z'`.\n\
                  4. Assign the highest-priority issues to the milestone using `gh issue edit <number> --milestone <title>`.\n\
-                 5. Leave a planning comment on the milestone (via `gh api`) summarising the scope."
+                 5. Verify the milestone is open and note its URL for reference: \
+   `gh api repos/:owner/:repo/milestones/<MILESTONE_NUMBER>`."
                     .to_string()
             }
         }
@@ -402,7 +405,8 @@ fn count_gh_items(owner: &str, repo: &str, kind: &str) -> Result<u32, LooperErro
     let repo_slug = format!("{owner}/{repo}");
     let output = Command::new("gh")
         .args([
-            kind, "list", "--repo", &repo_slug, "--state", "open", "--json", "number",
+            kind, "list", "--repo", &repo_slug, "--state", "open", "--json", "number", "--limit",
+            "500",
         ])
         .output()
         .map_err(|e| LooperError::ProviderSpawn {
@@ -557,6 +561,8 @@ fn count_gh_issues_no_milestone(repo_slug: &str) -> Result<u32, LooperError> {
             "milestone=none",
             "-f",
             "labels=ready-for-dev",
+            "-f",
+            "type=issue",
             "--paginate",
             "--jq",
             "length",

--- a/src/orchestration.rs
+++ b/src/orchestration.rs
@@ -21,7 +21,6 @@ impl RepoContext {
 
 /// Milestone-aware repository context for the lifecycle engine.
 #[derive(Debug, Clone, Default)]
-#[allow(dead_code)]
 pub struct MilestoneContext {
     /// Open issues in the current milestone with `ready-for-dev` label.
     pub milestone_ready_for_dev: u32,
@@ -36,21 +35,18 @@ pub struct MilestoneContext {
 }
 
 impl MilestoneContext {
-    #[allow(dead_code)]
     pub fn is_milestone_complete(&self) -> bool {
         self.milestone_open_issues == 0 && self.open_pr_count == 0
     }
 }
 
 /// Abstraction for fetching milestone-aware repository context.
-#[allow(dead_code)]
 pub trait MilestoneContextResolver: Send + Sync {
     fn resolve(&self) -> Result<MilestoneContext, LooperError>;
 }
 
 /// The five named lifecycles.
 #[derive(Debug, Clone, PartialEq)]
-#[allow(dead_code)]
 pub enum Lifecycle {
     /// Work items with `ready-for-dev` in the current milestone.
     Execution,
@@ -66,7 +62,6 @@ pub enum Lifecycle {
 
 impl Lifecycle {
     /// Return the default prompt payload for this lifecycle.
-    #[allow(dead_code)]
     pub fn default_prompt(&self, discovery_policy: &str, milestone: Option<u32>) -> String {
         let milestone_ref = milestone
             .map(|n| format!("milestone #{n}"))
@@ -145,21 +140,19 @@ impl std::fmt::Display for Lifecycle {
 
 /// Result of lifecycle selection.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct LifecycleSelection {
     pub lifecycle: Lifecycle,
+    #[allow(dead_code)]
     pub context: MilestoneContext,
 }
 
 /// Lifecycle engine: queries milestone-aware context and selects the active lifecycle.
-#[allow(dead_code)]
 pub struct LifecycleEngine {
     resolver: Box<dyn MilestoneContextResolver>,
     mode: crate::config::OrchestrationMode,
 }
 
 impl LifecycleEngine {
-    #[allow(dead_code)]
     pub fn new(
         resolver: Box<dyn MilestoneContextResolver>,
         mode: crate::config::OrchestrationMode,
@@ -167,7 +160,6 @@ impl LifecycleEngine {
         Self { resolver, mode }
     }
 
-    #[allow(dead_code)]
     pub fn select(&self) -> Result<LifecycleSelection, LooperError> {
         use crate::config::OrchestrationMode;
         let ctx = self.resolver.resolve()?;
@@ -289,13 +281,13 @@ pub trait ContextResolver: Send + Sync {
 
 /// Result of the policy engine's branch selection.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct BranchSelection {
     /// The workflow branch to execute.
     pub branch: WorkflowBranch,
     /// Prompt override from the matching rule, if any.
     pub prompt_override: Option<String>,
     /// Repository context snapshot used to make the decision.
+    #[allow(dead_code)]
     pub context: RepoContext,
 }
 

--- a/src/orchestration.rs
+++ b/src/orchestration.rs
@@ -362,6 +362,145 @@ fn count_gh_items(owner: &str, repo: &str, kind: &str) -> Result<u32, LooperErro
     Ok(items.len() as u32)
 }
 
+// ── GitHub CLI lifecycle context resolver ────────────────────────────────────
+
+/// State label names used by the lifecycle engine to classify issues.
+const STATE_LABELS: &[&str] = &["ready-for-dev", "in-progress", "blocked"];
+
+/// Fetches milestone-aware context by shelling out to `gh`.
+pub struct GhCliLifecycleContextResolver {
+    pub owner: String,
+    pub repo: String,
+    /// GitHub milestone number for label-filtered queries.
+    pub milestone: u32,
+}
+
+impl MilestoneContextResolver for GhCliLifecycleContextResolver {
+    fn resolve(&self) -> Result<MilestoneContext, LooperError> {
+        let repo_slug = format!("{}/{}", self.owner, self.repo);
+
+        // 1. Open PRs — all, not milestone-filtered (GitHub doesn't link PRs to milestones)
+        let open_pr_count = count_gh_items(&self.owner, &self.repo, "pr")?;
+
+        // 2. All open issues in the milestone with their labels
+        let milestone_issues = list_milestone_issues(&repo_slug, self.milestone)?;
+
+        let milestone_open_issues = milestone_issues.len() as u32;
+
+        // 3. Partition by state label
+        let milestone_ready_for_dev = milestone_issues
+            .iter()
+            .filter(|i| has_label(i, "ready-for-dev"))
+            .count() as u32;
+
+        let milestone_ungroomed = milestone_issues
+            .iter()
+            .filter(|i| STATE_LABELS.iter().all(|&l| !has_label(i, l)))
+            .count() as u32;
+
+        // 4. Backlog: ready-for-dev issues with no milestone
+        let backlog_ready_for_dev = count_gh_issues_no_milestone(&repo_slug)?;
+
+        Ok(MilestoneContext {
+            milestone_ready_for_dev,
+            milestone_ungroomed,
+            milestone_open_issues,
+            open_pr_count,
+            backlog_ready_for_dev,
+        })
+    }
+}
+
+fn list_milestone_issues(
+    repo_slug: &str,
+    milestone: u32,
+) -> Result<Vec<serde_json::Value>, LooperError> {
+    use std::process::Command;
+
+    let output = Command::new("gh")
+        .args([
+            "issue",
+            "list",
+            "--repo",
+            repo_slug,
+            "--state",
+            "open",
+            "--milestone",
+            &milestone.to_string(),
+            "--json",
+            "number,labels",
+            "--limit",
+            "200",
+        ])
+        .output()
+        .map_err(|e| LooperError::ProviderSpawn {
+            binary: "gh".to_string(),
+            source: e,
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(LooperError::InvalidArgument(format!(
+            "gh issue list --milestone {milestone} failed for {repo_slug}: {stderr}"
+        )));
+    }
+
+    let text = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&text).map_err(|e| {
+        LooperError::InvalidArgument(format!(
+            "failed to parse gh issue list output as JSON: {e}"
+        ))
+    })
+}
+
+fn has_label(issue: &serde_json::Value, label: &str) -> bool {
+    issue["labels"]
+        .as_array()
+        .map(|labels| labels.iter().any(|l| l["name"].as_str() == Some(label)))
+        .unwrap_or(false)
+}
+
+fn count_gh_issues_no_milestone(repo_slug: &str) -> Result<u32, LooperError> {
+    use std::process::Command;
+
+    let output = Command::new("gh")
+        .args([
+            "api",
+            &format!("repos/{repo_slug}/issues"),
+            "--method",
+            "GET",
+            "-f",
+            "state=open",
+            "-f",
+            "milestone=none",
+            "-f",
+            "labels=ready-for-dev",
+            "--paginate",
+            "--jq",
+            "length",
+        ])
+        .output()
+        .map_err(|e| LooperError::ProviderSpawn {
+            binary: "gh".to_string(),
+            source: e,
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(LooperError::InvalidArgument(format!(
+            "gh api issues (no-milestone) failed for {repo_slug}: {stderr}"
+        )));
+    }
+
+    // --paginate + --jq "length" outputs one count per page; sum them.
+    let text = String::from_utf8_lossy(&output.stdout);
+    let total: u32 = text
+        .lines()
+        .filter_map(|l| l.trim().parse::<u32>().ok())
+        .sum();
+    Ok(total)
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]

--- a/src/orchestration.rs
+++ b/src/orchestration.rs
@@ -984,4 +984,61 @@ pub mod tests {
             "expected milestone ref in: {add_prompt}"
         );
     }
+
+    #[test]
+    fn selects_grooming_when_ungroomed_and_mode_is_autonomous() {
+        use crate::config::OrchestrationMode;
+        let engine = LifecycleEngine::new(
+            Box::new(StubLifecycleResolver {
+                ctx: MilestoneContext {
+                    milestone_ungroomed: 3,
+                    milestone_open_issues: 3,
+                    ..Default::default()
+                },
+            }),
+            OrchestrationMode::Autonomous,
+        );
+        let sel = engine.select().unwrap();
+        assert_eq!(sel.lifecycle, Lifecycle::Grooming);
+    }
+
+    #[test]
+    fn assisted_mode_blocks_planning() {
+        use crate::config::OrchestrationMode;
+        // backlog_ready_for_dev > 0 triggers Planning only in Autonomous mode.
+        // milestone_open_issues > 0 prevents Release; no ungroomed prevents Grooming.
+        // In Assisted mode, Planning is blocked and no lifecycle applies → error.
+        let engine = LifecycleEngine::new(
+            Box::new(StubLifecycleResolver {
+                ctx: MilestoneContext {
+                    backlog_ready_for_dev: 2,
+                    milestone_open_issues: 1,
+                    ..Default::default()
+                },
+            }),
+            OrchestrationMode::Assisted,
+        );
+        assert!(engine.select().is_err());
+    }
+
+    #[test]
+    fn is_milestone_complete_requires_both_zero() {
+        assert!(MilestoneContext::default().is_milestone_complete());
+        assert!(!MilestoneContext {
+            open_pr_count: 1,
+            ..Default::default()
+        }
+        .is_milestone_complete());
+        assert!(!MilestoneContext {
+            milestone_open_issues: 1,
+            ..Default::default()
+        }
+        .is_milestone_complete());
+        assert!(!MilestoneContext {
+            milestone_open_issues: 1,
+            open_pr_count: 1,
+            ..Default::default()
+        }
+        .is_milestone_complete());
+    }
 }

--- a/src/orchestration.rs
+++ b/src/orchestration.rs
@@ -171,7 +171,10 @@ impl LifecycleEngine {
         } else if ctx.is_milestone_complete() {
             Some(Lifecycle::Release)
         } else if ctx.milestone_ungroomed > 0
-            && matches!(self.mode, OrchestrationMode::Assisted | OrchestrationMode::Autonomous)
+            && matches!(
+                self.mode,
+                OrchestrationMode::Assisted | OrchestrationMode::Autonomous
+            )
         {
             Some(Lifecycle::Grooming)
         } else if ctx.backlog_ready_for_dev > 0
@@ -190,7 +193,10 @@ impl LifecycleEngine {
                     open_pr_count = ctx.open_pr_count,
                     "Lifecycle engine selected lifecycle"
                 );
-                Ok(LifecycleSelection { lifecycle: lc, context: ctx })
+                Ok(LifecycleSelection {
+                    lifecycle: lc,
+                    context: ctx,
+                })
             }
             None => Err(LooperError::InvalidArgument(format!(
                 "No lifecycle applies to current state in `{}` mode. \
@@ -505,9 +511,7 @@ fn list_milestone_issues(
 
     let text = String::from_utf8_lossy(&output.stdout);
     serde_json::from_str(&text).map_err(|e| {
-        LooperError::InvalidArgument(format!(
-            "failed to parse gh issue list output as JSON: {e}"
-        ))
+        LooperError::InvalidArgument(format!("failed to parse gh issue list output as JSON: {e}"))
     })
 }
 
@@ -807,7 +811,10 @@ pub mod tests {
         use crate::config::OrchestrationMode;
         let engine = LifecycleEngine::new(
             Box::new(StubLifecycleResolver {
-                ctx: MilestoneContext { milestone_ready_for_dev: 2, ..Default::default() },
+                ctx: MilestoneContext {
+                    milestone_ready_for_dev: 2,
+                    ..Default::default()
+                },
             }),
             OrchestrationMode::ExecutionOnly,
         );
@@ -820,7 +827,10 @@ pub mod tests {
         use crate::config::OrchestrationMode;
         let engine = LifecycleEngine::new(
             Box::new(StubLifecycleResolver {
-                ctx: MilestoneContext { open_pr_count: 1, ..Default::default() },
+                ctx: MilestoneContext {
+                    open_pr_count: 1,
+                    ..Default::default()
+                },
             }),
             OrchestrationMode::ExecutionOnly,
         );
@@ -848,7 +858,11 @@ pub mod tests {
         let engine = LifecycleEngine::new(
             Box::new(StubLifecycleResolver {
                 // milestone_open_issues > 0 so is_milestone_complete() returns false
-                ctx: MilestoneContext { milestone_ungroomed: 3, milestone_open_issues: 3, ..Default::default() },
+                ctx: MilestoneContext {
+                    milestone_ungroomed: 3,
+                    milestone_open_issues: 3,
+                    ..Default::default()
+                },
             }),
             OrchestrationMode::Assisted,
         );
@@ -881,7 +895,11 @@ pub mod tests {
         let engine = LifecycleEngine::new(
             Box::new(StubLifecycleResolver {
                 // milestone_open_issues > 0 so Release doesn't fire; no ready-for-dev, no PRs
-                ctx: MilestoneContext { milestone_open_issues: 1, backlog_ready_for_dev: 2, ..Default::default() },
+                ctx: MilestoneContext {
+                    milestone_open_issues: 1,
+                    backlog_ready_for_dev: 2,
+                    ..Default::default()
+                },
             }),
             OrchestrationMode::Autonomous,
         );
@@ -900,11 +918,21 @@ pub mod tests {
 
     #[test]
     fn lifecycle_prompts_are_nonempty() {
-        assert!(!Lifecycle::Execution.default_prompt("add-to-milestone", Some(1)).is_empty());
-        assert!(!Lifecycle::PrReview.default_prompt("add-to-milestone", None).is_empty());
-        assert!(!Lifecycle::Release.default_prompt("add-to-milestone", Some(1)).is_empty());
-        assert!(!Lifecycle::Grooming.default_prompt("add-to-milestone", Some(1)).is_empty());
-        assert!(!Lifecycle::Planning.default_prompt("add-to-milestone", None).is_empty());
+        assert!(!Lifecycle::Execution
+            .default_prompt("add-to-milestone", Some(1))
+            .is_empty());
+        assert!(!Lifecycle::PrReview
+            .default_prompt("add-to-milestone", None)
+            .is_empty());
+        assert!(!Lifecycle::Release
+            .default_prompt("add-to-milestone", Some(1))
+            .is_empty());
+        assert!(!Lifecycle::Grooming
+            .default_prompt("add-to-milestone", Some(1))
+            .is_empty());
+        assert!(!Lifecycle::Planning
+            .default_prompt("add-to-milestone", None)
+            .is_empty());
     }
 
     #[test]

--- a/src/orchestration.rs
+++ b/src/orchestration.rs
@@ -62,17 +62,22 @@ pub enum Lifecycle {
 
 impl Lifecycle {
     /// Return the default prompt payload for this lifecycle.
-    pub fn default_prompt(&self, discovery_policy: &str, milestone: Option<u32>) -> String {
+    pub fn default_prompt(
+        &self,
+        discovery_policy: &crate::config::DiscoveryPolicy,
+        milestone: Option<u32>,
+    ) -> String {
         let milestone_ref = milestone
             .map(|n| format!("milestone #{n}"))
             .unwrap_or_else(|| "the current milestone".to_string());
 
         match self {
             Lifecycle::Execution => {
+                use crate::config::DiscoveryPolicy;
                 let discovery_note = match discovery_policy {
-                    "defer" => "create a new issue and leave it without a milestone (defer to next release)".to_string(),
-                    "prompt" => "pause and ask the user whether to add it to the current milestone or defer".to_string(),
-                    _ => format!("create a new issue and add it to {milestone_ref}"),
+                    DiscoveryPolicy::Defer => "create a new issue and leave it without a milestone (defer to next release)".to_string(),
+                    DiscoveryPolicy::Prompt => "pause and ask the user whether to add it to the current milestone or defer".to_string(),
+                    DiscoveryPolicy::AddToMilestone => format!("create a new issue and add it to {milestone_ref}"),
                 };
                 format!(
                     "Work on open GitHub issues in {milestone_ref} that have the `ready-for-dev` label. \
@@ -946,31 +951,34 @@ pub mod tests {
 
     #[test]
     fn lifecycle_prompts_are_nonempty() {
+        use crate::config::DiscoveryPolicy;
         assert!(!Lifecycle::Execution
-            .default_prompt("add-to-milestone", Some(1))
+            .default_prompt(&DiscoveryPolicy::AddToMilestone, Some(1))
             .is_empty());
         assert!(!Lifecycle::PrReview
-            .default_prompt("add-to-milestone", None)
+            .default_prompt(&DiscoveryPolicy::AddToMilestone, None)
             .is_empty());
         assert!(!Lifecycle::Release
-            .default_prompt("add-to-milestone", Some(1))
+            .default_prompt(&DiscoveryPolicy::AddToMilestone, Some(1))
             .is_empty());
         assert!(!Lifecycle::Grooming
-            .default_prompt("add-to-milestone", Some(1))
+            .default_prompt(&DiscoveryPolicy::AddToMilestone, Some(1))
             .is_empty());
         assert!(!Lifecycle::Planning
-            .default_prompt("add-to-milestone", None)
+            .default_prompt(&DiscoveryPolicy::AddToMilestone, None)
             .is_empty());
     }
 
     #[test]
     fn execution_prompt_injects_discovery_policy() {
-        let defer_prompt = Lifecycle::Execution.default_prompt("defer", Some(2));
+        use crate::config::DiscoveryPolicy;
+        let defer_prompt = Lifecycle::Execution.default_prompt(&DiscoveryPolicy::Defer, Some(2));
         assert!(
             defer_prompt.contains("defer to next release"),
             "expected defer text in: {defer_prompt}"
         );
-        let add_prompt = Lifecycle::Execution.default_prompt("add-to-milestone", Some(2));
+        let add_prompt =
+            Lifecycle::Execution.default_prompt(&DiscoveryPolicy::AddToMilestone, Some(2));
         assert!(
             add_prompt.contains("milestone #2"),
             "expected milestone ref in: {add_prompt}"

--- a/src/orchestration.rs
+++ b/src/orchestration.rs
@@ -19,6 +19,135 @@ impl RepoContext {
     }
 }
 
+/// Milestone-aware repository context for the lifecycle engine.
+#[derive(Debug, Clone, Default)]
+#[allow(dead_code)]
+pub struct MilestoneContext {
+    /// Open issues in the current milestone with `ready-for-dev` label.
+    pub milestone_ready_for_dev: u32,
+    /// Open issues in the current milestone with no state label.
+    pub milestone_ungroomed: u32,
+    /// Total open issues in the current milestone.
+    pub milestone_open_issues: u32,
+    /// Total open PRs in the repository.
+    pub open_pr_count: u32,
+    /// Issues with `ready-for-dev` label and no milestone assigned.
+    pub backlog_ready_for_dev: u32,
+}
+
+impl MilestoneContext {
+    #[allow(dead_code)]
+    pub fn is_milestone_complete(&self) -> bool {
+        self.milestone_open_issues == 0 && self.open_pr_count == 0
+    }
+}
+
+/// Abstraction for fetching milestone-aware repository context.
+#[allow(dead_code)]
+pub trait MilestoneContextResolver: Send + Sync {
+    fn resolve(&self) -> Result<MilestoneContext, LooperError>;
+}
+
+/// The five named lifecycles.
+#[derive(Debug, Clone, PartialEq)]
+#[allow(dead_code)]
+pub enum Lifecycle {
+    /// Work items with `ready-for-dev` in the current milestone.
+    Execution,
+    /// Open PRs exist (and no ready-for-dev items).
+    PrReview,
+    /// Milestone is fully closed — time to release.
+    Release,
+    /// Ungroomed issues in the milestone need scoping.
+    Grooming,
+    /// Ready-for-dev items with no milestone need milestone assignment.
+    Planning,
+}
+
+impl std::fmt::Display for Lifecycle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Lifecycle::Execution => write!(f, "execution"),
+            Lifecycle::PrReview => write!(f, "pr-review"),
+            Lifecycle::Release => write!(f, "release"),
+            Lifecycle::Grooming => write!(f, "grooming"),
+            Lifecycle::Planning => write!(f, "planning"),
+        }
+    }
+}
+
+/// Result of lifecycle selection.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct LifecycleSelection {
+    pub lifecycle: Lifecycle,
+    pub context: MilestoneContext,
+}
+
+/// Lifecycle engine: queries milestone-aware context and selects the active lifecycle.
+#[allow(dead_code)]
+pub struct LifecycleEngine {
+    resolver: Box<dyn MilestoneContextResolver>,
+    mode: crate::config::OrchestrationMode,
+}
+
+impl LifecycleEngine {
+    #[allow(dead_code)]
+    pub fn new(
+        resolver: Box<dyn MilestoneContextResolver>,
+        mode: crate::config::OrchestrationMode,
+    ) -> Self {
+        Self { resolver, mode }
+    }
+
+    #[allow(dead_code)]
+    pub fn select(&self) -> Result<LifecycleSelection, LooperError> {
+        use crate::config::OrchestrationMode;
+        let ctx = self.resolver.resolve()?;
+
+        // Priority order: execution → pr-review → release → grooming → planning
+        let lifecycle = if ctx.milestone_ready_for_dev > 0 {
+            Some(Lifecycle::Execution)
+        } else if ctx.open_pr_count > 0 {
+            Some(Lifecycle::PrReview)
+        } else if ctx.is_milestone_complete() {
+            Some(Lifecycle::Release)
+        } else if ctx.milestone_ungroomed > 0
+            && matches!(self.mode, OrchestrationMode::Assisted | OrchestrationMode::Autonomous)
+        {
+            Some(Lifecycle::Grooming)
+        } else if ctx.backlog_ready_for_dev > 0
+            && matches!(self.mode, OrchestrationMode::Autonomous)
+        {
+            Some(Lifecycle::Planning)
+        } else {
+            None
+        };
+
+        match lifecycle {
+            Some(lc) => {
+                tracing::info!(
+                    lifecycle = %lc,
+                    milestone_ready_for_dev = ctx.milestone_ready_for_dev,
+                    open_pr_count = ctx.open_pr_count,
+                    "Lifecycle engine selected lifecycle"
+                );
+                Ok(LifecycleSelection { lifecycle: lc, context: ctx })
+            }
+            None => Err(LooperError::InvalidArgument(format!(
+                "No lifecycle applies to current state in `{}` mode. \
+                 Ensure the current milestone has issues with `ready-for-dev` label, \
+                 or upgrade to a higher autonomy mode.",
+                match self.mode {
+                    OrchestrationMode::ExecutionOnly => "execution-only",
+                    OrchestrationMode::Assisted => "assisted",
+                    OrchestrationMode::Autonomous => "autonomous",
+                }
+            ))),
+        }
+    }
+}
+
 /// Workflow branch selected by the policy engine.
 #[derive(Debug, Clone, PartialEq)]
 pub enum WorkflowBranch {
@@ -464,5 +593,109 @@ pub mod tests {
             "has_open_issues"
         );
         assert_eq!(PolicyCondition::Always.to_string(), "always");
+    }
+
+    pub struct StubLifecycleResolver {
+        pub ctx: MilestoneContext,
+    }
+
+    impl MilestoneContextResolver for StubLifecycleResolver {
+        fn resolve(&self) -> Result<MilestoneContext, LooperError> {
+            Ok(self.ctx.clone())
+        }
+    }
+
+    #[test]
+    fn selects_execution_when_ready_for_dev_in_milestone() {
+        use crate::config::OrchestrationMode;
+        let engine = LifecycleEngine::new(
+            Box::new(StubLifecycleResolver {
+                ctx: MilestoneContext { milestone_ready_for_dev: 2, ..Default::default() },
+            }),
+            OrchestrationMode::ExecutionOnly,
+        );
+        let sel = engine.select().unwrap();
+        assert_eq!(sel.lifecycle, Lifecycle::Execution);
+    }
+
+    #[test]
+    fn selects_pr_review_when_prs_open_and_no_ready_for_dev() {
+        use crate::config::OrchestrationMode;
+        let engine = LifecycleEngine::new(
+            Box::new(StubLifecycleResolver {
+                ctx: MilestoneContext { open_pr_count: 1, ..Default::default() },
+            }),
+            OrchestrationMode::ExecutionOnly,
+        );
+        let sel = engine.select().unwrap();
+        assert_eq!(sel.lifecycle, Lifecycle::PrReview);
+    }
+
+    #[test]
+    fn selects_release_when_milestone_complete() {
+        use crate::config::OrchestrationMode;
+        // All fields default to 0, so is_milestone_complete() returns true
+        let engine = LifecycleEngine::new(
+            Box::new(StubLifecycleResolver {
+                ctx: MilestoneContext::default(),
+            }),
+            OrchestrationMode::ExecutionOnly,
+        );
+        let sel = engine.select().unwrap();
+        assert_eq!(sel.lifecycle, Lifecycle::Release);
+    }
+
+    #[test]
+    fn selects_grooming_when_ungroomed_and_mode_is_assisted() {
+        use crate::config::OrchestrationMode;
+        let engine = LifecycleEngine::new(
+            Box::new(StubLifecycleResolver {
+                // milestone_open_issues > 0 so is_milestone_complete() returns false
+                ctx: MilestoneContext { milestone_ungroomed: 3, milestone_open_issues: 3, ..Default::default() },
+            }),
+            OrchestrationMode::Assisted,
+        );
+        let sel = engine.select().unwrap();
+        assert_eq!(sel.lifecycle, Lifecycle::Grooming);
+    }
+
+    #[test]
+    fn execution_only_mode_blocks_grooming() {
+        use crate::config::OrchestrationMode;
+        let engine = LifecycleEngine::new(
+            Box::new(StubLifecycleResolver {
+                ctx: MilestoneContext { milestone_ungroomed: 3, ..Default::default() },
+            }),
+            OrchestrationMode::ExecutionOnly,
+        );
+        // No ready-for-dev, no PRs, milestone_open_issues=0 so Release fires first
+        // Wait — actually MilestoneContext::default() has milestone_open_issues=0 and open_pr_count=0,
+        // so is_milestone_complete() returns true → Release is selected, not an error.
+        // Execution-only cannot block Release. Test should verify grooming is NOT selected:
+        let sel = engine.select().unwrap();
+        assert_ne!(sel.lifecycle, Lifecycle::Grooming);
+    }
+
+    #[test]
+    fn selects_planning_when_backlog_ready_and_autonomous() {
+        use crate::config::OrchestrationMode;
+        let engine = LifecycleEngine::new(
+            Box::new(StubLifecycleResolver {
+                // milestone_open_issues > 0 so Release doesn't fire; no ready-for-dev, no PRs
+                ctx: MilestoneContext { milestone_open_issues: 1, backlog_ready_for_dev: 2, ..Default::default() },
+            }),
+            OrchestrationMode::Autonomous,
+        );
+        let sel = engine.select().unwrap();
+        assert_eq!(sel.lifecycle, Lifecycle::Planning);
+    }
+
+    #[test]
+    fn lifecycle_display() {
+        assert_eq!(Lifecycle::Execution.to_string(), "execution");
+        assert_eq!(Lifecycle::PrReview.to_string(), "pr-review");
+        assert_eq!(Lifecycle::Release.to_string(), "release");
+        assert_eq!(Lifecycle::Grooming.to_string(), "grooming");
+        assert_eq!(Lifecycle::Planning.to_string(), "planning");
     }
 }

--- a/src/orchestration.rs
+++ b/src/orchestration.rs
@@ -142,7 +142,6 @@ impl std::fmt::Display for Lifecycle {
 #[derive(Debug, Clone)]
 pub struct LifecycleSelection {
     pub lifecycle: Lifecycle,
-    #[allow(dead_code)]
     pub context: MilestoneContext,
 }
 

--- a/src/orchestration.rs
+++ b/src/orchestration.rs
@@ -662,18 +662,20 @@ pub mod tests {
     #[test]
     fn execution_only_mode_blocks_grooming() {
         use crate::config::OrchestrationMode;
+        // milestone_open_issues > 0 prevents is_milestone_complete() from firing;
+        // no ready-for-dev, no PRs → grooming would fire in Assisted mode but is
+        // blocked in ExecutionOnly → engine returns an error.
         let engine = LifecycleEngine::new(
             Box::new(StubLifecycleResolver {
-                ctx: MilestoneContext { milestone_ungroomed: 3, ..Default::default() },
+                ctx: MilestoneContext {
+                    milestone_ungroomed: 3,
+                    milestone_open_issues: 3,
+                    ..Default::default()
+                },
             }),
             OrchestrationMode::ExecutionOnly,
         );
-        // No ready-for-dev, no PRs, milestone_open_issues=0 so Release fires first
-        // Wait — actually MilestoneContext::default() has milestone_open_issues=0 and open_pr_count=0,
-        // so is_milestone_complete() returns true → Release is selected, not an error.
-        // Execution-only cannot block Release. Test should verify grooming is NOT selected:
-        let sel = engine.select().unwrap();
-        assert_ne!(sel.lifecycle, Lifecycle::Grooming);
+        assert!(engine.select().is_err());
     }
 
     #[test]

--- a/src/orchestration.rs
+++ b/src/orchestration.rs
@@ -50,13 +50,13 @@ pub trait MilestoneContextResolver: Send + Sync {
 pub enum Lifecycle {
     /// Work items with `ready-for-dev` in the current milestone.
     Execution,
-    /// Open PRs exist (and no ready-for-dev items).
+    /// Open PRs exist and the current milestone has no `ready-for-dev` issues.
     PrReview,
     /// Milestone is fully closed — time to release.
     Release,
     /// Ungroomed issues in the milestone need scoping.
     Grooming,
-    /// Ready-for-dev items with no milestone need milestone assignment.
+    /// Issues with `ready-for-dev` label and no milestone assignment exist in the backlog.
     Planning,
 }
 
@@ -982,6 +982,11 @@ pub mod tests {
         assert!(
             add_prompt.contains("milestone #2"),
             "expected milestone ref in: {add_prompt}"
+        );
+        let prompt_prompt = Lifecycle::Execution.default_prompt(&DiscoveryPolicy::Prompt, Some(2));
+        assert!(
+            prompt_prompt.contains("pause and ask the user"),
+            "expected pause text in: {prompt_prompt}"
         );
     }
 

--- a/src/orchestration.rs
+++ b/src/orchestration.rs
@@ -583,7 +583,7 @@ fn count_gh_issues_no_milestone(repo_slug: &str) -> Result<u32, LooperError> {
             continue;
         }
         match trimmed.parse::<u32>() {
-            Ok(n) => total += n,
+            Ok(n) => total = total.saturating_add(n),
             Err(e) => {
                 return Err(LooperError::InvalidArgument(format!(
                     "gh api issues (no-milestone) returned unparseable output for {repo_slug}: \


### PR DESCRIPTION
## Summary

Implements the five-lifecycle, milestone-aware orchestration engine described in issue #191. Replaces the flat three-branch policy engine with a GitHub-state-driven lifecycle selector when `orchestration.mode` is configured, while remaining fully backward compatible.

- Adds `OrchestrationMode` (`execution-only`, `assisted`, `autonomous`), `IterationPattern`, `DiscoveryPolicy`, and `current_milestone` to `OrchestrationConfig`
- Adds `LifecycleEngine` with five named lifecycles (execution → pr-review → release → grooming → planning), selected by querying milestone labels and PR count via `gh` CLI each iteration
- Wires `LifecycleEngine` into `LoopEngine`; it is preferred over the legacy `PolicyEngine` when `orchestration.mode` is set
- Each lifecycle generates a discovery-policy-aware prompt passed to the provider
- Adds 5 ADRs (ADR-009 through ADR-013) and updates `docs/orchestration.md` with the lifecycle table and execution-only setup guide

## Closes

Closes #191

## Test plan

- [ ] `cargo build --release` passes (verified clean)
- [ ] `cargo test` — 575 tests pass, 0 failures (verified)
- [ ] `cargo clippy -- -D warnings` — no warnings (verified)
- [ ] Review `src/config.rs`: new enums and fields deserialize correctly from TOML
- [ ] Review `src/orchestration.rs`: `LifecycleEngine::select()` priority order (execution → pr-review → release → grooming → planning) and autonomy mode filtering
- [ ] Review `src/loop_engine.rs`: lifecycle engine path is used when `mode` is set; policy engine fallback works when `mode` is `None`
- [ ] Review `docs/orchestration.md`: lifecycle table, TOML config example, and execution-only setup steps are accurate
- [ ] Review ADR-009 through ADR-013 in `docs/ADRs/` for design rationale

🤖 Generated with [Claude Code](https://claude.com/claude-code)