### PR TITLE
chore: bump version to v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "code-looper"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code-looper"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 description = "Pluggable loop engine for coding-agent CLIs"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bumps `Cargo.toml` version from `0.2.1` → `0.3.0`
- Updates `Cargo.lock` accordingly

## What's in v0.3.0

Since `v0.2.1`, the following features landed on main:

- **Milestone-aware lifecycle orchestration engine** (#191, #226) — five-lifecycle model (`execution`, `pr-review`, `release`, `grooming`, `planning`), `OrchestrationMode`, `DiscoveryPolicy`, `IterationPattern` config, `GhCliLifecycleContextResolver`, full validation and test coverage
- **gh-first GitHub policy** (#220) — `gh` CLI preferred over MCP by default, strict MCP-only mode opt-in
- **Curl install script + CI hardening** (#204, #221) — cross-platform install, shellcheck, release workflow fixes

## Test plan

- [ ] CI green on this branch
- [ ] After merge: tag `v0.3.0`, push tag → `release.yml` fires and publishes binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)